### PR TITLE
[#374] 릴리즈 시 앱스토어에 심사 요청 제출 Lane을 제거한다

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,18 +7,6 @@ on:
     branches:
       - main
 
-env:
-  RUBY_VERSION: "3.2"
-  XCODE_VERSION: latest
-  APP_STORE_TEAM_ID: ${{ secrets.APP_STORE_TEAM_ID }}
-  ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
-  ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
-  ASC_KEY_PATH: fastlane/AuthKey.p8
-  SPACESHIP_CONNECT_API_IN_HOUSE: "false"
-  MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
-  MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
-  MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
-
 permissions:
   contents: write
 
@@ -33,49 +21,6 @@ jobs:
         uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.merge_commit_sha }}
-
-      - name: Install private config files
-        uses: ./.github/actions/install-private-config
-        with:
-          git_url: ${{ env.MATCH_GIT_URL }}
-          git_basic_authorization: ${{ env.MATCH_GIT_BASIC_AUTHORIZATION }}
-
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          bundler-cache: true
-          ruby-version: ${{ env.RUBY_VERSION }}
-
-      - name: Select Xcode
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          if [ "$XCODE_VERSION" = "latest" ]; then
-            XCODE_APP="$(find /Applications -maxdepth 1 -name 'Xcode*.app' -type d | sort -V | tail -n 1)"
-          else
-            XCODE_APP="/Applications/Xcode_${XCODE_VERSION}.app"
-            if [ ! -d "$XCODE_APP" ]; then
-              XCODE_APP="/Applications/Xcode-${XCODE_VERSION}.app"
-            fi
-          fi
-
-          if [ ! -d "${XCODE_APP:-}" ]; then
-            echo "Requested Xcode not found for version: $XCODE_VERSION" >&2
-            exit 1
-          fi
-
-          sudo xcode-select -s "$XCODE_APP/Contents/Developer"
-          xcodebuild -version
-
-      - name: Write App Store Connect API key
-        env:
-          ASC_KEY_CONTENT: ${{ secrets.ASC_KEY_CONTENT }}
-        run: |
-          printf '%s' "$ASC_KEY_CONTENT" | base64 -D > "$ASC_KEY_PATH"
-
-      - name: Release to App Store Connect
-        run: bundle exec fastlane release
 
       - name: Read release version
         id: release_version

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -132,29 +132,4 @@ platform :ios do
     )
   end
 
-  lane :release do
-    api_key = asc_api_key
-    version_number = get_version_number(
-      xcodeproj: XCODE_PROJ,
-      target: TARGET_NAME
-    )
-    latest_testflight_build_number = fetch_latest_testflight_build_number(
-      api_key: api_key,
-      version: version_number
-    )
-
-    UI.user_error!("No existing TestFlight build found for #{version_number}") if latest_testflight_build_number <= 0
-
-    upload_to_app_store(
-      api_key: api_key,
-      app_version: version_number,
-      build_number: latest_testflight_build_number.to_s,
-      force: true,
-      skip_metadata: true,
-      skip_screenshots: true,
-      skip_binary_upload: true,
-      submit_for_review: true,
-      automatic_release: false
-    )
-  end
 end


### PR DESCRIPTION
## 🔗 연관된 이슈
- closed #374

## 📝 작업 내용

### 📌 요약
- develop 브랜치에서 main 브랜치로 머지될 때 실행되는 CD에서 App Store 제출 단계를 제거
- 릴리즈 생성 흐름은 유지하고, App Store 제출은 App Store Connect에서 수동으로 진행하도록 정리

### 🔍 상세
- .github/workflows/release.yml에서 App Store Connect 배포와 관련된 step을 제거
- 릴리즈 워크플로는 머지 커밋 기준으로 버전을 읽어 GitHub Release만 생성하도록 변경
- fastlane/Fastfile에서 upload_to_app_store를 호출하던 release lane을 제거