### PR TITLE
[#135] TodoListView에서 여러 데이터를 제거 후 다른 뷰로 넘어갔다 돌아오면 지워졌던 데이터가 롤백되는 현상을 해결한다

### DIFF
--- a/DevLog/Presentation/ViewModel/TodoListViewModel.swift
+++ b/DevLog/Presentation/ViewModel/TodoListViewModel.swift
@@ -181,12 +181,17 @@ private extension TodoListViewModel {
         case .setShowEditor(let value):
             state.showEditor = value
         case .swipeTodo(let todo):
+            var effects: [SideEffect] = []
+            if let (pendingItem, _) = state.pendingTask {
+                effects = [.delete(pendingItem.id)]
+            }
             guard let index = state.todos.firstIndex(where: { $0.id == todo.id }) else {
                 return []
             }
             state.pendingTask = (todo, index)
             state.todos.remove(at: index)
             setToast(&state, isPresented: true)
+            return effects
         case .tapFilterOption(let option):
             state.filterOption = option
         case .tapTogglePinned(let todo):


### PR DESCRIPTION
- closed #135