### PR TITLE
[#385] Github REST API 호출을 Nexa를 사용하도록 수정한다

### DIFF
--- a/DevLog.xcodeproj/project.pbxproj
+++ b/DevLog.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		DFABA3B02E23526500FEFBDB /* FirebaseFirestore in Frameworks */ = {isa = PBXBuildFile; productRef = DFABA3AF2E23526500FEFBDB /* FirebaseFirestore */; };
 		DFABA3B22E23526500FEFBDB /* FirebaseFunctions in Frameworks */ = {isa = PBXBuildFile; productRef = DFABA3B12E23526500FEFBDB /* FirebaseFunctions */; };
 		DFABA3B42E23526500FEFBDB /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = DFABA3B32E23526500FEFBDB /* FirebaseMessaging */; };
+		DFD3B68D2F8F1FB8001DA7CD /* Nexa in Frameworks */ = {isa = PBXBuildFile; productRef = DFD3B68C2F8F1FB8001DA7CD /* Nexa */; };
 		DFD645402EC827A10073E133 /* .gitignore in Resources */ = {isa = PBXBuildFile; fileRef = DFD6453F2EC827A10073E133 /* .gitignore */; };
 		DFD74E2F2E423EA700613803 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = DFD74E2E2E423EA700613803 /* README.md */; };
 		DFF2DACE2EDC02AD00778738 /* OrderedCollections in Frameworks */ = {isa = PBXBuildFile; productRef = DFF2DACD2EDC02AD00778738 /* OrderedCollections */; };
@@ -76,6 +77,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DFD3B68D2F8F1FB8001DA7CD /* Nexa in Frameworks */,
 				DFABA3B42E23526500FEFBDB /* FirebaseMessaging in Frameworks */,
 				DFABA3A92E2351EE00FEFBDB /* GoogleSignInSwift in Frameworks */,
 				DFABA3B22E23526500FEFBDB /* FirebaseFunctions in Frameworks */,
@@ -172,6 +174,7 @@
 				DFABA3B12E23526500FEFBDB /* FirebaseFunctions */,
 				DFABA3B32E23526500FEFBDB /* FirebaseMessaging */,
 				DFF2DACD2EDC02AD00778738 /* OrderedCollections */,
+				DFD3B68C2F8F1FB8001DA7CD /* Nexa */,
 			);
 			productName = SwiftUI_DevLog;
 			productReference = DFD48B002DC4D6E2005905C5 /* DevLog.app */;
@@ -211,6 +214,7 @@
 				DFABA3AA2E23526500FEFBDB /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 				DF66A07B2EA52E970098E643 /* XCRemoteSwiftPackageReference "SwiftLint" */,
 				DFF2DACC2EDC02AD00778738 /* XCRemoteSwiftPackageReference "swift-collections" */,
+				DFD3B68B2F8F1FB8001DA7CD /* XCRemoteSwiftPackageReference "Nexa" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = DFD48B012DC4D6E2005905C5 /* Products */;
@@ -610,6 +614,14 @@
 				minimumVersion = 11.15.0;
 			};
 		};
+		DFD3B68B2F8F1FB8001DA7CD /* XCRemoteSwiftPackageReference "Nexa" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/opficdev/Nexa";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.1.0;
+			};
+		};
 		DFF2DACC2EDC02AD00778738 /* XCRemoteSwiftPackageReference "swift-collections" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/apple/swift-collections.git";
@@ -665,6 +677,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = DFABA3AA2E23526500FEFBDB /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
 			productName = FirebaseMessaging;
+		};
+		DFD3B68C2F8F1FB8001DA7CD /* Nexa */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = DFD3B68B2F8F1FB8001DA7CD /* XCRemoteSwiftPackageReference "Nexa" */;
+			productName = Nexa;
 		};
 		DFF2DACD2EDC02AD00778738 /* OrderedCollections */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/DevLog.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DevLog.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "e440a72cfb4192fa35c539dad59247f988a89b2436e7dfc795518078100559a4",
