### PR TITLE
[#320] TodoListView에서 Todo가 없는 카테고리인 경우, 필터링 및 정렬 메뉴를 선택하면 메뉴가 ui에서 보이지 않는 현상을 해결한다

### DIFF
--- a/DevLog/UI/Home/TodoListView.swift
+++ b/DevLog/UI/Home/TodoListView.swift
@@ -13,6 +13,7 @@ struct TodoListView: View {
     @Environment(\.diContainer) var container: DIContainer
     @Environment(\.colorScheme) private var colorScheme
     @State private var headerOffset: CGFloat = 0
+    @State private var headerHeight: CGFloat = .pi
     @State private var isScrollTrackingEnabled = false
 
     var body: some View {
@@ -297,11 +298,23 @@ struct TodoListView: View {
                 sortMenu
                 filterMenu
             }
+            // iOS 26.4부터 헤더의 높이가 달라져서 리스트에서 필터링된 Todo가 없으면 사라지는 현상 해결
+            .background {
+                GeometryReader { geometry in
+                    Color.clear
+                        .onAppear {
+                            headerHeight = geometry.size.height
+                        }
+                        .onChange(of: geometry.size.height) { _, height in
+                            headerHeight = height
+                        }
+                }
+            }
         }
         .scrollIndicators(.never)
         .scrollDisabled(!isScrollTrackingEnabled)
         .contentMargins(.leading, 16, for: .scrollContent)
-        .frame(height: 36)
+        .frame(height: headerHeight)
         .onAppear {
             headerOffset = 0
             isScrollTrackingEnabled = false


### PR DESCRIPTION
- closed #320