### PR TITLE
[#377] 최초 가입 직후 ProfileView를 들어가면 얼럿이 뜨는 이슈를 해결한다

### DIFF
--- a/DevLog/Data/Repository/AuthenticationRepositoryImpl.swift
+++ b/DevLog/Data/Repository/AuthenticationRepositoryImpl.swift
@@ -27,16 +27,29 @@ final class AuthenticationRepositoryImpl: AuthenticationRepository {
     }
 
     func signIn(_ provider: AuthProvider) async throws {
-        let response: AuthDataResponse
-        switch provider {
-        case .apple:
-            response = try await appleAuthService.signIn()
-        case .github:
-            response = try await githubAuthService.signIn()
-        case .google:
-            response = try await googleAuthService.signIn()
+        authService.beginSignIn()
+
+        do {
+            let response: AuthDataResponse
+            switch provider {
+            case .apple:
+                response = try await appleAuthService.signIn()
+            case .github:
+                response = try await githubAuthService.signIn()
+            case .google:
+                response = try await googleAuthService.signIn()
+            }
+
+            try await userService.upsertUser(response)
+            authService.completeSignIn()
+        } catch {
+            if authService.uid != nil {
+                try? await authService.clearCurrentSession()
+            }
+
+            authService.cancelSignIn()
+            throw error
         }
-        try await userService.upsertUser(response)
     }
 
     func signOut() async throws {

--- a/DevLog/Infra/Service/AuthService.swift
+++ b/DevLog/Infra/Service/AuthService.swift
@@ -16,6 +16,7 @@ final class AuthService {
     private let logger = Logger(category: "AuthService")
     private let subject = CurrentValueSubject<Bool, Never>(Auth.auth().currentUser != nil)
     private var handler: AuthStateDidChangeListenerHandle?
+    private var isCompletingSignIn = false
 
     var uid: String? {
         Auth.auth().currentUser?.uid
@@ -27,9 +28,16 @@ final class AuthService {
 
     init() {
         handler = Auth.auth().addStateDidChangeListener { [weak self] _, user in
+            guard let self else { return }
             let signedIn = user != nil
-            self?.logger.info("Firebase auth state changed. signedIn: \(signedIn)")
-            self?.subject.send(signedIn)
+            self.logger.info("Firebase auth state changed. signedIn: \(signedIn)")
+
+            if signedIn && self.isCompletingSignIn {
+                self.logger.info("Delaying signed-in publication until user bootstrap finishes")
+                return
+            }
+
+            self.subject.send(signedIn)
         }
     }
 
@@ -40,6 +48,24 @@ final class AuthService {
 
     func observeSignedIn() -> AnyPublisher<Bool, Never> {
         subject.eraseToAnyPublisher()
+    }
+
+    func beginSignIn() {
+        logger.info("Beginning sign-in bootstrap")
+        isCompletingSignIn = true
+        subject.send(false)
+    }
+
+    func completeSignIn() {
+        logger.info("Completing sign-in bootstrap")
+        isCompletingSignIn = false
+        subject.send(Auth.auth().currentUser != nil)
+    }
+
+    func cancelSignIn() {
+        logger.info("Cancelling sign-in bootstrap")
+        isCompletingSignIn = false
+        subject.send(Auth.auth().currentUser != nil)
     }
 
     func getProviderID() async throws -> String? {


### PR DESCRIPTION
## 🔗 연관된 이슈
- closed #377

## 📝 작업 내용

### 📌 요약
- 최초 가입 직후 FirebaseAuth 로그인 상태가 먼저 반영되어 Firestore 사용자 문서가 아직 없는 상태로 메인 화면에 진입하던 문제를 수정
- 사용자 문서 초기화가 끝난 뒤에만 로그인 완료 상태가 반영되도록 인증 플로우를 조정

### 🔍 상세
- AuthService에 최초 로그인 직후의 bootstrap 상태를 제어하는 메서드를 추가
- 인증 상태 변경 리스너에서 bootstrap 진행 중에는 signedIn = true를 바로 publish하지 않도록 처리
- AuthenticationRepositoryImpl.signIn(_:)에서 소셜 로그인 성공 후 userService.upsertUser(_:) 완료까지 기다린 뒤 로그인 완료 상태를 반영
- 초기 사용자 문서 생성 중 오류가 발생하면 현재 세션을 정리하고 로그인 완료 상태를 취소하도록 보완

## 📸 영상 / 이미지 (Optional)

<table>
<tr>
<td align="center" width="50%">
<video src="https://github.com/user-attachments/assets/dcf6a6ed-4f2b-4220-8010-53964a8f5097">
</td>
<td align="center" width="50%">
<video src="https://github.com/user-attachments/assets/089f6b47-95b0-484a-b214-411c89adc32a">
</td>
</tr>
<tr>
<td align="center"> 개선 전 </td>
<td align="center"> 개선 후 </td>
</tr>
</table>
