### PR TITLE
[#381] 웹페이지 썸네일 저장 위치를 수정하여 썸네일이 재 fetch되는 현상을 해결한다

### DIFF
--- a/DevLog/App/Assembler/DataAssembler.swift
+++ b/DevLog/App/Assembler/DataAssembler.swift
@@ -87,6 +87,12 @@ final class DataAssembler: Assembler {
             )
         }
 
+        container.register(WebPageImageRepository.self) {
+            WebPageImageRepositoryImpl(
+                store: container.resolve(WebPageImageStore.self)
+            )
+        }
+
         container.register(UserPreferencesRepository.self) {
             UserPreferencesRepositoryImpl(
                 store: container.resolve(UserDefaultsStore.self),

--- a/DevLog/App/Assembler/DomainAssembler.swift
+++ b/DevLog/App/Assembler/DomainAssembler.swift
@@ -153,6 +153,10 @@ private extension DomainAssembler {
             AddWebPageUseCaseImpl(container.resolve(WebPageRepository.self))
         }
 
+        container.register(ClearWebPageImageDirectoryUseCase.self) {
+            ClearWebPageImageDirectoryUseCaseImpl(container.resolve(WebPageImageRepository.self))
+        }
+
         container.register(DeleteWebPageUseCase.self) {
             DeleteWebPageUseCaseImpl(container.resolve(WebPageRepository.self))
         }

--- a/DevLog/App/Assembler/DomainAssembler.swift
+++ b/DevLog/App/Assembler/DomainAssembler.swift
@@ -145,6 +145,10 @@ private extension DomainAssembler {
             FetchWebPagesUseCaseImpl(container.resolve(WebPageRepository.self))
         }
 
+        container.register(FetchWebPageImageDirSizeUseCase.self) {
+            FetchWebPageImageDirSizeUseCaseImpl(container.resolve(WebPageImageRepository.self))
+        }
+
         container.register(AddWebPageUseCase.self) {
             AddWebPageUseCaseImpl(container.resolve(WebPageRepository.self))
         }

--- a/DevLog/App/Assembler/InfraAssembler.swift
+++ b/DevLog/App/Assembler/InfraAssembler.swift
@@ -53,7 +53,9 @@ final class InfraAssembler: Assembler {
         }
 
         container.register(WebPageMetadataService.self) {
-            WebPageMetadataService()
+            WebPageMetadataService(
+                store: container.resolve(WebPageImageStore.self)
+            )
         }
 
         container.register(NWPathConnectivityProvider.self) {

--- a/DevLog/App/Assembler/PersistenceAssembler.swift
+++ b/DevLog/App/Assembler/PersistenceAssembler.swift
@@ -14,5 +14,9 @@ final class PersistenceAssembler: Assembler {
         container.register(ThemeStore.self) {
             ThemeStore()
         }
+
+        container.register(WebPageImageStore.self) {
+            WebPageImageStore()
+        }
     }
 }

--- a/DevLog/Data/Repository/WebPageImageRepositoryImpl.swift
+++ b/DevLog/Data/Repository/WebPageImageRepositoryImpl.swift
@@ -12,11 +12,17 @@ final class WebPageImageRepositoryImpl: WebPageImageRepository {
         self.store = store
     }
 
-    func fetchDirSizeInBytes() -> Int64 {
-        store.dirSizeInBytes()
+    func fetchDirSizeInBytes() async -> Int64 {
+        let store = self.store
+        return await Task.detached(priority: .utility) {
+            store.dirSizeInBytes()
+        }.value
     }
 
-    func clearDirectory() throws {
-        try store.clearDirectory()
+    func clearDirectory() async throws {
+        let store = self.store
+        try await Task.detached(priority: .utility) {
+            try store.clearDirectory()
+        }.value
     }
 }

--- a/DevLog/Data/Repository/WebPageImageRepositoryImpl.swift
+++ b/DevLog/Data/Repository/WebPageImageRepositoryImpl.swift
@@ -1,0 +1,22 @@
+//
+//  WebPageImageRepositoryImpl.swift
+//  DevLog
+//
+//  Created by opfic on 4/14/26.
+//
+
+final class WebPageImageRepositoryImpl: WebPageImageRepository {
+    private let store: WebPageImageStore
+
+    init(store: WebPageImageStore) {
+        self.store = store
+    }
+
+    func fetchDirSizeInBytes() -> Int64 {
+        store.dirSizeInBytes()
+    }
+
+    func clearDirectory() throws {
+        try store.clearDirectory()
+    }
+}

--- a/DevLog/Domain/Protocol/WebPageImageRepository.swift
+++ b/DevLog/Domain/Protocol/WebPageImageRepository.swift
@@ -6,6 +6,6 @@
 //
 
 protocol WebPageImageRepository {
-    func fetchDirSizeInBytes() -> Int64
-    func clearDirectory() throws
+    func fetchDirSizeInBytes() async -> Int64
+    func clearDirectory() async throws
 }

--- a/DevLog/Domain/Protocol/WebPageImageRepository.swift
+++ b/DevLog/Domain/Protocol/WebPageImageRepository.swift
@@ -1,0 +1,11 @@
+//
+//  WebPageImageRepository.swift
+//  DevLog
+//
+//  Created by opfic on 4/14/26.
+//
+
+protocol WebPageImageRepository {
+    func fetchDirSizeInBytes() -> Int64
+    func clearDirectory() throws
+}

--- a/DevLog/Domain/UseCase/WebPage/Fetch/FetchWebPageImageDirSizeUseCase.swift
+++ b/DevLog/Domain/UseCase/WebPage/Fetch/FetchWebPageImageDirSizeUseCase.swift
@@ -6,5 +6,5 @@
 //
 
 protocol FetchWebPageImageDirSizeUseCase {
-    func execute() -> Int64
+    func execute() async -> Int64
 }

--- a/DevLog/Domain/UseCase/WebPage/Fetch/FetchWebPageImageDirSizeUseCase.swift
+++ b/DevLog/Domain/UseCase/WebPage/Fetch/FetchWebPageImageDirSizeUseCase.swift
@@ -1,0 +1,10 @@
+//
+//  FetchWebPageImageDirSizeUseCase.swift
+//  DevLog
+//
+//  Created by opfic on 4/14/26.
+//
+
+protocol FetchWebPageImageDirSizeUseCase {
+    func execute() -> Int64
+}

--- a/DevLog/Domain/UseCase/WebPage/Fetch/FetchWebPageImageDirSizeUseCaseImpl.swift
+++ b/DevLog/Domain/UseCase/WebPage/Fetch/FetchWebPageImageDirSizeUseCaseImpl.swift
@@ -12,7 +12,7 @@ final class FetchWebPageImageDirSizeUseCaseImpl: FetchWebPageImageDirSizeUseCase
         self.repository = repository
     }
 
-    func execute() -> Int64 {
-        repository.fetchDirSizeInBytes()
+    func execute() async -> Int64 {
+        await repository.fetchDirSizeInBytes()
     }
 }

--- a/DevLog/Domain/UseCase/WebPage/Fetch/FetchWebPageImageDirSizeUseCaseImpl.swift
+++ b/DevLog/Domain/UseCase/WebPage/Fetch/FetchWebPageImageDirSizeUseCaseImpl.swift
@@ -1,0 +1,18 @@
+//
+//  FetchWebPageImageDirSizeUseCaseImpl.swift
+//  DevLog
+//
+//  Created by opfic on 4/14/26.
+//
+
+final class FetchWebPageImageDirSizeUseCaseImpl: FetchWebPageImageDirSizeUseCase {
+    private let repository: WebPageImageRepository
+
+    init(_ repository: WebPageImageRepository) {
+        self.repository = repository
+    }
+
+    func execute() -> Int64 {
+        repository.fetchDirSizeInBytes()
+    }
+}

--- a/DevLog/Domain/UseCase/WebPage/Upsert/ClearWebPageImageDirectoryUseCase.swift
+++ b/DevLog/Domain/UseCase/WebPage/Upsert/ClearWebPageImageDirectoryUseCase.swift
@@ -6,5 +6,5 @@
 //
 
 protocol ClearWebPageImageDirectoryUseCase {
-    func execute() throws
+    func execute() async throws
 }

--- a/DevLog/Domain/UseCase/WebPage/Upsert/ClearWebPageImageDirectoryUseCase.swift
+++ b/DevLog/Domain/UseCase/WebPage/Upsert/ClearWebPageImageDirectoryUseCase.swift
@@ -1,0 +1,10 @@
+//
+//  ClearWebPageImageDirectoryUseCase.swift
+//  DevLog
+//
+//  Created by opfic on 4/14/26.
+//
+
+protocol ClearWebPageImageDirectoryUseCase {
+    func execute() throws
+}

--- a/DevLog/Domain/UseCase/WebPage/Upsert/ClearWebPageImageDirectoryUseCaseImpl.swift
+++ b/DevLog/Domain/UseCase/WebPage/Upsert/ClearWebPageImageDirectoryUseCaseImpl.swift
@@ -12,7 +12,7 @@ final class ClearWebPageImageDirectoryUseCaseImpl: ClearWebPageImageDirectoryUse
         self.repository = repository
     }
 
-    func execute() throws {
-        try repository.clearDirectory()
+    func execute() async throws {
+        try await repository.clearDirectory()
     }
 }

--- a/DevLog/Domain/UseCase/WebPage/Upsert/ClearWebPageImageDirectoryUseCaseImpl.swift
+++ b/DevLog/Domain/UseCase/WebPage/Upsert/ClearWebPageImageDirectoryUseCaseImpl.swift
@@ -1,0 +1,18 @@
+//
+//  ClearWebPageImageDirectoryUseCaseImpl.swift
+//  DevLog
+//
+//  Created by opfic on 4/14/26.
+//
+
+final class ClearWebPageImageDirectoryUseCaseImpl: ClearWebPageImageDirectoryUseCase {
+    private let repository: WebPageImageRepository
+
+    init(_ repository: WebPageImageRepository) {
+        self.repository = repository
+    }
+
+    func execute() throws {
+        try repository.clearDirectory()
+    }
+}

--- a/DevLog/Infra/Service/WebPageMetadataService.swift
+++ b/DevLog/Infra/Service/WebPageMetadataService.swift
@@ -104,7 +104,6 @@ final class WebPageMetadataService {
 
     private static func cacheFileURL(for url: URL) throws -> URL {
         let imageDir = try imageDirectoryURL()
-
         let fileName = url.absoluteString
             .addingPercentEncoding(withAllowedCharacters: .alphanumerics) ?? UUID().uuidString
 
@@ -114,13 +113,13 @@ final class WebPageMetadataService {
     }
 
     private static func imageDirectoryURL() throws -> URL {
-        let cachesDir = try FileManager.default.url(
-            for: .cachesDirectory,
+        let directory = try FileManager.default.url(
+            for: .applicationSupportDirectory,
             in: .userDomainMask,
             appropriateFor: nil,
             create: true
         )
-        let imageDir = cachesDir.appendingPathComponent("webPageImages", isDirectory: true)
+        let imageDir = directory.appendingPathComponent("webPageImages", isDirectory: true)
         if !FileManager.default.fileExists(atPath: imageDir.path) {
             try FileManager.default.createDirectory(at: imageDir, withIntermediateDirectories: true)
         }

--- a/DevLog/Infra/Service/WebPageMetadataService.swift
+++ b/DevLog/Infra/Service/WebPageMetadataService.swift
@@ -10,7 +10,12 @@ import LinkPresentation
 import UIKit
 
 final class WebPageMetadataService {
+    private let imageStore: WebPageImageStore
     private let logger = Logger(category: "WebPageMetadataService")
+
+    init(store: WebPageImageStore) {
+        self.imageStore = store
+    }
 
     func fetchMetadata(from urlString: String) async throws -> WebPageMetadataResponse {
         logger.info("Fetching metadata for URL: \(urlString)")
@@ -46,12 +51,7 @@ final class WebPageMetadataService {
         }
 
         do {
-            let removed = try await Task.detached(priority: .utility) {
-                let fileURL = try Self.cacheFileURL(for: url)
-                guard FileManager.default.fileExists(atPath: fileURL.path) else { return false }
-                try FileManager.default.removeItem(at: fileURL)
-                return true
-            }.value
+            let removed = try imageStore.removeImage(for: url)
 
             if removed {
                 logger.info("Removed cached image for URL: \(urlString)")
@@ -66,11 +66,12 @@ final class WebPageMetadataService {
             throw URLError(.badURL)
         }
 
-        return try Self.cacheFileURL(for: url)
+        return try imageStore.cachedImageURL(for: url)
     }
 
     private func extractImageURL(from imageProvider: NSItemProvider?, url: URL) async throws -> URL? {
         guard let imageProvider else { return nil }
+        let imageStore = self.imageStore
 
         return try await withCheckedThrowingContinuation { continuation in
             imageProvider.loadObject(ofClass: UIImage.self) { image, error in
@@ -86,44 +87,12 @@ final class WebPageMetadataService {
                 }
 
                 do {
-                    let fileURL = try Self.cacheFileURL(for: url)
-                    Task.detached { [data, fileURL] in
-                        do {
-                            try data.write(to: fileURL, options: [.atomic])
-                            continuation.resume(returning: fileURL)
-                        } catch {
-                            continuation.resume(throwing: error)
-                        }
-                    }
+                    let fileURL = try imageStore.saveImage(data, for: url)
+                    continuation.resume(returning: fileURL)
                 } catch {
                     continuation.resume(throwing: error)
                 }
             }
         }
-    }
-
-    private static func cacheFileURL(for url: URL) throws -> URL {
-        let imageDir = try imageDirectoryURL()
-        let fileName = url.absoluteString
-            .addingPercentEncoding(withAllowedCharacters: .alphanumerics) ?? UUID().uuidString
-
-        return imageDir
-            .appendingPathComponent(fileName)
-            .appendingPathExtension("jpeg")
-    }
-
-    private static func imageDirectoryURL() throws -> URL {
-        let directory = try FileManager.default.url(
-            for: .applicationSupportDirectory,
-            in: .userDomainMask,
-            appropriateFor: nil,
-            create: true
-        )
-        let imageDir = directory.appendingPathComponent("webPageImages", isDirectory: true)
-        if !FileManager.default.fileExists(atPath: imageDir.path) {
-            try FileManager.default.createDirectory(at: imageDir, withIntermediateDirectories: true)
-        }
-
-        return imageDir
     }
 }

--- a/DevLog/Presentation/ViewModel/SettingViewModel.swift
+++ b/DevLog/Presentation/ViewModel/SettingViewModel.swift
@@ -24,6 +24,7 @@ final class SettingViewModel: Store {
     enum Action {
         case networkStatusChanged(Bool)
         case setAlert(isPresented: Bool, type: AlertType? = nil)
+        case setDirSize(Int64)
         case setLoading(Bool)
         case setTheme(SystemTheme)
         case updateDirSize
@@ -34,7 +35,9 @@ final class SettingViewModel: Store {
     }
 
     enum SideEffect {
+        case clearWebPageImageDirectory
         case deleteAuth
+        case fetchWebPageImageDirSize
         case signOut
     }
 
@@ -86,13 +89,15 @@ final class SettingViewModel: Store {
             state.isNetworkConnected = isConnected
         case .setAlert(let isPresented, let type):
             setAlert(&state, isPresented: isPresented, type: type)
+        case .setDirSize(let value):
+            state.dirSize = value
         case .setLoading(let value):
             state.isLoading = value
         case .setTheme(let value):
             state.theme = value
             updateSystemThemeUseCase.execute(value)
         case .updateDirSize:
-            state.dirSize = fetchWebPageImageDirSizeUseCase.execute()
+            effects = [.fetchWebPageImageDirSize]
         case .tapDeleteAuthButton:
             effects = [.deleteAuth]
         case .tapSignOutButton:
@@ -100,13 +105,8 @@ final class SettingViewModel: Store {
         case .tapRemoveCacheButton:
             setAlert(&state, isPresented: true, type: .removeCache)
         case .confirmRemoveCache:
-            do {
-                setAlert(&state, isPresented: false)
-                try clearWebPageImageDirectoryUseCase.execute()
-                state.dirSize = fetchWebPageImageDirSizeUseCase.execute()
-            } catch {
-                setAlert(&state, isPresented: true, type: .error)
-            }
+            setAlert(&state, isPresented: false)
+            effects = [.clearWebPageImageDirectory]
         }
 
         if self.state != state { self.state = state }
@@ -115,6 +115,16 @@ final class SettingViewModel: Store {
 
     func run(_ effect: SideEffect) {
         switch effect {
+        case .clearWebPageImageDirectory:
+            Task {
+                do {
+                    try await clearWebPageImageDirectoryUseCase.execute()
+                    let dirSize = await fetchWebPageImageDirSizeUseCase.execute()
+                    send(.setDirSize(dirSize))
+                } catch {
+                    send(.setAlert(isPresented: true, type: .error))
+                }
+            }
         case .deleteAuth:
             beginLoading(.delayed)
             Task {
@@ -125,6 +135,11 @@ final class SettingViewModel: Store {
                 } catch {
                     send(.setAlert(isPresented: true, type: .error))
                 }
+            }
+        case .fetchWebPageImageDirSize:
+            Task {
+                let dirSize = await fetchWebPageImageDirSizeUseCase.execute()
+                send(.setDirSize(dirSize))
             }
         case .signOut:
             beginLoading(.delayed)

--- a/DevLog/Presentation/ViewModel/SettingViewModel.swift
+++ b/DevLog/Presentation/ViewModel/SettingViewModel.swift
@@ -183,14 +183,15 @@ private extension SettingViewModel {
 
     func dirSizeInBytes() -> Int64 {
         do {
-            let cachesDir = try FileManager.default.url(
-                for: .cachesDirectory,
+            let directory = try FileManager.default.url(
+                for: .applicationSupportDirectory,
                 in: .userDomainMask,
                 appropriateFor: nil,
                 create: false
             )
-            guard FileManager.default.fileExists(atPath: cachesDir.path) else { return 0 }
-            return directorySize(at: cachesDir)
+            let imageDir = directory.appendingPathComponent("webPageImages", isDirectory: true)
+            guard FileManager.default.fileExists(atPath: imageDir.path) else { return 0 }
+            return directorySize(at: imageDir)
         } catch {
             return 0
         }
@@ -231,15 +232,16 @@ private extension SettingViewModel {
     }
 
     private func clearCacheDirectory() throws {
-        let cachesDir = try FileManager.default.url(
-            for: .cachesDirectory,
+        let directory = try FileManager.default.url(
+            for: .applicationSupportDirectory,
             in: .userDomainMask,
             appropriateFor: nil,
             create: false
         )
-        guard FileManager.default.fileExists(atPath: cachesDir.path) else { return }
+        let imageDir = directory.appendingPathComponent("webPageImages", isDirectory: true)
+        guard FileManager.default.fileExists(atPath: imageDir.path) else { return }
         let contents = try FileManager.default.contentsOfDirectory(
-            at: cachesDir,
+            at: imageDir,
             includingPropertiesForKeys: nil,
             options: [.skipsHiddenFiles]
         )

--- a/DevLog/Presentation/ViewModel/SettingViewModel.swift
+++ b/DevLog/Presentation/ViewModel/SettingViewModel.swift
@@ -48,6 +48,8 @@ final class SettingViewModel: Store {
     private let networkConnectivityUseCase: ObserveNetworkConnectivityUseCase
     private let systemThemeUseCase: ObserveSystemThemeUseCase
     private let updateSystemThemeUseCase: UpdateSystemThemeUseCase
+    private let fetchWebPageImageDirSizeUseCase: FetchWebPageImageDirSizeUseCase
+    private let clearWebPageImageDirectoryUseCase: ClearWebPageImageDirectoryUseCase
     private let loadingState = LoadingState()
     private var cancellables = Set<AnyCancellable>()
 
@@ -60,13 +62,17 @@ final class SettingViewModel: Store {
         signOutUseCase: SignOutUseCase,
         networkConnectivityUseCase: ObserveNetworkConnectivityUseCase,
         systemThemeUseCase: ObserveSystemThemeUseCase,
-        updateSystemThemeUseCase: UpdateSystemThemeUseCase
+        updateSystemThemeUseCase: UpdateSystemThemeUseCase,
+        fetchWebPageImageDirSizeUseCase: FetchWebPageImageDirSizeUseCase,
+        clearWebPageImageDirectoryUseCase: ClearWebPageImageDirectoryUseCase
     ) {
         self.deleteAuthuseCase = deleteAuthUseCase
         self.signOutUseCase = signOutUseCase
         self.networkConnectivityUseCase = networkConnectivityUseCase
         self.systemThemeUseCase = systemThemeUseCase
         self.updateSystemThemeUseCase = updateSystemThemeUseCase
+        self.fetchWebPageImageDirSizeUseCase = fetchWebPageImageDirSizeUseCase
+        self.clearWebPageImageDirectoryUseCase = clearWebPageImageDirectoryUseCase
         setupNetworkObserving()
         setupThemeMonitoring()
     }
@@ -86,7 +92,7 @@ final class SettingViewModel: Store {
             state.theme = value
             updateSystemThemeUseCase.execute(value)
         case .updateDirSize:
-            state.dirSize = dirSizeInBytes()
+            state.dirSize = fetchWebPageImageDirSizeUseCase.execute()
         case .tapDeleteAuthButton:
             effects = [.deleteAuth]
         case .tapSignOutButton:
@@ -96,8 +102,8 @@ final class SettingViewModel: Store {
         case .confirmRemoveCache:
             do {
                 setAlert(&state, isPresented: false)
-                try clearCacheDirectory()
-                state.dirSize = dirSizeInBytes()
+                try clearWebPageImageDirectoryUseCase.execute()
+                state.dirSize = fetchWebPageImageDirSizeUseCase.execute()
             } catch {
                 setAlert(&state, isPresented: true, type: .error)
             }
@@ -181,44 +187,6 @@ private extension SettingViewModel {
             .store(in: &cancellables)
     }
 
-    func dirSizeInBytes() -> Int64 {
-        do {
-            let directory = try FileManager.default.url(
-                for: .applicationSupportDirectory,
-                in: .userDomainMask,
-                appropriateFor: nil,
-                create: false
-            )
-            let imageDir = directory.appendingPathComponent("webPageImages", isDirectory: true)
-            guard FileManager.default.fileExists(atPath: imageDir.path) else { return 0 }
-            return directorySize(at: imageDir)
-        } catch {
-            return 0
-        }
-    }
-
-    private func directorySize(at url: URL) -> Int64 {
-        guard FileManager.default.fileExists(atPath: url.path) else { return 0 }
-        guard let enumerator = FileManager.default.enumerator(
-            at: url,
-            includingPropertiesForKeys: [.isRegularFileKey, .fileSizeKey],
-            options: [.skipsHiddenFiles]
-        ) else {
-            return 0
-        }
-
-        var total: Int64 = 0
-        for case let fileURL as URL in enumerator {
-            guard let resourceValues = try? fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey]),
-                  resourceValues.isRegularFile == true,
-                  let fileSize = resourceValues.fileSize else {
-                continue
-            }
-            total += Int64(fileSize)
-        }
-        return total
-    }
-
     private func beginLoading(_ mode: LoadingState.Mode) {
         loadingState.begin(mode: mode) { [weak self] isLoading in
             self?.send(.setLoading(isLoading))
@@ -231,22 +199,4 @@ private extension SettingViewModel {
         }
     }
 
-    private func clearCacheDirectory() throws {
-        let directory = try FileManager.default.url(
-            for: .applicationSupportDirectory,
-            in: .userDomainMask,
-            appropriateFor: nil,
-            create: false
-        )
-        let imageDir = directory.appendingPathComponent("webPageImages", isDirectory: true)
-        guard FileManager.default.fileExists(atPath: imageDir.path) else { return }
-        let contents = try FileManager.default.contentsOfDirectory(
-            at: imageDir,
-            includingPropertiesForKeys: nil,
-            options: [.skipsHiddenFiles]
-        )
-        for url in contents {
-            try FileManager.default.removeItem(at: url)
-        }
-    }
 }

--- a/DevLog/Storage/Persistence/WebPageImageStore.swift
+++ b/DevLog/Storage/Persistence/WebPageImageStore.swift
@@ -61,10 +61,6 @@ final class WebPageImageStore {
         }
     }
 
-    func observeDirSize() -> AnyPublisher<Int64, Never> {
-        subject.eraseToAnyPublisher()
-    }
-
     func clearDirectory() throws {
         let imageDirectoryURL = try self.imageDirectoryURL(create: false)
         guard fileManager.fileExists(atPath: imageDirectoryURL.path) else { return }

--- a/DevLog/Storage/Persistence/WebPageImageStore.swift
+++ b/DevLog/Storage/Persistence/WebPageImageStore.swift
@@ -1,0 +1,106 @@
+//
+//  WebPageImageStore.swift
+//  DevLog
+//
+//  Created by opfic on 4/14/26.
+//
+
+import Combine
+import Foundation
+
+final class WebPageImageStore {
+    private let fileManager: FileManager
+    private let subject = CurrentValueSubject<Int64, Never>(0)
+
+    init(fileManager: FileManager = .default) {
+        self.fileManager = fileManager
+        subject.send(dirSizeInBytes())
+    }
+
+    func cachedImageURL(for url: URL) throws -> URL {
+        let imageDirectoryURL = try self.imageDirectoryURL(create: true)
+        let fileName = url.absoluteString
+            .addingPercentEncoding(withAllowedCharacters: .alphanumerics) ?? UUID().uuidString
+
+        return imageDirectoryURL
+            .appendingPathComponent(fileName)
+            .appendingPathExtension("jpeg")
+    }
+
+    func saveImage(_ data: Data, for url: URL) throws -> URL {
+        let fileURL = try cachedImageURL(for: url)
+        try data.write(to: fileURL, options: [.atomic])
+        subject.send(dirSizeInBytes())
+        return fileURL
+    }
+
+    func dirSizeInBytes() -> Int64 {
+        do {
+            let imageDirectoryURL = try self.imageDirectoryURL(create: false)
+            guard fileManager.fileExists(atPath: imageDirectoryURL.path) else { return 0 }
+            guard let enumerator = fileManager.enumerator(
+                at: imageDirectoryURL,
+                includingPropertiesForKeys: [.isRegularFileKey, .fileSizeKey],
+                options: [.skipsHiddenFiles]
+            ) else {
+                return 0
+            }
+
+            var total: Int64 = 0
+            for case let fileURL as URL in enumerator {
+                guard let resourceValues = try? fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey]),
+                      resourceValues.isRegularFile == true,
+                      let fileSize = resourceValues.fileSize else {
+                    continue
+                }
+                total += Int64(fileSize)
+            }
+            return total
+        } catch {
+            return 0
+        }
+    }
+
+    func observeDirSize() -> AnyPublisher<Int64, Never> {
+        subject.eraseToAnyPublisher()
+    }
+
+    func clearDirectory() throws {
+        let imageDirectoryURL = try self.imageDirectoryURL(create: false)
+        guard fileManager.fileExists(atPath: imageDirectoryURL.path) else { return }
+        let contentURLs = try fileManager.contentsOfDirectory(
+            at: imageDirectoryURL,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        )
+        for contentURL in contentURLs {
+            try fileManager.removeItem(at: contentURL)
+        }
+        subject.send(dirSizeInBytes())
+    }
+
+    func removeImage(for url: URL) throws -> Bool {
+        let fileURL = try cachedImageURL(for: url)
+        guard fileManager.fileExists(atPath: fileURL.path) else { return false }
+        try fileManager.removeItem(at: fileURL)
+        subject.send(dirSizeInBytes())
+        return true
+    }
+}
+
+private extension WebPageImageStore {
+    func imageDirectoryURL(create: Bool) throws -> URL {
+        let directory = try fileManager.url(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: create
+        )
+        let imageDirectory = directory.appendingPathComponent("webPageImages", isDirectory: true)
+        if create && !fileManager.fileExists(atPath: imageDirectory.path) {
+            try fileManager.createDirectory(at: imageDirectory, withIntermediateDirectories: true)
+        }
+
+        return imageDirectory
+    }
+}

--- a/DevLog/Storage/Persistence/WebPageImageStore.swift
+++ b/DevLog/Storage/Persistence/WebPageImageStore.swift
@@ -6,6 +6,7 @@
 //
 
 import Combine
+import CryptoKit
 import Foundation
 
 final class WebPageImageStore {
@@ -19,8 +20,7 @@ final class WebPageImageStore {
 
     func cachedImageURL(for url: URL) throws -> URL {
         let imageDirectoryURL = try self.imageDirectoryURL(create: true)
-        let fileName = url.absoluteString
-            .addingPercentEncoding(withAllowedCharacters: .alphanumerics) ?? UUID().uuidString
+        let fileName = hashedFileName(for: url)
 
         return imageDirectoryURL
             .appendingPathComponent(fileName)
@@ -89,6 +89,11 @@ final class WebPageImageStore {
 }
 
 private extension WebPageImageStore {
+    func hashedFileName(for url: URL) -> String {
+        let hashValue = SHA256.hash(data: Data(url.absoluteString.utf8))
+        return hashValue.map { String(format: "%02x", $0) }.joined()
+    }
+
     func imageDirectoryURL(create: Bool) throws -> URL {
         let directory = try fileManager.url(
             for: .applicationSupportDirectory,

--- a/DevLog/Storage/Persistence/WebPageImageStore.swift
+++ b/DevLog/Storage/Persistence/WebPageImageStore.swift
@@ -105,6 +105,12 @@ private extension WebPageImageStore {
         if create && !fileManager.fileExists(atPath: imageDirectory.path) {
             try fileManager.createDirectory(at: imageDirectory, withIntermediateDirectories: true)
         }
+        if create {
+            var resourceValues = URLResourceValues()
+            resourceValues.isExcludedFromBackup = true
+            var imageDirectory = imageDirectory
+            try imageDirectory.setResourceValues(resourceValues)
+        }
 
         return imageDirectory
     }

--- a/DevLog/UI/Profile/ProfileView.swift
+++ b/DevLog/UI/Profile/ProfileView.swift
@@ -103,7 +103,9 @@ struct ProfileView: View {
                         signOutUseCase: container.resolve(SignOutUseCase.self),
                         networkConnectivityUseCase: container.resolve(ObserveNetworkConnectivityUseCase.self),
                         systemThemeUseCase: container.resolve(ObserveSystemThemeUseCase.self),
-                        updateSystemThemeUseCase: container.resolve(UpdateSystemThemeUseCase.self)
+                        updateSystemThemeUseCase: container.resolve(UpdateSystemThemeUseCase.self),
+                        fetchWebPageImageDirSizeUseCase: container.resolve(FetchWebPageImageDirSizeUseCase.self),
+                        clearWebPageImageDirectoryUseCase: container.resolve(ClearWebPageImageDirectoryUseCase.self)
                     ))
                     .environment(router)
                 case .activity(let todoId):


### PR DESCRIPTION
## 🔗 연관된 이슈
- closed #381

## 📝 작업 내용

### 📌 요약
- 웹페이지 썸네일 저장 경로를 `Application Support/webPageImages`로 정리했습니다.
- 웹페이지 썸네일 파일 관리를 `WebPageImageStore`로 분리했습니다.
- 설정 화면의 썸네일 디렉터리 용량 조회/전체 삭제를 `Repository -> UseCase -> SettingViewModel` 경로로 연결했습니다.
- `WebPageMetadataService`가 직접 처리하던 파일 저장/삭제를 `WebPageImageStore`에 위임했습니다.
- 긴 URL에서도 안정적으로 캐시 경로를 만들 수 있도록 파일명을 해시 기반으로 변경했습니다.
- 설정 화면의 디렉터리 작업은 백그라운드에서 실행되도록 조정했습니다.
- 썸네일 저장 디렉터리를 iCloud 백업 제외 대상으로 설정했습니다.

### 🔍 상세
- `WebPageImageStore` 추가
  - 썸네일 파일 경로 계산
  - 이미지 저장/삭제
  - 디렉터리 전체 삭제
  - 디렉터리 용량 계산
- `WebPageImageRepository` 추가
  - 설정 화면에서 필요한 디렉터리 조회/삭제 책임 분리
- UseCase 추가
  - `FetchWebPageImageDirSizeUseCase`
  - `ClearWebPageImageDirectoryUseCase`
- `SettingViewModel` 수정
  - 파일 시스템 직접 접근 제거
  - 유즈케이스를 통해 용량 조회 및 임시 파일 삭제 처리
  - 디렉터리 조회/삭제를 비동기 side effect로 실행하도록 변경
- `WebPageMetadataService` 수정
  - 파일 IO 직접 처리 제거
  - `WebPageImageStore`를 통한 저장/삭제로 정리
- `WebPageImageStore` 개선
  - URL 기반 파일명을 SHA-256 해시로 변경
  - `webPageImages` 디렉터리에 백업 제외 속성 설정
  - 미사용 `observeDirSize()` 제거
- DI 등록 추가
  - `PersistenceAssembler`
  - `DataAssembler`
  - `DomainAssembler`
  - `InfraAssembler`

## 📸 영상 / 이미지 (Optional)
- 없음
