### PR TITLE
[#325] iOS 26.4 이상에서 내비게이션 헤더가 보이지 않는 현상을 해결한다

### DIFF
--- a/DevLog/UI/Home/TodoListView.swift
+++ b/DevLog/UI/Home/TodoListView.swift
@@ -303,10 +303,10 @@ struct TodoListView: View {
                 GeometryReader { geometry in
                     Color.clear
                         .onAppear {
-                            headerHeight = geometry.size.height
+                            headerHeight = geometry.size.height + 1
                         }
                         .onChange(of: geometry.size.height) { _, height in
-                            headerHeight = height
+                            headerHeight = height + 1
                         }
                 }
             }


### PR DESCRIPTION
- closed #325