+  "originHash" : "6e83e8a97f59e7d95bbfcd1dc82daad8306c7a0f7df1e8bb7966a26baf0e4a2b",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -161,6 +161,15 @@
       "state" : {
         "revision" : "2849f5323265386e200484b0d0f896e73c3411b9",
         "version" : "6.0.1"
+      }
+    },
+    {
+      "identity" : "nexa",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/opficdev/Nexa",
+      "state" : {
+        "revision" : "a2f3ca9862eb24ffc28bdeb6d67293b4e8ddf3a5",
+        "version" : "1.1.0"
       }
     },
     {

--- a/DevLog/Infra/Service/SocialLogin/GithubAuthenticationService.swift
+++ b/DevLog/Infra/Service/SocialLogin/GithubAuthenticationService.swift
@@ -11,11 +11,17 @@ import FirebaseAuth
 import FirebaseFirestore
 import FirebaseFunctions
 import FirebaseMessaging
+import Nexa
 
 final class GithubAuthenticationService: NSObject, AuthenticationService {
     private enum FunctionName: String {
         case requestGithubTokens
         case revokeGithubAccessToken
+    }
+
+    private enum GitHubAPI {
+        static let baseURL = URL(string: "https://api.github.com")!
+        static let acceptHeader = "application/vnd.github.v3+json"
     }
 
     private let store = Firestore.firestore()
@@ -243,24 +249,18 @@ final class GithubAuthenticationService: NSObject, AuthenticationService {
 
     // GitHub API로 사용자 프로필 정보 가져오기
     private func requestUserProfile(accessToken: String) async throws -> GitHubUser {
-        guard let url = URL(string: "https://api.github.com/user") else {
-            throw URLError(.badURL)
-        }
+        let gitHubApiClient = NXAPIClient(
+            configuration: NXClientConfiguration(
+                baseURL: GitHubAPI.baseURL,
+                headers: ["Accept": GitHubAPI.acceptHeader]
+            )
+        )
 
-        var request = URLRequest(url: url)
-        request.httpMethod = "GET"
-        request.addValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
-        request.addValue("application/vnd.github.v3+json", forHTTPHeaderField: "Accept")
-        
-        let (data, response) = try await URLSession.shared.data(for: request)
-        
-        guard let httpResponse = response as? HTTPURLResponse,
-              httpResponse.statusCode == 200 else {
-            throw URLError(.badServerResponse)
-        }
-        
-        let decoder = JSONDecoder()
-        let gitHubUser = try decoder.decode(GitHubUser.self, from: data)
+        let gitHubUser = try await gitHubApiClient
+            .get("/user", as: GitHubUser.self)
+            .header("Authorization", "Bearer \(accessToken)")
+            .validate(.statusCodes([200]))
+            .send()
 
         if gitHubUser.email != nil {
             return gitHubUser
@@ -276,24 +276,18 @@ final class GithubAuthenticationService: NSObject, AuthenticationService {
     }
 
     private func requestPrimaryVerifiedEmail(accessToken: String) async throws -> String? {
-        guard let url = URL(string: "https://api.github.com/user/emails") else {
-            throw URLError(.badURL)
-        }
+        let gitHubApiClient = NXAPIClient(
+            configuration: NXClientConfiguration(
+                baseURL: GitHubAPI.baseURL,
+                headers: ["Accept": GitHubAPI.acceptHeader]
+            )
+        )
 
-        var request = URLRequest(url: url)
-        request.httpMethod = "GET"
-        request.addValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
-        request.addValue("application/vnd.github.v3+json", forHTTPHeaderField: "Accept")
-
-        let (data, response) = try await URLSession.shared.data(for: request)
-
-        guard let httpResponse = response as? HTTPURLResponse,
-              httpResponse.statusCode == 200 else {
-            throw URLError(.badServerResponse)
-        }
-
-        let decoder = JSONDecoder()
-        let gitHubEmails = try decoder.decode([GitHubEmail].self, from: data)
+        let gitHubEmails = try await gitHubApiClient
+            .get("/user/emails", as: [GitHubEmail].self)
+            .header("Authorization", "Bearer \(accessToken)")
+            .validate(.statusCodes([200]))
+            .send()
 
         if let primaryVerifiedEmail = gitHubEmails.first(where: { $0.primary && $0.verified }) {
             return primaryVerifiedEmail.email

--- a/DevLog/Infra/Service/SocialLogin/GithubAuthenticationService.swift
+++ b/DevLog/Infra/Service/SocialLogin/GithubAuthenticationService.swift
@@ -31,6 +31,12 @@ final class GithubAuthenticationService: NSObject, AuthenticationService {
     private let providerID = AuthProviderID.gitHub
     private let provider = TopViewControllerProvider()
     private let logger = Logger(category: "GithubAuthService")
+    private let gitHubApiClient = NXAPIClient(
+        configuration: NXClientConfiguration(
+            baseURL: GitHubAPI.baseURL,
+            headers: ["Accept": GitHubAPI.acceptHeader]
+        )
+    )
 
     func signIn() async throws -> AuthDataResponse {
         logger.info("Starting GitHub sign in")
@@ -249,13 +255,6 @@ final class GithubAuthenticationService: NSObject, AuthenticationService {
 
     // GitHub API로 사용자 프로필 정보 가져오기
     private func requestUserProfile(accessToken: String) async throws -> GitHubUser {
-        let gitHubApiClient = NXAPIClient(
-            configuration: NXClientConfiguration(
-                baseURL: GitHubAPI.baseURL,
-                headers: ["Accept": GitHubAPI.acceptHeader]
-            )
-        )
-
         let gitHubUser = try await gitHubApiClient
             .get("/user", as: GitHubUser.self)
             .header("Authorization", "Bearer \(accessToken)")
@@ -276,13 +275,6 @@ final class GithubAuthenticationService: NSObject, AuthenticationService {
     }
 
     private func requestPrimaryVerifiedEmail(accessToken: String) async throws -> String? {
-        let gitHubApiClient = NXAPIClient(
-            configuration: NXClientConfiguration(
-                baseURL: GitHubAPI.baseURL,
-                headers: ["Accept": GitHubAPI.acceptHeader]
-            )
-        )
-
         let gitHubEmails = try await gitHubApiClient
             .get("/user/emails", as: [GitHubEmail].self)
             .header("Authorization", "Bearer \(accessToken)")


### PR DESCRIPTION
## 🔗 연관된 이슈
- closed #385

## 📝 작업 내용

### 📌 요약
- `GithubAuthenticationService` 내 GitHub REST API 호출부의 `Nexa` 기반 요청 방식 전환
- GitHub API 설정값의 `GitHubAPI` 내부 상수화
- GitHub 프로필 조회 / 이메일 조회 로직의 기존 메서드 내부 생성 스타일 기준 정리
- 대상 파일 기준 순감 14줄

### 🔍 상세
- `https://api.github.com/user` 호출부의 `NXAPIClient` + `.get(_:as:)` 기반 구조로의 변경
- `https://api.github.com/user/emails` 호출부의 동일 패턴 적용
- `URLRequest` 생성, `addValue`, `URLSession.shared.data`, `HTTPURLResponse` 검증, `JSONDecoder` 수동 디코딩 코드 제거
- `baseURL`, `Accept` 헤더 문자열의 `GitHubAPI` enum 내부 상수 분리
- `GithubAuthenticationService.swift` 기준 브랜치 분기점 대비 `22`줄 추가, `36`줄 삭제, 순감 `14`줄 

## 📸 영상 / 이미지 (Optional)
