### PR TITLE
[#396] 위젯 UI를 구성한다

### DIFF
--- a/DevLog/Widget/Heatmap/HeatmapWidgetSnapshot.swift
+++ b/DevLog/Widget/Heatmap/HeatmapWidgetSnapshot.swift
@@ -9,9 +9,14 @@ import Foundation
 
 struct HeatmapWidgetSnapshot: Codable, Equatable {
     let generatedAt: Date
-    let monthStart: Date
+    let quarterStart: Date
     let selectedActivityKindRawValues: [String]
     let maxCount: Int
+    let months: [WidgetHeatmapMonthSnapshot]
+}
+
+struct WidgetHeatmapMonthSnapshot: Codable, Equatable {
+    let monthStart: Date
     let weeks: [WidgetHeatmapWeekSnapshot]
 }
 

--- a/DevLog/Widget/Heatmap/HeatmapWidgetSnapshotFactory.swift
+++ b/DevLog/Widget/Heatmap/HeatmapWidgetSnapshotFactory.swift
@@ -36,30 +36,40 @@ struct HeatmapWidgetSnapshotFactory {
         completedTodos: [Todo],
         deletedTodos: [Todo],
         selectedActivityKinds: Set<ActivityKind>,
-        monthStart: Date,
+        quarterStart: Date,
         now: Date = Date()
     ) -> HeatmapWidgetSnapshot {
-        let normalizedMonthStart = startOfMonth(for: monthStart)
+        let normalizedQuarterStart = startOfQuarter(for: quarterStart)
+        guard let nextQuarterStart = calendar.date(byAdding: .month, value: 3, to: normalizedQuarterStart) else {
+            return HeatmapWidgetSnapshot(
+                generatedAt: now,
+                quarterStart: normalizedQuarterStart,
+                selectedActivityKindRawValues: orderedActivityKinds(from: selectedActivityKinds).map(\.rawValue),
+                maxCount: 0,
+                months: []
+            )
+        }
         let dailyCountsByDate = makeDailyCountsByDate(
             createdTodos: createdTodos,
             completedTodos: completedTodos,
             deletedTodos: deletedTodos,
-            monthStart: normalizedMonthStart
+            quarterStart: normalizedQuarterStart,
+            nextQuarterStart: nextQuarterStart
         )
-        let weeks = makeWeeks(
-            monthStart: normalizedMonthStart,
+        let months = makeMonths(
+            quarterStart: normalizedQuarterStart,
             dailyCountsByDate: dailyCountsByDate
         )
 
         return HeatmapWidgetSnapshot(
             generatedAt: now,
-            monthStart: normalizedMonthStart,
+            quarterStart: normalizedQuarterStart,
             selectedActivityKindRawValues: orderedActivityKinds(from: selectedActivityKinds).map(\.rawValue),
             maxCount: maxCount(
-                from: weeks,
+                from: months,
                 selectedActivityKinds: selectedActivityKinds
             ),
-            weeks: weeks
+            months: months
         )
     }
 }
@@ -69,7 +79,8 @@ private extension HeatmapWidgetSnapshotFactory {
         createdTodos: [Todo],
         completedTodos: [Todo],
         deletedTodos: [Todo],
-        monthStart: Date
+        quarterStart: Date,
+        nextQuarterStart: Date
     ) -> [Date: DailyCounts] {
         var dailyCountsByDate = [Date: DailyCounts]()
 
@@ -77,7 +88,8 @@ private extension HeatmapWidgetSnapshotFactory {
             appendCount(
                 activityKind: .created,
                 occurredAt: todo.createdAt,
-                monthStart: monthStart,
+                quarterStart: quarterStart,
+                nextQuarterStart: nextQuarterStart,
                 dailyCountsByDate: &dailyCountsByDate
             )
         }
@@ -87,7 +99,8 @@ private extension HeatmapWidgetSnapshotFactory {
             appendCount(
                 activityKind: .completed,
                 occurredAt: completedAt,
-                monthStart: monthStart,
+                quarterStart: quarterStart,
+                nextQuarterStart: nextQuarterStart,
                 dailyCountsByDate: &dailyCountsByDate
             )
         }
@@ -97,7 +110,8 @@ private extension HeatmapWidgetSnapshotFactory {
             appendCount(
                 activityKind: .deleted,
                 occurredAt: deletedAt,
-                monthStart: monthStart,
+                quarterStart: quarterStart,
+                nextQuarterStart: nextQuarterStart,
                 dailyCountsByDate: &dailyCountsByDate
             )
         }
@@ -108,15 +122,35 @@ private extension HeatmapWidgetSnapshotFactory {
     func appendCount(
         activityKind: ActivityKind,
         occurredAt: Date,
-        monthStart: Date,
+        quarterStart: Date,
+        nextQuarterStart: Date,
         dailyCountsByDate: inout [Date: DailyCounts]
     ) {
-        guard isDateInMonth(occurredAt, monthStart: monthStart) else { return }
+        guard quarterStart <= occurredAt && occurredAt < nextQuarterStart else { return }
 
         let dayStart = calendar.startOfDay(for: occurredAt)
         var dailyCounts = dailyCountsByDate[dayStart] ?? DailyCounts()
         dailyCounts.increment(activityKind)
         dailyCountsByDate[dayStart] = dailyCounts
+    }
+
+    func makeMonths(
+        quarterStart: Date,
+        dailyCountsByDate: [Date: DailyCounts]
+    ) -> [WidgetHeatmapMonthSnapshot] {
+        let monthStarts = (0..<3).compactMap {
+            calendar.date(byAdding: .month, value: $0, to: quarterStart)
+        }
+
+        return monthStarts.map { monthStart in
+            WidgetHeatmapMonthSnapshot(
+                monthStart: monthStart,
+                weeks: makeWeeks(
+                    monthStart: monthStart,
+                    dailyCountsByDate: dailyCountsByDate
+                )
+            )
+        }
     }
 
     func makeWeeks(
@@ -173,29 +207,21 @@ private extension HeatmapWidgetSnapshotFactory {
         return weeks
     }
 
-    func startOfMonth(for date: Date) -> Date {
-        guard let monthInterval = calendar.dateInterval(of: .month, for: date) else {
-            return calendar.startOfDay(for: date)
-        }
-        return monthInterval.start
-    }
-
-    func isDateInMonth(
-        _ date: Date,
-        monthStart: Date
-    ) -> Bool {
-        calendar.isDate(
-            calendar.startOfDay(for: date),
-            equalTo: monthStart,
-            toGranularity: .month
-        )
+    func startOfQuarter(for date: Date) -> Date {
+        let month = calendar.component(.month, from: date)
+        let startMonth = ((month - 1) / 3) * 3 + 1
+        var components = calendar.dateComponents([.year], from: date)
+        components.month = startMonth
+        components.day = 1
+        return calendar.date(from: components) ?? calendar.startOfDay(for: date)
     }
 
     func maxCount(
-        from weeks: [WidgetHeatmapWeekSnapshot],
+        from months: [WidgetHeatmapMonthSnapshot],
         selectedActivityKinds: Set<ActivityKind>
     ) -> Int {
-        weeks
+        months
+            .flatMap(\.weeks)
             .flatMap(\.days)
             .filter(\.isVisible)
             .map { day in

--- a/DevLog/Widget/Heatmap/HeatmapWidgetSyncCoordinator.swift
+++ b/DevLog/Widget/Heatmap/HeatmapWidgetSyncCoordinator.swift
@@ -31,16 +31,16 @@ final class HeatmapWidgetSyncCoordinator {
         selectedActivityKinds: Set<ActivityKind>,
         now: Date = Date()
     ) async {
-        let monthStart = startOfMonth(for: now)
-        guard let nextMonthStart = calendar.date(byAdding: .month, value: 1, to: monthStart) else {
+        let quarterStart = startOfQuarter(for: now)
+        guard let nextQuarterStart = calendar.date(byAdding: .month, value: 3, to: quarterStart) else {
             return
         }
 
         do {
             async let createdTodoPage = fetchTodosUseCase.execute(
                 TodoQuery(
-                    sortDateFrom: monthStart,
-                    sortDateTo: nextMonthStart,
+                    sortDateFrom: quarterStart,
+                    sortDateTo: nextQuarterStart,
                     includesDeleted: true,
                     sortTarget: .createdAt,
                     pageSize: 100,
@@ -50,8 +50,8 @@ final class HeatmapWidgetSyncCoordinator {
             )
             async let completedTodoPage = fetchTodosUseCase.execute(
                 TodoQuery(
-                    sortDateFrom: monthStart,
-                    sortDateTo: nextMonthStart,
+                    sortDateFrom: quarterStart,
+                    sortDateTo: nextQuarterStart,
                     includesDeleted: true,
                     sortTarget: .completedAt,
                     pageSize: 100,
@@ -61,8 +61,8 @@ final class HeatmapWidgetSyncCoordinator {
             )
             async let deletedTodoPage = fetchTodosUseCase.execute(
                 TodoQuery(
-                    sortDateFrom: monthStart,
-                    sortDateTo: nextMonthStart,
+                    sortDateFrom: quarterStart,
+                    sortDateTo: nextQuarterStart,
                     includesDeleted: true,
                     sortTarget: .deletedAt,
                     pageSize: 100,
@@ -76,7 +76,7 @@ final class HeatmapWidgetSyncCoordinator {
                 completedTodos: try await completedTodoPage.items,
                 deletedTodos: try await deletedTodoPage.items,
                 selectedActivityKinds: selectedActivityKinds,
-                monthStart: monthStart,
+                quarterStart: quarterStart,
                 now: now
             )
 
@@ -94,11 +94,12 @@ final class HeatmapWidgetSyncCoordinator {
 }
 
 private extension HeatmapWidgetSyncCoordinator {
-    func startOfMonth(for date: Date) -> Date {
-        guard let monthInterval = calendar.dateInterval(of: .month, for: date) else {
-            return calendar.startOfDay(for: date)
-        }
-
-        return monthInterval.start
+    func startOfQuarter(for date: Date) -> Date {
+        let month = calendar.component(.month, from: date)
+        let startMonth = ((month - 1) / 3) * 3 + 1
+        var components = calendar.dateComponents([.year], from: date)
+        components.month = startMonth
+        components.day = 1
+        return calendar.date(from: components) ?? calendar.startOfDay(for: date)
     }
 }

--- a/DevLogWidget/Common/WidgetPlaceholderCard.swift
+++ b/DevLogWidget/Common/WidgetPlaceholderCard.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 
 struct WidgetPlaceholderCard: View {
-    let title: String
     let message: String
 
     var body: some View {
@@ -18,11 +17,7 @@ struct WidgetPlaceholderCard: View {
                 Text(message)
                     .font(.caption)
                     .foregroundStyle(.secondary)
-            }
-            .overlay(alignment: .topLeading) {
-                Text(title)
-                    .font(.headline)
-                    .padding(12)
+                    .multilineTextAlignment(.center)
             }
     }
 }

--- a/DevLogWidget/Heatmap/HeatmapWidget.swift
+++ b/DevLogWidget/Heatmap/HeatmapWidget.swift
@@ -22,7 +22,7 @@ struct HeatmapWidget: Widget {
                 .containerBackground(.fill.tertiary, for: .widget)
         }
         .configurationDisplayName("Heatmap")
-        .description("이번 달 활동 히트맵을 표시합니다.")
-        .supportedFamilies([.systemSmall, .systemMedium, .systemLarge])
+        .description("활동 히트맵을 표시합니다.")
+        .supportedFamilies([.systemSmall, .systemMedium])
     }
 }

--- a/DevLogWidget/Heatmap/HeatmapWidgetConfigurationIntent.swift
+++ b/DevLogWidget/Heatmap/HeatmapWidgetConfigurationIntent.swift
@@ -10,5 +10,5 @@ import WidgetKit
 
 struct HeatmapWidgetConfigurationIntent: WidgetConfigurationIntent {
     static var title: LocalizedStringResource = "Heatmap"
-    static var description = IntentDescription("이번 달 활동 히트맵을 표시합니다.")
+    static var description = IntentDescription("활동 히트맵을 표시합니다.")
 }

--- a/DevLogWidget/Heatmap/HeatmapWidgetEntryView.swift
+++ b/DevLogWidget/Heatmap/HeatmapWidgetEntryView.swift
@@ -58,13 +58,27 @@ struct HeatmapWidgetEntryView: View {
             VStack(alignment: .leading, spacing: 8) {
                 Text("이번 달 히트맵")
                     .font(.headline)
-                Text("앱을 열어\n히트맵을 준비하세요")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                GeometryReader { proxy in
+                    placeholderHeatmapGrid(
+                        monthCount: 1,
+                        availableSize: proxy.size,
+                        showsMonthTitles: false
+                    )
+                }
+                .frame(height: 72)
             }
         case .systemMedium:
-            WidgetPlaceholderCard(message: "앱을 열어\n히트맵을 준비하세요")
-                .frame(maxWidth: .infinity)
+            VStack(alignment: .leading, spacing: 8) {
+                header(title: "이번 분기 히트맵")
+                GeometryReader { proxy in
+                    placeholderHeatmapGrid(
+                        monthCount: 3,
+                        availableSize: proxy.size,
+                        showsMonthTitles: true
+                    )
+                }
+                .frame(height: 80)
+            }
         default:
             EmptyView()
         }
@@ -87,5 +101,101 @@ struct HeatmapWidgetEntryView: View {
         }
 
         return Array(snapshot.months.prefix(1))
+    }
+
+    private func placeholderHeatmapGrid(
+        monthCount: Int,
+        availableSize: CGSize,
+        showsMonthTitles: Bool
+    ) -> some View {
+        let resolvedMonthCount = max(monthCount, 1)
+        let columnCount = showsMonthTitles ? 5 : 6
+        let monthSpacing = showsMonthTitles ? availableSize.width / 18 : 0
+        let cellSpacing: CGFloat = 3
+        let monthTitleHeight: CGFloat = showsMonthTitles ? 8 : 0
+        let monthTitleSpacing: CGFloat = showsMonthTitles ? 6 : 0
+        let totalMonthSpacing = monthSpacing * CGFloat(max(resolvedMonthCount - 1, 0))
+        let monthWidth = max((availableSize.width - totalMonthSpacing) / CGFloat(resolvedMonthCount), 0)
+        let widthBasedCellSize = max(
+            (monthWidth - cellSpacing * CGFloat(max(columnCount - 1, 0))) / CGFloat(columnCount),
+            0
+        )
+        let verticalFixedHeight = monthTitleHeight
+            + monthTitleSpacing
+            + cellSpacing * CGFloat(max(7 - 1, 0))
+        let heightBasedCellSize = max((availableSize.height - verticalFixedHeight) / 7, 0)
+        let cellSize = min(widthBasedCellSize, heightBasedCellSize)
+
+        return HStack(alignment: .top, spacing: monthSpacing) {
+            ForEach(0..<resolvedMonthCount, id: \.self) { _ in
+                placeholderHeatmapMonth(
+                    columnCount: columnCount,
+                    cellSize: cellSize,
+                    cellSpacing: cellSpacing,
+                    monthTitleHeight: monthTitleHeight,
+                    monthTitleSpacing: monthTitleSpacing,
+                    showsMonthTitles: showsMonthTitles
+                )
+            }
+        }
+    }
+
+    private func placeholderHeatmapMonth(
+        columnCount: Int,
+        cellSize: CGFloat,
+        cellSpacing: CGFloat,
+        monthTitleHeight: CGFloat,
+        monthTitleSpacing: CGFloat,
+        showsMonthTitles: Bool
+    ) -> some View {
+        VStack(alignment: .leading, spacing: monthTitleSpacing) {
+            if showsMonthTitles {
+                RoundedRectangle(cornerRadius: 3)
+                    .fill(Color.secondary.opacity(0.18))
+                    .frame(width: cellSize * 3, height: monthTitleHeight)
+            }
+
+            HStack(alignment: .top, spacing: cellSpacing) {
+                ForEach(0..<columnCount, id: \.self) { columnIndex in
+                    VStack(spacing: cellSpacing) {
+                        ForEach(0..<7, id: \.self) { rowIndex in
+                            placeholderHeatmapCell(
+                                columnIndex: columnIndex,
+                                rowIndex: rowIndex,
+                                size: cellSize
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private func placeholderHeatmapCell(
+        columnIndex: Int,
+        rowIndex: Int,
+        size: CGFloat
+    ) -> some View {
+        let opacity = placeholderHeatmapCellOpacity(columnIndex: columnIndex, rowIndex: rowIndex)
+
+        return RoundedRectangle(cornerRadius: max(2, size / 5))
+            .fill(Color.secondary.opacity(opacity))
+            .frame(width: size, height: size)
+    }
+
+    private func placeholderHeatmapCellOpacity(
+        columnIndex: Int,
+        rowIndex: Int
+    ) -> Double {
+        switch (columnIndex + rowIndex) % 4 {
+        case 0:
+            return 1 / 8
+        case 1:
+            return 1 / 5
+        case 2:
+            return 1 / 4
+        default:
+            return 3 / 20
+        }
     }
 }

--- a/DevLogWidget/Heatmap/HeatmapWidgetEntryView.swift
+++ b/DevLogWidget/Heatmap/HeatmapWidgetEntryView.swift
@@ -62,7 +62,6 @@ struct HeatmapWidgetEntryView: View {
                     weekCounts: [5],
                     showsMonthTitles: false
                 )
-                .frame(height: 72)
             }
         case .systemMedium:
             VStack(alignment: .leading, spacing: 8) {
@@ -71,7 +70,6 @@ struct HeatmapWidgetEntryView: View {
                     weekCounts: [5, 5, 5],
                     showsMonthTitles: true
                 )
-                .frame(height: 80)
             }
         default:
             EmptyView()

--- a/DevLogWidget/Heatmap/HeatmapWidgetEntryView.swift
+++ b/DevLogWidget/Heatmap/HeatmapWidgetEntryView.swift
@@ -13,12 +13,7 @@ struct HeatmapWidgetEntryView: View {
     @Environment(\.widgetFamily) private var widgetFamily
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text("이번 달 히트맵")
-                .font(.headline)
-
-            Spacer()
-
+        Group {
             if let snapshot = entry.snapshot {
                 content(snapshot)
             } else {
@@ -30,36 +25,70 @@ struct HeatmapWidgetEntryView: View {
 
     @ViewBuilder
     private func content(_ snapshot: HeatmapWidgetSnapshot) -> some View {
-        if widgetFamily == .systemSmall {
+        switch widgetFamily {
+        case .systemSmall:
             VStack(alignment: .leading, spacing: 4) {
-                Text("\(snapshot.maxCount)")
-                    .font(.title)
-                    .bold()
-                Text("이번 달 최대 활동 수")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                header(title: "이번 달 히트맵")
+                WidgetHeatmapGrid(
+                    months: currentMonths(from: snapshot),
+                    selectedActivityKindRawValues: snapshot.selectedActivityKindRawValues,
+                    maxCount: snapshot.maxCount,
+                    showsMonthTitles: false
+                )
             }
-        } else {
-            WidgetPlaceholderCard(
-                title: "이번 달 히트맵",
-                message: "저장된 주차 \(snapshot.weeks.count)개"
-            )
-            .frame(maxWidth: .infinity)
+        case .systemMedium:
+            VStack(alignment: .leading, spacing: 8) {
+                header(title: "이번 분기 히트맵")
+                WidgetHeatmapGrid(
+                    months: snapshot.months,
+                    selectedActivityKindRawValues: snapshot.selectedActivityKindRawValues,
+                    maxCount: snapshot.maxCount,
+                    showsMonthTitles: true
+                )
+            }
+        default:
+            EmptyView()
         }
     }
 
     @ViewBuilder
     private var emptyState: some View {
-        if widgetFamily == .systemSmall {
-            Text("앱을 열어\n히트맵을 준비하세요")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-        } else {
+        switch widgetFamily {
+        case .systemSmall:
+            VStack(alignment: .leading, spacing: 8) {
+                Text("이번 달 히트맵")
+                    .font(.headline)
+                Text("앱을 열어\n히트맵을 준비하세요")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        case .systemMedium:
             WidgetPlaceholderCard(
-                title: "이번 달 히트맵",
+                title: "이번 분기 히트맵",
                 message: "데이터 연결 전"
             )
             .frame(maxWidth: .infinity)
+        default:
+            EmptyView()
         }
+    }
+
+    private func header(title: String) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 6) {
+            Text(title)
+                .font(.headline)
+                .lineLimit(1)
+            Spacer(minLength: 0)
+        }
+    }
+
+    private func currentMonths(from snapshot: HeatmapWidgetSnapshot) -> [WidgetHeatmapMonthSnapshot] {
+        if let currentMonth = snapshot.months.first(where: {
+            Calendar.current.isDate($0.monthStart, equalTo: snapshot.generatedAt, toGranularity: .month)
+        }) {
+            return [currentMonth]
+        }
+
+        return Array(snapshot.months.prefix(1))
     }
 }

--- a/DevLogWidget/Heatmap/HeatmapWidgetEntryView.swift
+++ b/DevLogWidget/Heatmap/HeatmapWidgetEntryView.swift
@@ -58,25 +58,19 @@ struct HeatmapWidgetEntryView: View {
             VStack(alignment: .leading, spacing: 8) {
                 Text("이번 달 히트맵")
                     .font(.headline)
-                GeometryReader { proxy in
-                    placeholderHeatmapGrid(
-                        monthCount: 1,
-                        availableSize: proxy.size,
-                        showsMonthTitles: false
-                    )
-                }
+                WidgetHeatmapPlaceholderGrid(
+                    weekCounts: [5],
+                    showsMonthTitles: false
+                )
                 .frame(height: 72)
             }
         case .systemMedium:
             VStack(alignment: .leading, spacing: 8) {
                 header(title: "이번 분기 히트맵")
-                GeometryReader { proxy in
-                    placeholderHeatmapGrid(
-                        monthCount: 3,
-                        availableSize: proxy.size,
-                        showsMonthTitles: true
-                    )
-                }
+                WidgetHeatmapPlaceholderGrid(
+                    weekCounts: [5, 5, 5],
+                    showsMonthTitles: true
+                )
                 .frame(height: 80)
             }
         default:
@@ -101,101 +95,5 @@ struct HeatmapWidgetEntryView: View {
         }
 
         return Array(snapshot.months.prefix(1))
-    }
-
-    private func placeholderHeatmapGrid(
-        monthCount: Int,
-        availableSize: CGSize,
-        showsMonthTitles: Bool
-    ) -> some View {
-        let resolvedMonthCount = max(monthCount, 1)
-        let columnCount = showsMonthTitles ? 5 : 6
-        let monthSpacing = showsMonthTitles ? availableSize.width / 18 : 0
-        let cellSpacing: CGFloat = 3
-        let monthTitleHeight: CGFloat = showsMonthTitles ? 8 : 0
-        let monthTitleSpacing: CGFloat = showsMonthTitles ? 6 : 0
-        let totalMonthSpacing = monthSpacing * CGFloat(max(resolvedMonthCount - 1, 0))
-        let monthWidth = max((availableSize.width - totalMonthSpacing) / CGFloat(resolvedMonthCount), 0)
-        let widthBasedCellSize = max(
-            (monthWidth - cellSpacing * CGFloat(max(columnCount - 1, 0))) / CGFloat(columnCount),
-            0
-        )
-        let verticalFixedHeight = monthTitleHeight
-            + monthTitleSpacing
-            + cellSpacing * CGFloat(max(7 - 1, 0))
-        let heightBasedCellSize = max((availableSize.height - verticalFixedHeight) / 7, 0)
-        let cellSize = min(widthBasedCellSize, heightBasedCellSize)
-
-        return HStack(alignment: .top, spacing: monthSpacing) {
-            ForEach(0..<resolvedMonthCount, id: \.self) { _ in
-                placeholderHeatmapMonth(
-                    columnCount: columnCount,
-                    cellSize: cellSize,
-                    cellSpacing: cellSpacing,
-                    monthTitleHeight: monthTitleHeight,
-                    monthTitleSpacing: monthTitleSpacing,
-                    showsMonthTitles: showsMonthTitles
-                )
-            }
-        }
-    }
-
-    private func placeholderHeatmapMonth(
-        columnCount: Int,
-        cellSize: CGFloat,
-        cellSpacing: CGFloat,
-        monthTitleHeight: CGFloat,
-        monthTitleSpacing: CGFloat,
-        showsMonthTitles: Bool
-    ) -> some View {
-        VStack(alignment: .leading, spacing: monthTitleSpacing) {
-            if showsMonthTitles {
-                RoundedRectangle(cornerRadius: 3)
-                    .fill(Color.secondary.opacity(0.18))
-                    .frame(width: cellSize * 3, height: monthTitleHeight)
-            }
-
-            HStack(alignment: .top, spacing: cellSpacing) {
-                ForEach(0..<columnCount, id: \.self) { columnIndex in
-                    VStack(spacing: cellSpacing) {
-                        ForEach(0..<7, id: \.self) { rowIndex in
-                            placeholderHeatmapCell(
-                                columnIndex: columnIndex,
-                                rowIndex: rowIndex,
-                                size: cellSize
-                            )
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    private func placeholderHeatmapCell(
-        columnIndex: Int,
-        rowIndex: Int,
-        size: CGFloat
-    ) -> some View {
-        let opacity = placeholderHeatmapCellOpacity(columnIndex: columnIndex, rowIndex: rowIndex)
-
-        return RoundedRectangle(cornerRadius: max(2, size / 5))
-            .fill(Color.secondary.opacity(opacity))
-            .frame(width: size, height: size)
-    }
-
-    private func placeholderHeatmapCellOpacity(
-        columnIndex: Int,
-        rowIndex: Int
-    ) -> Double {
-        switch (columnIndex + rowIndex) % 4 {
-        case 0:
-            return 1 / 8
-        case 1:
-            return 1 / 5
-        case 2:
-            return 1 / 4
-        default:
-            return 3 / 20
-        }
     }
 }

--- a/DevLogWidget/Heatmap/HeatmapWidgetEntryView.swift
+++ b/DevLogWidget/Heatmap/HeatmapWidgetEntryView.swift
@@ -63,11 +63,8 @@ struct HeatmapWidgetEntryView: View {
                     .foregroundStyle(.secondary)
             }
         case .systemMedium:
-            WidgetPlaceholderCard(
-                title: "이번 분기 히트맵",
-                message: "데이터 연결 전"
-            )
-            .frame(maxWidth: .infinity)
+            WidgetPlaceholderCard(message: "앱을 열어\n히트맵을 준비하세요")
+                .frame(maxWidth: .infinity)
         default:
             EmptyView()
         }

--- a/DevLogWidget/Heatmap/HeatmapWidgetProvider.swift
+++ b/DevLogWidget/Heatmap/HeatmapWidgetProvider.swift
@@ -25,7 +25,7 @@ struct HeatmapWidgetProvider: AppIntentTimelineProvider {
     ) async -> HeatmapWidgetEntry {
         let snapshot = try? store.loadHeatmapSnapshot()
         return .init(
-            date: snapshot?.generatedAt ?? .now,
+            date: .now,
             snapshot: snapshot
         )
     }
@@ -39,7 +39,7 @@ struct HeatmapWidgetProvider: AppIntentTimelineProvider {
         let snapshot = try? store.loadHeatmapSnapshot()
         let entries: [HeatmapWidgetEntry] = [
             .init(
-                date: snapshot?.generatedAt ?? .now,
+                date: .now,
                 snapshot: snapshot
             )
         ]

--- a/DevLogWidget/Heatmap/HeatmapWidgetSnapshot.swift
+++ b/DevLogWidget/Heatmap/HeatmapWidgetSnapshot.swift
@@ -9,9 +9,47 @@ import Foundation
 
 struct HeatmapWidgetSnapshot: Decodable, Equatable {
     let generatedAt: Date
-    let monthStart: Date
+    let quarterStart: Date
     let selectedActivityKindRawValues: [String]
     let maxCount: Int
+    let months: [WidgetHeatmapMonthSnapshot]
+
+    private enum CodingKeys: String, CodingKey {
+        case generatedAt
+        case quarterStart
+        case monthStart
+        case selectedActivityKindRawValues
+        case maxCount
+        case months
+        case weeks
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        generatedAt = try container.decode(Date.self, forKey: .generatedAt)
+        selectedActivityKindRawValues = try container.decode([String].self, forKey: .selectedActivityKindRawValues)
+        maxCount = try container.decode(Int.self, forKey: .maxCount)
+
+        if let quarterStart = try container.decodeIfPresent(Date.self, forKey: .quarterStart),
+           let months = try container.decodeIfPresent([WidgetHeatmapMonthSnapshot].self, forKey: .months) {
+            self.quarterStart = quarterStart
+            self.months = months
+        } else {
+            let monthStart = try container.decode(Date.self, forKey: .monthStart)
+            let weeks = try container.decode([WidgetHeatmapWeekSnapshot].self, forKey: .weeks)
+            self.quarterStart = monthStart
+            self.months = [
+                WidgetHeatmapMonthSnapshot(
+                    monthStart: monthStart,
+                    weeks: weeks
+                )
+            ]
+        }
+    }
+}
+
+struct WidgetHeatmapMonthSnapshot: Decodable, Equatable {
+    let monthStart: Date
     let weeks: [WidgetHeatmapWeekSnapshot]
 }
 

--- a/DevLogWidget/Heatmap/WidgetHeatmapGrid.swift
+++ b/DevLogWidget/Heatmap/WidgetHeatmapGrid.swift
@@ -12,7 +12,6 @@ struct WidgetHeatmapGrid: View {
     let selectedActivityKindRawValues: [String]
     let maxCount: Int
     let showsMonthTitles: Bool
-    private let orderedWeekdays = Array(1...7)
 
     var body: some View {
         GeometryReader { proxy in
@@ -24,7 +23,7 @@ struct WidgetHeatmapGrid: View {
             )
 
             HStack(alignment: .top, spacing: layout.weekdayLabelSpacing) {
-                weekdayLabel(layout)
+                WidgetHeatmapWeekdayLabels(layout: layout)
 
                 HStack(alignment: .top, spacing: layout.monthSpacing) {
                     ForEach(months, id: \.monthStart) { month in
@@ -41,36 +40,75 @@ struct WidgetHeatmapGrid: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         }
     }
+}
 
-    @ViewBuilder
-    private func weekdayLabel(_ layout: WidgetHeatmapLayout) -> some View {
-        let weekdayLabels = [
-            2: "월",
-            4: "수",
-            6: "금"
-        ]
+struct WidgetHeatmapPlaceholderGrid: View {
+    let weekCounts: [Int]
+    let showsMonthTitles: Bool
 
+    var body: some View {
+        GeometryReader { proxy in
+            let layout = WidgetHeatmapLayout(
+                availableWidth: proxy.size.width,
+                availableHeight: proxy.size.height,
+                weekCounts: weekCounts,
+                showsMonthTitles: showsMonthTitles
+            )
+
+            HStack(alignment: .top, spacing: layout.weekdayLabelSpacing) {
+                WidgetHeatmapWeekdayLabels(layout: layout)
+
+                HStack(alignment: .top, spacing: layout.monthSpacing) {
+                    ForEach(Array(weekCounts.enumerated()), id: \.offset) { _, weekCount in
+                        WidgetHeatmapPlaceholderMonthGrid(
+                            weekCount: weekCount,
+                            layout: layout,
+                            showsMonthTitle: showsMonthTitles
+                        )
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        }
+    }
+}
+
+private struct WidgetHeatmapWeekdayLabels: View {
+    let layout: WidgetHeatmapLayout
+    private let orderedWeekdays = Array(1...7)
+    private let weekdayLabels = [
+        2: "월",
+        4: "수",
+        6: "금"
+    ]
+
+    var body: some View {
         VStack(alignment: .leading, spacing: layout.cellSpacing) {
             ForEach(orderedWeekdays, id: \.self) { weekday in
-                if let label = weekdayLabels[weekday] {
-                    Text(label)
-                        .font(.caption2)
-                        .foregroundStyle(.secondary)
-                        .frame(
-                            width: layout.weekdayLabelWidth,
-                            height: layout.cellSize,
-                            alignment: .leading
-                        )
-                } else {
-                    Color.clear
-                        .frame(
-                            width: layout.weekdayLabelWidth,
-                            height: layout.cellSize
-                        )
-                }
+                weekdayLabel(for: weekday)
             }
         }
         .padding(.top, layout.weekdayTopPadding)
+    }
+
+    @ViewBuilder
+    private func weekdayLabel(for weekday: Int) -> some View {
+        if let label = weekdayLabels[weekday] {
+            Text(label)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .frame(
+                    width: layout.weekdayLabelWidth,
+                    height: layout.cellSize,
+                    alignment: .leading
+                )
+        } else {
+            Color.clear
+                .frame(
+                    width: layout.weekdayLabelWidth,
+                    height: layout.cellSize
+                )
+        }
     }
 }
 
@@ -150,4 +188,47 @@ private enum WidgetHeatmapActivityKind: String {
     case created
     case completed
     case deleted
+}
+
+private struct WidgetHeatmapPlaceholderMonthGrid: View {
+    let weekCount: Int
+    let layout: WidgetHeatmapLayout
+    let showsMonthTitle: Bool
+    private let orderedWeekdays = Array(1...7)
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: layout.monthTitleSpacing) {
+            if showsMonthTitle {
+                RoundedRectangle(cornerRadius: 3)
+                    .fill(Color.secondary.opacity(0.18))
+                    .frame(width: layout.cellSize * 3, height: 8)
+                    .frame(height: layout.cellSize, alignment: .leading)
+            }
+
+            VStack(alignment: .leading, spacing: layout.cellSpacing) {
+                ForEach(orderedWeekdays, id: \.self) { weekday in
+                    HStack(spacing: layout.cellSpacing) {
+                        ForEach(0..<weekCount, id: \.self) { weekIndex in
+                            RoundedRectangle(cornerRadius: layout.cellCornerRadius)
+                                .fill(Color.secondary.opacity(opacity(weekday: weekday, weekIndex: weekIndex)))
+                                .frame(width: layout.cellSize, height: layout.cellSize)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private func opacity(weekday: Int, weekIndex: Int) -> Double {
+        switch (weekday + weekIndex) % 4 {
+        case 0:
+            return 1 / 8
+        case 1:
+            return 1 / 5
+        case 2:
+            return 1 / 4
+        default:
+            return 3 / 20
+        }
+    }
 }

--- a/DevLogWidget/Heatmap/WidgetHeatmapGrid.swift
+++ b/DevLogWidget/Heatmap/WidgetHeatmapGrid.swift
@@ -55,17 +55,13 @@ struct WidgetHeatmapPlaceholderGrid: View {
                 showsMonthTitles: showsMonthTitles
             )
 
-            HStack(alignment: .top, spacing: layout.weekdayLabelSpacing) {
-                WidgetHeatmapWeekdayLabels(layout: layout)
-
-                HStack(alignment: .top, spacing: layout.monthSpacing) {
-                    ForEach(Array(weekCounts.enumerated()), id: \.offset) { _, weekCount in
-                        WidgetHeatmapPlaceholderMonthGrid(
-                            weekCount: weekCount,
-                            layout: layout,
-                            showsMonthTitle: showsMonthTitles
-                        )
-                    }
+            HStack(alignment: .top, spacing: layout.monthSpacing) {
+                ForEach(Array(weekCounts.enumerated()), id: \.offset) { _, weekCount in
+                    WidgetHeatmapPlaceholderMonthGrid(
+                        weekCount: weekCount,
+                        layout: layout,
+                        showsMonthTitle: showsMonthTitles
+                    )
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)

--- a/DevLogWidget/Heatmap/WidgetHeatmapGrid.swift
+++ b/DevLogWidget/Heatmap/WidgetHeatmapGrid.swift
@@ -1,0 +1,153 @@
+//
+//  WidgetHeatmapGrid.swift
+//  DevLogWidget
+//
+//  Created by opfic on 4/28/26.
+//
+
+import SwiftUI
+
+struct WidgetHeatmapGrid: View {
+    let months: [WidgetHeatmapMonthSnapshot]
+    let selectedActivityKindRawValues: [String]
+    let maxCount: Int
+    let showsMonthTitles: Bool
+    private let orderedWeekdays = Array(1...7)
+
+    var body: some View {
+        GeometryReader { proxy in
+            let layout = WidgetHeatmapLayout(
+                availableWidth: proxy.size.width,
+                availableHeight: proxy.size.height,
+                weekCounts: months.map(\.weeks.count),
+                showsMonthTitles: showsMonthTitles
+            )
+
+            HStack(alignment: .top, spacing: layout.weekdayLabelSpacing) {
+                weekdayLabel(layout)
+
+                HStack(alignment: .top, spacing: layout.monthSpacing) {
+                    ForEach(months, id: \.monthStart) { month in
+                        WidgetHeatmapMonthGrid(
+                            month: month,
+                            layout: layout,
+                            selectedActivityKindRawValues: selectedActivityKindRawValues,
+                            maxCount: maxCount,
+                            showsMonthTitle: showsMonthTitles
+                        )
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        }
+    }
+
+    @ViewBuilder
+    private func weekdayLabel(_ layout: WidgetHeatmapLayout) -> some View {
+        let weekdayLabels = [
+            2: "월",
+            4: "수",
+            6: "금"
+        ]
+
+        VStack(alignment: .leading, spacing: layout.cellSpacing) {
+            ForEach(orderedWeekdays, id: \.self) { weekday in
+                if let label = weekdayLabels[weekday] {
+                    Text(label)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .frame(
+                            width: layout.weekdayLabelWidth,
+                            height: layout.cellSize,
+                            alignment: .leading
+                        )
+                } else {
+                    Color.clear
+                        .frame(
+                            width: layout.weekdayLabelWidth,
+                            height: layout.cellSize
+                        )
+                }
+            }
+        }
+        .padding(.top, layout.weekdayTopPadding)
+    }
+}
+
+private struct WidgetHeatmapMonthGrid: View {
+    let month: WidgetHeatmapMonthSnapshot
+    let layout: WidgetHeatmapLayout
+    let selectedActivityKindRawValues: [String]
+    let maxCount: Int
+    let showsMonthTitle: Bool
+    private let orderedWeekdays = Array(1...7)
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: layout.monthTitleSpacing) {
+            if showsMonthTitle {
+                Text(month.monthStart.formatted(.dateTime.month(.abbreviated)))
+                    .frame(height: layout.cellSize)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            VStack(alignment: .leading, spacing: layout.cellSpacing) {
+                ForEach(orderedWeekdays, id: \.self) { weekday in
+                    HStack(spacing: layout.cellSpacing) {
+                        ForEach(month.weeks, id: \.id) { week in
+                            let day = week.days.first {
+                                Calendar.current.component(.weekday, from: $0.date) == weekday
+                            }
+
+                            RoundedRectangle(cornerRadius: layout.cellCornerRadius)
+                                .fill(fillColor(for: day))
+                                .frame(width: layout.cellSize, height: layout.cellSize)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private func fillColor(for day: WidgetHeatmapDaySnapshot?) -> Color {
+        guard let day, day.isVisible else { return .clear }
+
+        let count = dayCount(for: day)
+        if count == 0 {
+            return Color(.systemGray5)
+        }
+
+        return Color.blue.opacity(opacity(for: count, max: maxCount))
+    }
+
+    private func dayCount(for day: WidgetHeatmapDaySnapshot) -> Int {
+        let selectedActivityKindRawValues = Set(selectedActivityKindRawValues)
+        var value = 0
+
+        if selectedActivityKindRawValues.contains(WidgetHeatmapActivityKind.created.rawValue) {
+            value += day.createdCount
+        }
+
+        if selectedActivityKindRawValues.contains(WidgetHeatmapActivityKind.completed.rawValue) {
+            value += day.completedCount
+        }
+
+        if selectedActivityKindRawValues.contains(WidgetHeatmapActivityKind.deleted.rawValue) {
+            value += day.deletedCount
+        }
+
+        return value
+    }
+
+    private func opacity(for count: Int, max: Int) -> Double {
+        guard 0 < count && 0 < max else { return 0 }
+        let ratio = Double(count) / Double(max)
+        return ceil(ratio * 10) / 10
+    }
+}
+
+private enum WidgetHeatmapActivityKind: String {
+    case created
+    case completed
+    case deleted
+}

--- a/DevLogWidget/Heatmap/WidgetHeatmapLayout.swift
+++ b/DevLogWidget/Heatmap/WidgetHeatmapLayout.swift
@@ -1,0 +1,130 @@
+//
+//  WidgetHeatmapLayout.swift
+//  DevLogWidget
+//
+//  Created by opfic on 4/28/26.
+//
+
+import SwiftUI
+
+struct WidgetHeatmapLayout {
+    let cellSize: CGFloat
+    let cellSpacing: CGFloat
+    let monthSpacing: CGFloat
+    let monthTitleSpacing: CGFloat
+    let weekdayLabelSpacing: CGFloat = Self.baseWeekdayLabelSpacing
+    let weekdayLabelWidth: CGFloat = Self.baseWeekdayLabelWidth
+    let showsMonthTitles: Bool
+
+    init(
+        availableWidth: CGFloat,
+        availableHeight: CGFloat,
+        weekCounts: [Int],
+        showsMonthTitles: Bool
+    ) {
+        self.showsMonthTitles = showsMonthTitles
+        self.monthTitleSpacing = Self.resolvedMonthTitleSpacing(showsMonthTitles: showsMonthTitles)
+        cellSize = Self.cellSize(
+            availableHeight: availableHeight,
+            showsMonthTitles: showsMonthTitles
+        )
+        cellSpacing = Self.baseCellSpacing
+        monthSpacing = Self.monthSpacing(
+            availableWidth: availableWidth,
+            cellSize: cellSize,
+            weekCounts: weekCounts,
+            showsMonthTitles: showsMonthTitles
+        )
+    }
+
+    var weekdayTopPadding: CGFloat {
+        showsMonthTitles ? cellSize + monthTitleSpacing : 0
+    }
+
+    var cellCornerRadius: CGFloat {
+        max(2, cellSize * 0.2)
+    }
+
+    private static let baseCellSpacing: CGFloat = 3
+    private static let baseMonthSpacing: CGFloat = 10
+    private static let maxMonthSpacing: CGFloat = 26
+    private static let baseMonthTitleSpacing: CGFloat = 4
+    private static let baseWeekdayLabelSpacing: CGFloat = 5
+    private static let baseWeekdayLabelWidth: CGFloat = 14
+
+    private static func resolvedMonthTitleSpacing(showsMonthTitles: Bool) -> CGFloat {
+        // 월 제목을 표시하는 Medium에서만 제목과 셀 사이 간격을 확보한다.
+        showsMonthTitles ? baseMonthTitleSpacing : 0
+    }
+
+    private static func sanitizedWeekCounts(_ weekCounts: [Int]) -> [Int] {
+        // 빈 월이 있어도 0개 주차가 전체 컬럼 계산에 섞이지 않도록 제거한다.
+        weekCounts.filter { 0 < $0 }
+    }
+
+    private static func totalColumns(in weekCounts: [Int]) -> Int {
+        // 모든 월의 주차 수를 더해 실제 셀 컬럼 수를 구한다.
+        max(weekCounts.reduce(0, +), 1)
+    }
+
+    private static func totalColumnSpacings(in weekCounts: [Int]) -> Int {
+        // 각 월 내부에서 주차 컬럼 사이에 들어가는 spacing 개수를 합산한다.
+        weekCounts.reduce(0) { partialResult, count in
+            partialResult + max(count - 1, 0)
+        }
+    }
+
+    private static func monthSpacingCount(in weekCounts: [Int]) -> Int {
+        // 월과 월 사이 간격 개수는 표시되는 월 개수보다 하나 적다.
+        max(weekCounts.count - 1, 0)
+    }
+
+    private static func cellSize(
+        availableHeight: CGFloat,
+        showsMonthTitles: Bool
+    ) -> CGFloat {
+        // 히트맵은 세로 7일 행이 고정이므로 높이를 기준으로 셀 크기를 결정한다.
+        // Medium은 월 제목 1행을 같은 셀 높이로 추가해 총 8행 기준으로 계산한다.
+        let verticalCellCount = showsMonthTitles ? 8 : 7
+        // 날짜 셀 7행 사이의 세로 spacing 6개와 월 제목 spacing을 높이에서 제외한다.
+        let verticalFixedHeight = resolvedMonthTitleSpacing(showsMonthTitles: showsMonthTitles)
+            + baseCellSpacing * CGFloat(max(7 - 1, 0))
+        return max(0, availableHeight - verticalFixedHeight) / CGFloat(verticalCellCount)
+    }
+
+    private static func extraWidth(
+        availableWidth: CGFloat,
+        cellSize: CGFloat,
+        weekCounts: [Int]
+    ) -> CGFloat {
+        // 셀 크기는 높이 기준으로 고정하고, 남는 가로폭만 월 간격 계산에 사용한다.
+        let sanitizedWeekCounts = sanitizedWeekCounts(weekCounts)
+        // 요일 라벨 영역, 전체 셀 컬럼, 월 내부 주차 spacing을 더해 기본 너비를 구한다.
+        let contentWidth = baseWeekdayLabelWidth
+            + baseWeekdayLabelSpacing
+            + cellSize * CGFloat(totalColumns(in: sanitizedWeekCounts))
+            + baseCellSpacing * CGFloat(totalColumnSpacings(in: sanitizedWeekCounts))
+        // 기본 너비보다 위젯이 넓을 때만 월 간격에 분배할 여유 폭이 생긴다.
+        return max(0, availableWidth - contentWidth)
+    }
+
+    private static func monthSpacing(
+        availableWidth: CGFloat,
+        cellSize: CGFloat,
+        weekCounts: [Int],
+        showsMonthTitles: Bool
+    ) -> CGFloat {
+        // Medium의 3개월 사이 간격만 확장하고, 과한 벌어짐은 상한으로 제한한다.
+        let sanitizedWeekCounts = sanitizedWeekCounts(weekCounts)
+        let monthSpacingCount = monthSpacingCount(in: sanitizedWeekCounts)
+        // Small은 한 달만 표시하므로 월 간격이 필요 없다.
+        guard showsMonthTitles && 0 < monthSpacingCount else { return 0 }
+        let extraWidth = extraWidth(
+            availableWidth: availableWidth,
+            cellSize: cellSize,
+            weekCounts: sanitizedWeekCounts
+        )
+        // 남는 폭을 월 사이 간격에 균등 분배하되 기본값과 상한 사이로 제한한다.
+        return min(max(extraWidth / CGFloat(monthSpacingCount), baseMonthSpacing), maxMonthSpacing)
+    }
+}

--- a/DevLogWidget/Today/TodayTodoWidget.swift
+++ b/DevLogWidget/Today/TodayTodoWidget.swift
@@ -21,8 +21,8 @@ struct TodayTodoWidget: Widget {
             TodayTodoWidgetEntryView(entry: entry)
                 .containerBackground(.fill.tertiary, for: .widget)
         }
-        .configurationDisplayName("Today Todo")
         .description("오늘 기준 Todo 목록을 표시합니다.")
+        .configurationDisplayName("Today")
         .supportedFamilies([.systemSmall, .systemMedium, .systemLarge])
     }
 }

--- a/DevLogWidget/Today/TodayTodoWidget.swift
+++ b/DevLogWidget/Today/TodayTodoWidget.swift
@@ -23,6 +23,6 @@ struct TodayTodoWidget: Widget {
         }
         .description("오늘 기준 Todo 목록을 표시합니다.")
         .configurationDisplayName("Today")
-        .supportedFamilies([.systemSmall, .systemMedium, .systemLarge])
+        .supportedFamilies([.systemSmall, .systemMedium])
     }
 }

--- a/DevLogWidget/Today/TodayTodoWidgetConfigurationIntent.swift
+++ b/DevLogWidget/Today/TodayTodoWidgetConfigurationIntent.swift
@@ -9,6 +9,6 @@ import AppIntents
 import WidgetKit
 
 struct TodayTodoWidgetConfigurationIntent: WidgetConfigurationIntent {
-    static var title: LocalizedStringResource = "Today Todo"
+    static var title: LocalizedStringResource = "Today"
     static var description = IntentDescription("오늘 기준 Todo 목록을 표시합니다.")
 }

--- a/DevLogWidget/Today/TodayTodoWidgetEntryView.swift
+++ b/DevLogWidget/Today/TodayTodoWidgetEntryView.swift
@@ -13,7 +13,7 @@ struct TodayTodoWidgetEntryView: View {
     @Environment(\.widgetFamily) private var widgetFamily
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading) {
             Text("Today")
                 .font(.headline)
 
@@ -24,6 +24,8 @@ struct TodayTodoWidgetEntryView: View {
             } else {
                 emptyState
             }
+
+            Spacer()
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
@@ -40,12 +42,21 @@ struct TodayTodoWidgetEntryView: View {
                     .foregroundStyle(.secondary)
                     .lineLimit(2)
             }
-        case .systemMedium, .systemLarge:
-            WidgetPlaceholderCard(
-                title: "Today",
-                message: "저장된 할 일 \(snapshot.totalCount)개"
-            )
-            .frame(maxWidth: .infinity)
+        case .systemMedium:
+            let items = displayedItems(from: snapshot)
+            VStack(alignment: .leading, spacing: 6) {
+                if items.isEmpty {
+                    Text("오늘은 할 일이 없어요.\n잠시 휴식을 취해보세요!")
+                        .multilineTextAlignment(.center)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(items, id: \.id) { item in
+                        todoRow(item)
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
         default:
             EmptyView()
         }
@@ -54,16 +65,9 @@ struct TodayTodoWidgetEntryView: View {
     @ViewBuilder
     private var emptyState: some View {
         switch widgetFamily {
-        case .systemSmall:
-            Text("앱을 열어\nToday 위젯을 준비하세요")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-        case .systemMedium, .systemLarge:
-            WidgetPlaceholderCard(
-                title: "Today",
-                message: "데이터 연결 전"
-            )
-            .frame(maxWidth: .infinity)
+        case .systemSmall, .systemMedium:
+            WidgetPlaceholderCard(message: "앱을 열어\nToday 위젯을 준비하세요")
+                .frame(maxWidth: .infinity)
         default:
             EmptyView()
         }
@@ -73,6 +77,31 @@ struct TodayTodoWidgetEntryView: View {
         snapshot.sections
             .flatMap(\.items)
             .first?
-            .title ?? "할 일이 없습니다"
+            .title ?? "오늘은 할 일이 없어요.\n잠시 휴식을 취해보세요!"
+    }
+
+    private func displayedItems(from snapshot: TodayWidgetSnapshot) -> [WidgetTodoSnapshotItem] {
+        Array(snapshot
+            .sections
+            .flatMap(\.items)
+            .prefix(3))
+    }
+
+    private func todoRow(_ item: WidgetTodoSnapshotItem) -> some View {
+        HStack(spacing: 6) {
+            Text("#\(item.number)")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+
+            if item.isPinned {
+                Image(systemName: "star.fill")
+                    .font(.caption2)
+                    .foregroundStyle(.orange)
+            }
+
+            Text(item.title)
+                .font(.caption)
+                .lineLimit(1)
+        }
     }
 }

--- a/DevLogWidget/Today/TodayTodoWidgetEntryView.swift
+++ b/DevLogWidget/Today/TodayTodoWidgetEntryView.swift
@@ -72,16 +72,12 @@ struct TodayTodoWidgetEntryView: View {
         switch widgetFamily {
         case .systemSmall:
             GeometryReader { proxy in
-                VStack(alignment: .leading, spacing: 8) {
-                    Text("준비 중")
-                        .font(.caption)
-                        .foregroundStyle(.tertiary)
-
+                VStack(alignment: .leading, spacing: 4) {
+                    placeholderTodoCount()
                     placeholderTodoRow(width: placeholderTodoRowWidth(in: proxy.size.width, at: 0))
-                    placeholderTodoRow(width: placeholderTodoRowWidth(in: proxy.size.width, at: 1))
                 }
             }
-            .frame(height: 48)
+            .frame(height: 56)
             .frame(maxWidth: .infinity, alignment: .leading)
         case .systemMedium:
             GeometryReader { proxy in
@@ -125,6 +121,12 @@ struct TodayTodoWidgetEntryView: View {
                 .font(.caption)
                 .lineLimit(lineLimit)
         }
+    }
+
+    private func placeholderTodoCount() -> some View {
+        RoundedRectangle(cornerRadius: 4)
+            .fill(Color.secondary.opacity(0.18))
+            .frame(width: 22, height: 28)
     }
 
     private func placeholderTodoRow(width: CGFloat) -> some View {

--- a/DevLogWidget/Today/TodayTodoWidgetEntryView.swift
+++ b/DevLogWidget/Today/TodayTodoWidgetEntryView.swift
@@ -65,9 +65,33 @@ struct TodayTodoWidgetEntryView: View {
     @ViewBuilder
     private var emptyState: some View {
         switch widgetFamily {
-        case .systemSmall, .systemMedium:
-            WidgetPlaceholderCard(message: "앱을 열어\nToday 위젯을 준비하세요")
-                .frame(maxWidth: .infinity)
+        case .systemSmall:
+            GeometryReader { proxy in
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("준비 중")
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+
+                    placeholderTodoRow(width: placeholderTodoRowWidth(in: proxy.size.width, at: 0))
+                    placeholderTodoRow(width: placeholderTodoRowWidth(in: proxy.size.width, at: 1))
+                }
+            }
+            .frame(height: 48)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        case .systemMedium:
+            GeometryReader { proxy in
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("준비 중")
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+
+                    ForEach(0..<3, id: \.self) { index in
+                        placeholderTodoRow(width: placeholderTodoRowWidth(in: proxy.size.width, at: index))
+                    }
+                }
+            }
+            .frame(height: 56)
+            .frame(maxWidth: .infinity, alignment: .leading)
         default:
             EmptyView()
         }
@@ -102,6 +126,31 @@ struct TodayTodoWidgetEntryView: View {
             Text(item.title)
                 .font(.caption)
                 .lineLimit(1)
+        }
+    }
+
+    private func placeholderTodoRow(width: CGFloat) -> some View {
+        HStack(spacing: 6) {
+            RoundedRectangle(cornerRadius: 3)
+                .fill(Color.secondary.opacity(0.18))
+                .frame(width: 22, height: 8)
+
+            RoundedRectangle(cornerRadius: 3)
+                .fill(Color.secondary.opacity(0.18))
+                .frame(width: width, height: 8)
+        }
+    }
+
+    private func placeholderTodoRowWidth(in availableWidth: CGFloat, at index: Int) -> CGFloat {
+        let titleAreaWidth = max(availableWidth - 28, 0)
+
+        switch index {
+        case 0:
+            return titleAreaWidth * 2 / 3
+        case 1:
+            return titleAreaWidth / 2
+        default:
+            return titleAreaWidth * 3 / 5
         }
     }
 }

--- a/DevLogWidget/Today/TodayTodoWidgetEntryView.swift
+++ b/DevLogWidget/Today/TodayTodoWidgetEntryView.swift
@@ -82,10 +82,6 @@ struct TodayTodoWidgetEntryView: View {
         case .systemMedium:
             GeometryReader { proxy in
                 VStack(alignment: .leading, spacing: 6) {
-                    Text("준비 중")
-                        .font(.caption2)
-                        .foregroundStyle(.tertiary)
-
                     ForEach(0..<3, id: \.self) { index in
                         placeholderTodoRow(width: placeholderTodoRowWidth(in: proxy.size.width, at: index))
                     }

--- a/DevLogWidget/Today/TodayTodoWidgetEntryView.swift
+++ b/DevLogWidget/Today/TodayTodoWidgetEntryView.swift
@@ -37,10 +37,15 @@ struct TodayTodoWidgetEntryView: View {
             VStack(alignment: .leading, spacing: 4) {
                 Text("\(snapshot.totalCount)")
                     .font(.system(size: 28, weight: .bold))
-                Text(topItemTitle(from: snapshot))
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(2)
+
+                if let item = displayedItems(from: snapshot).first {
+                    todoRow(item)
+                } else {
+                    Text("오늘은 할 일이 없어요.\n잠시 휴식을 취해보세요!")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                }
             }
         case .systemMedium:
             let items = displayedItems(from: snapshot)
@@ -52,7 +57,7 @@ struct TodayTodoWidgetEntryView: View {
                         .foregroundStyle(.secondary)
                 } else {
                     ForEach(items, id: \.id) { item in
-                        todoRow(item)
+                        todoRow(item, lineLimit: 1)
                     }
                 }
             }
@@ -97,13 +102,6 @@ struct TodayTodoWidgetEntryView: View {
         }
     }
 
-    private func topItemTitle(from snapshot: TodayWidgetSnapshot) -> String {
-        snapshot.sections
-            .flatMap(\.items)
-            .first?
-            .title ?? "오늘은 할 일이 없어요.\n잠시 휴식을 취해보세요!"
-    }
-
     private func displayedItems(from snapshot: TodayWidgetSnapshot) -> [WidgetTodoSnapshotItem] {
         Array(snapshot
             .sections
@@ -111,7 +109,7 @@ struct TodayTodoWidgetEntryView: View {
             .prefix(3))
     }
 
-    private func todoRow(_ item: WidgetTodoSnapshotItem) -> some View {
+    private func todoRow(_ item: WidgetTodoSnapshotItem, lineLimit: Int? = nil) -> some View {
         HStack(spacing: 6) {
             Text("#\(item.number)")
                 .font(.caption2)
@@ -125,7 +123,7 @@ struct TodayTodoWidgetEntryView: View {
 
             Text(item.title)
                 .font(.caption)
-                .lineLimit(1)
+                .lineLimit(lineLimit)
         }
     }
 

--- a/DevLogWidget/Today/TodayTodoWidgetEntryView.swift
+++ b/DevLogWidget/Today/TodayTodoWidgetEntryView.swift
@@ -14,7 +14,7 @@ struct TodayTodoWidgetEntryView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text("Today Todo")
+            Text("Today")
                 .font(.headline)
 
             Spacer()
@@ -42,7 +42,7 @@ struct TodayTodoWidgetEntryView: View {
             }
         case .systemMedium, .systemLarge:
             WidgetPlaceholderCard(
-                title: "Today Todo",
+                title: "Today",
                 message: "저장된 할 일 \(snapshot.totalCount)개"
             )
             .frame(maxWidth: .infinity)
@@ -60,7 +60,7 @@ struct TodayTodoWidgetEntryView: View {
                 .foregroundStyle(.secondary)
         case .systemMedium, .systemLarge:
             WidgetPlaceholderCard(
-                title: "Today Todo",
+                title: "Today",
                 message: "데이터 연결 전"
             )
             .frame(maxWidth: .infinity)

--- a/DevLogWidget/Today/TodayTodoWidgetProvider.swift
+++ b/DevLogWidget/Today/TodayTodoWidgetProvider.swift
@@ -25,7 +25,7 @@ struct TodayTodoWidgetProvider: AppIntentTimelineProvider {
     ) async -> TodayTodoWidgetEntry {
         let snapshot = try? store.loadTodaySnapshot()
         return .init(
-            date: snapshot?.generatedAt ?? .now,
+            date: .now,
             snapshot: snapshot
         )
     }
@@ -39,7 +39,7 @@ struct TodayTodoWidgetProvider: AppIntentTimelineProvider {
         let snapshot = try? store.loadTodaySnapshot()
         let entries: [TodayTodoWidgetEntry] = [
             .init(
-                date: snapshot?.generatedAt ?? .now,
+                date: .now,
                 snapshot: snapshot
             )
         ]

--- a/DevLog_Unit/Widget/HeatmapWidgetSnapshotFactoryTests.swift
+++ b/DevLog_Unit/Widget/HeatmapWidgetSnapshotFactoryTests.swift
@@ -10,10 +10,12 @@ import Testing
 @testable import DevLog
 
 struct HeatmapWidgetSnapshotFactoryTests {
-    @Test("Heatmap 위젯 스냅샷은 이번 달 기준 주차와 일별 count를 만든다")
-    func heatmap_위젯_스냅샷은_이번_달_기준_주차와_일별_count를_만든다() throws {
+    @Test("Heatmap 위젯 스냅샷은 이번 분기 기준 월과 일별 count를 만든다")
+    func heatmap_위젯_스냅샷은_이번_분기_기준_월과_일별_count를_만든다() throws {
         let calendar = Calendar(identifier: .gregorian)
-        let monthStart = try #require(calendar.date(from: DateComponents(year: 2026, month: 4, day: 1)))
+        let quarterStart = try #require(calendar.date(from: DateComponents(year: 2026, month: 4, day: 1)))
+        let mayStart = try #require(calendar.date(from: DateComponents(year: 2026, month: 5, day: 1)))
+        let juneStart = try #require(calendar.date(from: DateComponents(year: 2026, month: 6, day: 1)))
         let aprilThirdDate = calendar.date(from: DateComponents(year: 2026, month: 4, day: 3))!
         let mayFirstDate = calendar.date(from: DateComponents(year: 2026, month: 5, day: 1))!
         let aprilFifteenthDate = calendar.date(from: DateComponents(year: 2026, month: 4, day: 15))!
@@ -33,32 +35,38 @@ struct HeatmapWidgetSnapshotFactoryTests {
             completedTodos: [
                 makeTodo(
                     id: "todo-completed-apr-03",
-                    createdAt: monthStart,
+                    createdAt: quarterStart,
                     completedAt: aprilThirdDate
                 ),
                 makeTodo(
                     id: "todo-completed-may-01",
-                    createdAt: monthStart,
+                    createdAt: quarterStart,
                     completedAt: mayFirstDate
                 )
             ],
             deletedTodos: [
                 makeTodo(
                     id: "todo-deleted-apr-15",
-                    createdAt: monthStart,
+                    createdAt: quarterStart,
                     deletedAt: aprilFifteenthDate
                 )
             ],
             selectedActivityKinds: [.created, .completed],
-            monthStart: monthStart,
-            now: monthStart
+            quarterStart: quarterStart,
+            now: quarterStart
         )
 
-        #expect(snapshot.monthStart == monthStart)
+        #expect(snapshot.quarterStart == quarterStart)
         #expect(snapshot.selectedActivityKindRawValues == ["created", "completed"])
         #expect(snapshot.maxCount == 2)
-        #expect(snapshot.weeks.count == 5)
-        #expect(snapshot.weeks.flatMap(\.days).filter(\.isVisible).count == 30)
+        #expect(snapshot.months.count == 3)
+        #expect(snapshot.months.map(\.monthStart) == [
+            quarterStart,
+            mayStart,
+            juneStart
+        ])
+        #expect(snapshot.months[0].weeks.count == 5)
+        #expect(snapshot.months.flatMap(\.weeks).flatMap(\.days).filter(\.isVisible).count == 91)
 
         let aprilThird = try #require(day(for: DateComponents(year: 2026, month: 4, day: 3), in: snapshot, calendar: calendar))
         #expect(aprilThird.createdCount == 1)
@@ -70,12 +78,15 @@ struct HeatmapWidgetSnapshotFactoryTests {
         #expect(aprilFifteenth.createdCount == 0)
         #expect(aprilFifteenth.completedCount == 0)
         #expect(aprilFifteenth.deletedCount == 1)
+
+        let mayFirst = try #require(day(for: DateComponents(year: 2026, month: 5, day: 1), in: snapshot, calendar: calendar))
+        #expect(mayFirst.completedCount == 1)
     }
 
     @Test("Heatmap 위젯 스냅샷 maxCount는 선택된 activity kind만 기준으로 계산한다")
     func heatmap_위젯_스냅샷_maxCount는_선택된_activity_kind만_기준으로_계산한다() throws {
         let calendar = Calendar(identifier: .gregorian)
-        let monthStart = try #require(calendar.date(from: DateComponents(year: 2026, month: 4, day: 1)))
+        let quarterStart = try #require(calendar.date(from: DateComponents(year: 2026, month: 4, day: 1)))
         let targetDate = try #require(calendar.date(from: DateComponents(year: 2026, month: 4, day: 10)))
         let factory = HeatmapWidgetSnapshotFactory(calendar: calendar)
 
@@ -88,23 +99,23 @@ struct HeatmapWidgetSnapshotFactoryTests {
             deletedTodos: [
                 makeTodo(
                     id: "deleted-1",
-                    createdAt: monthStart,
+                    createdAt: quarterStart,
                     deletedAt: targetDate
                 ),
                 makeTodo(
                     id: "deleted-2",
-                    createdAt: monthStart,
+                    createdAt: quarterStart,
                     deletedAt: targetDate
                 ),
                 makeTodo(
                     id: "deleted-3",
-                    createdAt: monthStart,
+                    createdAt: quarterStart,
                     deletedAt: targetDate
                 )
             ],
             selectedActivityKinds: [.deleted],
-            monthStart: monthStart,
-            now: monthStart
+            quarterStart: quarterStart,
+            now: quarterStart
         )
 
         #expect(snapshot.selectedActivityKindRawValues == ["deleted"])
@@ -123,7 +134,8 @@ struct HeatmapWidgetSnapshotFactoryTests {
         guard let date = calendar.date(from: components) else { return nil }
         let targetDate = calendar.startOfDay(for: date)
 
-        return snapshot.weeks
+        return snapshot.months
+            .flatMap(\.weeks)
             .flatMap(\.days)
             .first { day in
                 calendar.isDate(day.date, inSameDayAs: targetDate)

--- a/docs/DevLog.drawio
+++ b/docs/DevLog.drawio
@@ -1,0 +1,719 @@
+<mxfile host="app.diagrams.net" agent="Codex" pages="6">
+  <diagram id="store-protocol-page" name="Store Protocol">
+    <mxGraphModel dx="912" dy="491" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" background="none" math="0" shadow="0">
+      <root>
+        <mxCell id="0" />
+        <mxCell id="1" parent="0" />
+        <mxCell id="2" parent="1" style="rounded=1;arcSize=20;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#D8E0EA;strokeWidth=2;" value="" vertex="1">
+          <mxGeometry height="316" width="600" x="60" y="52" as="geometry" />
+        </mxCell>
+        <mxCell id="3" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=18;fontStyle=1;fontColor=#1F2328;" value="Store Protocol Flow" vertex="1">
+          <mxGeometry height="28" width="300" x="210" y="72" as="geometry" />
+        </mxCell>
+        <mxCell id="4" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#EAF2FF;strokeColor=#0A84FF;strokeWidth=2;fontColor=#0B1F33;fontStyle=1;fontSize=20;" value="Action" vertex="1">
+          <mxGeometry height="56" width="120" x="300" y="118" as="geometry" />
+        </mxCell>
+        <mxCell id="5" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#A7B4C6;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=18;" value="View" vertex="1">
+          <mxGeometry height="52" width="110" x="105" y="208" as="geometry" />
+        </mxCell>
+        <mxCell id="6" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#A7B4C6;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=18;" value="State" vertex="1">
+          <mxGeometry height="52" width="120" x="285" y="292" as="geometry" />
+        </mxCell>
+        <mxCell id="7" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#A7B4C6;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=18;" value="SideEffect" vertex="1">
+          <mxGeometry height="52" width="130" x="500" y="208" as="geometry" />
+        </mxCell>
+        <mxCell id="8" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=13;fontColor=#6B7280;" value="render" vertex="1">
+          <mxGeometry height="22" width="80" x="190" y="288" as="geometry" />
+        </mxCell>
+        <mxCell id="9" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=13;fontColor=#6B7280;" value="user event" vertex="1">
+          <mxGeometry height="22" width="110" x="140" y="118" as="geometry" />
+        </mxCell>
+        <mxCell id="10" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=13;fontColor=#6B7280;" value="update state" vertex="1">
+          <mxGeometry height="22" width="110" x="270" y="220" as="geometry" />
+        </mxCell>
+        <mxCell id="11" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=13;fontColor=#6B7280;" value="emit effect" vertex="1">
+          <mxGeometry height="22" width="110" x="400" y="186" as="geometry" />
+        </mxCell>
+        <mxCell id="12" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=13;fontColor=#6B7280;" value="next action" vertex="1">
+          <mxGeometry height="22" width="110" x="490" y="118" as="geometry" />
+        </mxCell>
+        <mxCell id="13" edge="1" parent="1" source="6" style="curved=1;endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0A84FF;strokeWidth=3;" target="5">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="185" y="320" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="14" edge="1" parent="1" source="5" style="curved=1;endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#5E6AD2;strokeWidth=3;" target="4">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="168" y="128" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="15" edge="1" parent="1" source="4" style="curved=1;endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0A84FF;strokeWidth=3;exitX=0.25;exitY=1;exitDx=0;exitDy=0;" target="6">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="380" y="230" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="16" edge="1" parent="1" source="4" style="curved=1;endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#5E6AD2;strokeWidth=3;" target="7">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="410" y="200" />
+              <mxPoint x="460" y="230" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="17" edge="1" parent="1" source="7" style="curved=1;endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0A84FF;strokeWidth=3;" target="4">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="580" y="130" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+  <diagram id="delete-flow-page" name="Delete Undo Flow">
+    <mxGraphModel dx="1285" dy="692" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="900" pageHeight="1200" background="none" math="0" shadow="0">
+      <root>
+        <mxCell id="0" />
+        <mxCell id="1" parent="0" />
+        <mxCell id="100" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=18;fontStyle=1;fontColor=#1F2328;" value="개선 전" vertex="1">
+          <mxGeometry height="28" width="120" x="360" y="24" as="geometry" />
+        </mxCell>
+        <mxCell id="101" parent="1" style="rounded=1;arcSize=20;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#D8E0EA;strokeWidth=2;" value="" vertex="1">
+          <mxGeometry height="300" width="760" x="40" y="60" as="geometry" />
+        </mxCell>
+        <mxCell id="102" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#F8FAFC;strokeColor=#B8C4D6;strokeWidth=2;" value="" vertex="1">
+          <mxGeometry height="206" width="346" x="68" y="112" as="geometry" />
+        </mxCell>
+        <mxCell id="103" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#F8FAFC;strokeColor=#B8C4D6;strokeWidth=2;" value="" vertex="1">
+          <mxGeometry height="170" width="190" x="560" y="126" as="geometry" />
+        </mxCell>
+        <mxCell id="104" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=14;fontStyle=1;fontColor=#6B7280;" value="Client" vertex="1">
+          <mxGeometry height="22" width="80" x="201" y="90" as="geometry" />
+        </mxCell>
+        <mxCell id="105" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=14;fontStyle=1;fontColor=#6B7280;" value="Server" vertex="1">
+          <mxGeometry height="22" width="80" x="615" y="126" as="geometry" />
+        </mxCell>
+        <mxCell id="106" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;fontSize=13;fontStyle=1;fontColor=#C2410C;" value="삭제 책임: Client" vertex="1">
+          <mxGeometry height="22" width="120" x="96" y="120" as="geometry" />
+        </mxCell>
+        <mxCell id="107" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#A7B4C6;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=18;" value="사용자" vertex="1">
+          <mxGeometry height="42" width="96" x="102" y="152" as="geometry" />
+        </mxCell>
+        <mxCell id="108" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#EAF2FF;strokeColor=#0A84FF;strokeWidth=2;fontColor=#0B1F33;fontStyle=1;fontSize=18;" value="ViewModel" vertex="1">
+          <mxGeometry height="44" width="112" x="286" y="150" as="geometry" />
+        </mxCell>
+        <mxCell id="109" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#A7B4C6;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=18;" value="Toast" vertex="1">
+          <mxGeometry height="42" width="84" x="300" y="262" as="geometry" />
+        </mxCell>
+        <mxCell id="110" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#A7B4C6;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=18;" value="로컬 리스트" vertex="1">
+          <mxGeometry height="42" width="108" x="110" y="260" as="geometry" />
+        </mxCell>
+        <mxCell id="111" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#A7B4C6;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=18;" value="Cloud Functions" vertex="1">
+          <mxGeometry height="44" width="126" x="592" y="150" as="geometry" />
+        </mxCell>
+        <mxCell id="112" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#A7B4C6;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=18;" value="Firestore" vertex="1">
+          <mxGeometry height="42" width="108" x="601" y="240" as="geometry" />
+        </mxCell>
+        <mxCell id="113" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=10;fontColor=#6B7280;" value="삭제 요청" vertex="1">
+          <mxGeometry height="22" width="82" x="187" y="152" as="geometry" />
+        </mxCell>
+        <mxCell id="114" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=8;fontColor=#6B7280;" value="Undo 토스트 표시" vertex="1">
+          <mxGeometry height="22" width="104" x="258" y="220" as="geometry" />
+        </mxCell>
+        <mxCell id="115" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=10;fontColor=#6B7280;" value="Undo 대상 로컬 보관" vertex="1">
+          <mxGeometry height="22" width="84" x="174" y="205" as="geometry" />
+        </mxCell>
+        <mxCell id="116" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=10;fontColor=#6B7280;" value="Undo 선택" vertex="1">
+          <mxGeometry height="22" width="82" x="345" y="226" as="geometry" />
+        </mxCell>
+        <mxCell id="117" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=10;fontColor=#6B7280;" value="복원 / 제거 결정" vertex="1">
+          <mxGeometry height="22" width="118" x="204" y="260" as="geometry" />
+        </mxCell>
+        <mxCell id="118" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=10;fontColor=#6B7280;" value="삭제 요청" vertex="1">
+          <mxGeometry height="22" width="100" x="437" y="150" as="geometry" />
+        </mxCell>
+        <mxCell id="119" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=10;fontColor=#6B7280;" value="데이터 수정" vertex="1">
+          <mxGeometry height="22" width="66" x="649" y="194" as="geometry" />
+        </mxCell>
+        <mxCell id="120" edge="1" parent="1" source="107" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#5E6AD2;strokeWidth=3;" target="108">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="121" edge="1" parent="1" source="108" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0A84FF;strokeWidth=3;" target="109">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="122" edge="1" parent="1" source="108" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0A84FF;strokeWidth=3;exitX=0.06;exitY=0.988;exitDx=0;exitDy=0;exitPerimeter=0;entryX=1;entryY=0;entryDx=0;entryDy=0;" target="110">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="123" edge="1" parent="1" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#5E6AD2;strokeWidth=3;">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="361" y="262" as="sourcePoint" />
+            <mxPoint x="361" y="194" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="124" edge="1" parent="1" source="110" style="curved=1;endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#5E6AD2;strokeWidth=3;exitX=0.998;exitY=0.46;exitDx=0;exitDy=0;exitPerimeter=0;" target="108">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="125" edge="1" parent="1" source="108" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0A84FF;strokeWidth=3;" target="111">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="126" edge="1" parent="1" source="111" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0A84FF;strokeWidth=3;" target="112">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="127" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=18;fontStyle=1;fontColor=#1F2328;" value="개선 후" vertex="1">
+          <mxGeometry height="28" width="110" x="365" y="404" as="geometry" />
+        </mxCell>
+        <mxCell id="128" parent="1" style="rounded=1;arcSize=20;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#D8E0EA;strokeWidth=2;" value="" vertex="1">
+          <mxGeometry height="300" width="760" x="40" y="440" as="geometry" />
+        </mxCell>
+        <mxCell id="129" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#F8FAFC;strokeColor=#B8C4D6;strokeWidth=2;" value="" vertex="1">
+          <mxGeometry height="176" width="346" x="68" y="520" as="geometry" />
+        </mxCell>
+        <mxCell id="130" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#F8FAFC;strokeColor=#B8C4D6;strokeWidth=2;" value="" vertex="1">
+          <mxGeometry height="196" width="214" x="546" y="500" as="geometry" />
+        </mxCell>
+        <mxCell id="131" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=14;fontStyle=1;fontColor=#6B7280;" value="Client" vertex="1">
+          <mxGeometry height="22" width="80" x="201" y="497" as="geometry" />
+        </mxCell>
+        <mxCell id="132" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=14;fontStyle=1;fontColor=#6B7280;" value="Server" vertex="1">
+          <mxGeometry height="22" width="80" x="613" y="476" as="geometry" />
+        </mxCell>
+        <mxCell id="133" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=13;fontStyle=1;fontColor=#15803D;" value="삭제 책임: Server" vertex="1">
+          <mxGeometry height="22" width="120" x="560" y="516" as="geometry" />
+        </mxCell>
+        <mxCell id="134" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#A7B4C6;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=18;" value="사용자" vertex="1">
+          <mxGeometry height="42" width="96" x="102" y="547" as="geometry" />
+        </mxCell>
+        <mxCell id="135" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#EAF2FF;strokeColor=#0A84FF;strokeWidth=2;fontColor=#0B1F33;fontStyle=1;fontSize=18;" value="ViewModel" vertex="1">
+          <mxGeometry height="44" width="112" x="286" y="545" as="geometry" />
+        </mxCell>
+        <mxCell id="136" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#A7B4C6;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=18;" value="Toast" vertex="1">
+          <mxGeometry height="42" width="84" x="199" y="638" as="geometry" />
+        </mxCell>
+        <mxCell id="137" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#A7B4C6;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=18;" value="Cloud Functions" vertex="1">
+          <mxGeometry height="44" width="126" x="598" y="545" as="geometry" />
+        </mxCell>
+        <mxCell id="138" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#A7B4C6;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=18;" value="Firestore" vertex="1">
+          <mxGeometry height="42" width="108" x="609" y="638" as="geometry" />
+        </mxCell>
+        <mxCell id="139" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=10;fontColor=#6B7280;" value="삭제 요청" vertex="1">
+          <mxGeometry height="22" width="82" x="188" y="548" as="geometry" />
+        </mxCell>
+        <mxCell id="140" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=10;fontColor=#6B7280;" value="Undo 토스트 표시" vertex="1">
+          <mxGeometry height="22" width="104" x="207" y="595" as="geometry" />
+        </mxCell>
+        <mxCell id="141" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=10;fontColor=#6B7280;" value="Undo 요청" vertex="1">
+          <mxGeometry height="22" width="82" x="286" y="619" as="geometry" />
+        </mxCell>
+        <mxCell id="142" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=10;fontColor=#6B7280;" value="삭제 / Undo 요청" vertex="1">
+          <mxGeometry height="22" width="100" x="430" y="546" as="geometry" />
+        </mxCell>
+        <mxCell id="144" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=10;fontColor=#6B7280;" value="데이터 수정" vertex="1">
+          <mxGeometry height="22" width="148" x="615" y="591" as="geometry" />
+        </mxCell>
+        <mxCell id="145" edge="1" parent="1" source="134" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#5E6AD2;strokeWidth=3;" target="135">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="146" edge="1" parent="1" source="135" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0A84FF;strokeWidth=3;entryX=0.866;entryY=0.013;entryDx=0;entryDy=0;entryPerimeter=0;" target="136">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="147" edge="1" parent="1" source="136" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#5E6AD2;strokeWidth=3;entryX=0.5;entryY=1;entryDx=0;entryDy=0;exitX=1;exitY=0.25;exitDx=0;exitDy=0;" target="135">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="290.95294117647063" y="658" as="sourcePoint" />
+            <mxPoint x="340.8588235294119" y="616" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="148" edge="1" parent="1" source="135" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0A84FF;strokeWidth=3;" target="137">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="150" edge="1" parent="1" source="137" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0A84FF;strokeWidth=3;" target="138">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+  <diagram id="todo-reminder-flow-page" name="Todo Reminder Flow">
+    <mxGraphModel dx="1768" dy="951" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1200" pageHeight="1200" background="none" math="0" shadow="0">
+      <root>
+        <mxCell id="0" />
+        <mxCell id="1" parent="0" />
+        <mxCell id="200" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=18;fontStyle=1;fontColor=#1F2328;" value="개선 전" vertex="1">
+          <mxGeometry height="28" width="120" x="180" y="24" as="geometry" />
+        </mxCell>
+        <mxCell id="201" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=18;fontStyle=1;fontColor=#1F2328;" value="개선 후" vertex="1">
+          <mxGeometry height="28" width="120" x="656" y="24" as="geometry" />
+        </mxCell>
+        <mxCell id="202" parent="1" style="rounded=1;arcSize=20;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#D8E0EA;strokeWidth=2;" value="" vertex="1">
+          <mxGeometry height="390" width="444" x="36" y="60" as="geometry" />
+        </mxCell>
+        <mxCell id="203" parent="1" style="rounded=1;arcSize=20;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#D8E0EA;strokeWidth=2;" value="" vertex="1">
+          <mxGeometry height="740" width="410" x="500" y="60" as="geometry" />
+        </mxCell>
+        <mxCell id="204" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#F8FAFC;strokeColor=#B8C4D6;strokeWidth=2;" value="" vertex="1">
+          <mxGeometry height="330" width="196" x="56" y="96" as="geometry" />
+        </mxCell>
+        <mxCell id="205" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#F8FAFC;strokeColor=#B8C4D6;strokeWidth=2;" value="" vertex="1">
+          <mxGeometry height="180" width="148" x="312" y="116" as="geometry" />
+        </mxCell>
+        <mxCell id="206" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=14;fontStyle=1;fontColor=#6B7280;" value="Client" vertex="1">
+          <mxGeometry height="22" width="80" x="114" y="72" as="geometry" />
+        </mxCell>
+        <mxCell id="207" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=14;fontStyle=1;fontColor=#6B7280;" value="Server" vertex="1">
+          <mxGeometry height="22" width="80" x="346" y="94" as="geometry" />
+        </mxCell>
+        <mxCell id="208" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;fontSize=13;fontStyle=1;fontColor=#C2410C;" value="예약 책임: Client" vertex="1">
+          <mxGeometry height="22" width="110" x="70" y="106" as="geometry" />
+        </mxCell>
+        <mxCell id="209" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#0A84FF;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=15;" value="Todo 생성 / 수정" vertex="1">
+          <mxGeometry height="52" width="140" x="84" y="132" as="geometry" />
+        </mxCell>
+        <mxCell id="210" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#A7B4C6;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=15;" value="사용자 설정&#xa;(시각 / Timezone)" vertex="1">
+          <mxGeometry height="64" width="140" x="84" y="240" as="geometry" />
+        </mxCell>
+        <mxCell id="211" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#EAF2FF;strokeColor=#0A84FF;strokeWidth=2;fontColor=#0B1F33;fontStyle=1;fontSize=15;" value="이벤트 기반 예약" vertex="1">
+          <mxGeometry height="52" width="140" x="84" y="364" as="geometry" />
+        </mxCell>
+        <mxCell id="212" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#A7B4C6;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=14;" value="Cloud Tasks" vertex="1">
+          <mxGeometry height="40" width="100" x="336" y="128" as="geometry" />
+        </mxCell>
+        <mxCell id="213" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#A7B4C6;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=12;" value="알림 발송 처리" vertex="1">
+          <mxGeometry height="40" width="100" x="336" y="238" as="geometry" />
+        </mxCell>
+        <mxCell id="214" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#A7B4C6;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=12;" value="설정 변경 후&#xa;예상 시간과 달라질 수 있음&#xa;최신 Todo 상태 미반영 가능" vertex="1">
+          <mxGeometry height="67" width="164" x="304" y="329" as="geometry" />
+        </mxCell>
+        <mxCell id="218" edge="1" parent="1" source="209" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0A84FF;strokeWidth=3;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" target="210">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="219" edge="1" parent="1" source="210" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#5E6AD2;strokeWidth=3;" target="211">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="220" edge="1" parent="1" source="211" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0A84FF;strokeWidth=3;edgeStyle=orthogonalEdgeStyle;" target="212">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="280" y="406" />
+              <mxPoint x="280" y="146" />
+              <mxPoint x="330" y="146" />
+              <mxPoint x="330" y="148" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="221" edge="1" parent="1" source="212" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0A84FF;strokeWidth=3;entryX=0.5;entryY=0;entryDx=0;entryDy=0;exitX=0.5;exitY=1;exitDx=0;exitDy=0;" target="213">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="385.7624590163934" y="182.16" as="sourcePoint" />
+            <mxPoint x="386.114" y="234.99600000000004" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="222" edge="1" parent="1" source="213" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#5E6AD2;strokeWidth=3;entryX=0.5;entryY=0;entryDx=0;entryDy=0;exitX=0.5;exitY=1;exitDx=0;exitDy=0;" target="214">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="344" y="346" as="sourcePoint" />
+            <mxPoint x="343" y="466" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="223" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#F8FAFC;strokeColor=#B8C4D6;strokeWidth=2;" value="" vertex="1">
+          <mxGeometry height="80" width="170" x="520" y="112" as="geometry" />
+        </mxCell>
+        <mxCell id="225" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=14;fontStyle=1;fontColor=#6B7280;" value="Client" vertex="1">
+          <mxGeometry height="22" width="80" x="565" y="90" as="geometry" />
+        </mxCell>
+        <mxCell id="235" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=11;fontColor=#6B7280;" value="설정 기준" vertex="1">
+          <mxGeometry height="20" width="70" x="600" y="272" as="geometry" />
+        </mxCell>
+        <mxCell id="238" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=11;fontColor=#6B7280;" value="발송 시점 재검증" vertex="1">
+          <mxGeometry height="20" width="136" x="690" y="522" as="geometry" />
+        </mxCell>
+        <mxCell id="216" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=11;fontColor=#6B7280;" value="enqueue" vertex="1">
+          <mxGeometry height="20" width="54" x="251" y="403" as="geometry" />
+        </mxCell>
+        <mxCell id="217" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=11;fontColor=#6B7280;" value="예약 당시 데이터 사용" vertex="1">
+          <mxGeometry height="20" width="120" x="299" y="183" as="geometry" />
+        </mxCell>
+        <mxCell id="215" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=11;fontColor=#6B7280;" value="변경 시 예약" vertex="1">
+          <mxGeometry height="20" width="70" x="150" y="316" as="geometry" />
+        </mxCell>
+        <mxCell id="228" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#0A84FF;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=15;" value="사용자 설정&#xa;(시각 / Timezone)" vertex="1">
+          <mxGeometry height="60" width="150" x="530" y="122" as="geometry" />
+        </mxCell>
+        <mxCell id="224" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#F8FAFC;strokeColor=#B8C4D6;strokeWidth=2;" value="" vertex="1">
+          <mxGeometry height="550" width="192" x="705" y="95" as="geometry" />
+        </mxCell>
+        <mxCell id="226" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=14;fontStyle=1;fontColor=#6B7280;" value="Server" vertex="1">
+          <mxGeometry height="22" width="80" x="759" y="71" as="geometry" />
+        </mxCell>
+        <mxCell id="239" edge="1" parent="1" source="228" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#5E6AD2;strokeWidth=3;exitX=0.5;exitY=1;exitDx=0;exitDy=0;edgeStyle=orthogonalEdgeStyle;" target="230">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="605" y="270" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="227" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;fontSize=13;fontStyle=1;fontColor=#15803D;" value="예약 책임: Server" vertex="1">
+          <mxGeometry height="22" width="110" x="727" y="105" as="geometry" />
+        </mxCell>
+        <mxCell id="229" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#0A84FF;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=15;" value="5분 주기&#xa;Scheduler" vertex="1">
+          <mxGeometry height="64" width="110" x="746" y="133" as="geometry" />
+        </mxCell>
+        <mxCell id="230" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#EAF2FF;strokeColor=#0A84FF;strokeWidth=2;fontColor=#0B1F33;fontStyle=1;fontSize=13;" value="리마인더 배치 실행" vertex="1">
+          <mxGeometry height="60" width="110" x="746" y="243" as="geometry" />
+        </mxCell>
+        <mxCell id="231" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#A7B4C6;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=14;" value="내일 마감 Todo&#xa;재계산" vertex="1">
+          <mxGeometry height="60" width="110" x="746" y="353" as="geometry" />
+        </mxCell>
+        <mxCell id="232" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#A7B4C6;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=14;" value="Cloud Tasks" vertex="1">
+          <mxGeometry height="60" width="110" x="746" y="463" as="geometry" />
+        </mxCell>
+        <mxCell id="233" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#A7B4C6;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=12;" value="알림 발송 처리" vertex="1">
+          <mxGeometry height="60" width="110" x="746" y="573" as="geometry" />
+        </mxCell>
+        <mxCell id="234" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#A7B4C6;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=12;" value="설정 변경 이후에도&#xa;최신 기준으로 스케줄링&#xa;최신 Todo 상태 반영" vertex="1">
+          <mxGeometry height="96" width="119" x="741.5" y="683" as="geometry" />
+        </mxCell>
+        <mxCell id="237" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=11;fontColor=#6B7280;" value="enqueue" vertex="1">
+          <mxGeometry height="20" width="60" x="744" y="417" as="geometry" />
+        </mxCell>
+        <mxCell id="240" edge="1" parent="1" source="229" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#5E6AD2;strokeWidth=3;" target="230">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="241" edge="1" parent="1" source="230" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0A84FF;strokeWidth=3;entryX=0.473;entryY=0.012;entryDx=0;entryDy=0;entryPerimeter=0;" target="231">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="242" edge="1" parent="1" source="231" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0A84FF;strokeWidth=3;exitX=0.475;exitY=0.986;exitDx=0;exitDy=0;exitPerimeter=0;" target="232">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="243" edge="1" parent="1" source="232" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0A84FF;strokeWidth=3;" target="233">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="244" edge="1" parent="1" source="233" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#5E6AD2;strokeWidth=3;entryX=0.5;entryY=0;entryDx=0;entryDy=0;exitX=0.5;exitY=1;exitDx=0;exitDy=0;" target="234">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="QxAspJlolYb2ybC7-Ub2-246" edge="1" parent="1" source="203" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;" target="203">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+  <diagram id="webpage-image-restore-page" name="WebPage Image Restore Flow">
+    <mxGraphModel dx="1885" dy="1015" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="900" pageHeight="1400" background="none" math="0" shadow="0">
+      <root>
+        <mxCell id="0" />
+        <mxCell id="1" parent="0" />
+        <mxCell id="300" parent="1" style="rounded=1;arcSize=20;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#D8E0EA;strokeWidth=2;" value="" vertex="1">
+          <mxGeometry height="1024" width="450" x="200" y="36" as="geometry" />
+        </mxCell>
+        <mxCell id="301" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=18;fontStyle=1;fontColor=#1F2328;" value="WebPage Image Restore Flow" vertex="1">
+          <mxGeometry height="28" width="300" x="263" y="50" as="geometry" />
+        </mxCell>
+        <mxCell id="302" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#EAF2FF;strokeColor=#0A84FF;strokeWidth=2;fontColor=#0B1F33;fontStyle=1;fontSize=15;" value="웹페이지 데이터 fetch" vertex="1">
+          <mxGeometry height="50" width="230" x="220" y="100" as="geometry" />
+        </mxCell>
+        <mxCell id="303" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#A7B4C6;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=15;" value="Firestore 웹페이지 데이터 조회" vertex="1">
+          <mxGeometry height="50" width="230" x="220" y="200" as="geometry" />
+        </mxCell>
+        <mxCell id="304" parent="1" style="rhombus;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#0A84FF;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=15;" value="&lt;div&gt;&lt;br&gt;&lt;/div&gt;이미지 복구 필요?&lt;div&gt;&lt;span style=&quot;color: rgb(107, 114, 128); font-size: 11px; font-weight: 400; white-space: nowrap;&quot;&gt;imageURL이 실제 로컬 리소스를&lt;/span&gt;&lt;br style=&quot;color: rgb(107, 114, 128); font-size: 11px; font-weight: 400; white-space: nowrap;&quot;&gt;&lt;span style=&quot;color: rgb(107, 114, 128); font-size: 11px; font-weight: 400; white-space: nowrap;&quot;&gt;가리키는지 확인&lt;/span&gt;&lt;/div&gt;" vertex="1">
+          <mxGeometry height="110" width="230" x="220" y="300" as="geometry" />
+        </mxCell>
+        <mxCell id="306" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#A7B4C6;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=15;" value="메타데이터 재수집" vertex="1">
+          <mxGeometry height="50" width="230" x="220" y="460" as="geometry" />
+        </mxCell>
+        <mxCell id="307" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#A7B4C6;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=15;" value="로컬 이미지 캐시 생성" vertex="1">
+          <mxGeometry height="50" width="230" x="220" y="560" as="geometry" />
+        </mxCell>
+        <mxCell id="308" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#A7B4C6;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=15;" value="Application Support /&#xa;webPageImages 저장" vertex="1">
+          <mxGeometry height="50" width="230" x="220" y="660" as="geometry" />
+        </mxCell>
+        <mxCell id="309" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#A7B4C6;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=15;" value="복구된 imageURL로&#xa;Firestore 데이터 갱신" vertex="1">
+          <mxGeometry height="50" width="230" x="220" y="760" as="geometry" />
+        </mxCell>
+        <mxCell id="310" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#A7B4C6;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=15;" value="기존 데이터 반환" vertex="1">
+          <mxGeometry height="52" width="108" x="520" y="329" as="geometry" />
+        </mxCell>
+        <mxCell id="311" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#A7B4C6;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=14;" value="실패 시 썸네일&amp;nbsp;&lt;div&gt;없이 반환&lt;/div&gt;" vertex="1">
+          <mxGeometry height="72" width="108" x="492" y="449" as="geometry" />
+        </mxCell>
+        <mxCell id="312" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#A7B4C6;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=15;" value="복구된 데이터 반환" vertex="1">
+          <mxGeometry height="50" width="230" x="220" y="860" as="geometry" />
+        </mxCell>
+        <mxCell id="313" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#A7B4C6;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=15;" value="UI에 전달" vertex="1">
+          <mxGeometry height="50" width="230" x="220" y="960" as="geometry" />
+        </mxCell>
+        <mxCell id="314" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=12;fontColor=#6B7280;" value="No" vertex="1">
+          <mxGeometry height="20" width="28" x="460" y="361" as="geometry" />
+        </mxCell>
+        <mxCell id="315" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=12;fontColor=#6B7280;" value="Yes" vertex="1">
+          <mxGeometry height="20" width="40" x="330" y="411" as="geometry" />
+        </mxCell>
+        <mxCell id="317" edge="1" parent="1" source="303" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0A84FF;strokeWidth=3;" target="304">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="318" edge="1" parent="1" source="304" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0A84FF;strokeWidth=3;" target="306">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="319" edge="1" parent="1" source="304" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#5E6AD2;strokeWidth=3;" target="310">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="320" edge="1" parent="1" source="306" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0A84FF;strokeWidth=3;" target="307">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="321" edge="1" parent="1" source="307" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0A84FF;strokeWidth=3;" target="308">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="322" edge="1" parent="1" source="308" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0A84FF;strokeWidth=3;" target="309">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="323" edge="1" parent="1" source="309" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0A84FF;strokeWidth=3;" target="312">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="325" edge="1" parent="1" source="306" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#5E6AD2;strokeWidth=3;exitX=1;exitY=0.5;exitDx=0;exitDy=0;" target="311">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="326" edge="1" parent="1" source="311" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#5E6AD2;strokeWidth=3;edgeStyle=orthogonalEdgeStyle;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" target="313">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="550" y="985" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="327" edge="1" parent="1" source="312" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0A84FF;strokeWidth=3;" target="313">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="t-uegaWhmTgudXhdjnCE-327" edge="1" parent="1" source="300" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;" target="300">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="DXkntij-9fGk1yJ9dKEM-329" edge="1" parent="1" source="302" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0A84FF;strokeWidth=3;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" target="303">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="335" y="160" as="sourcePoint" />
+            <mxPoint x="334.77" y="200" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="yQ3WxlWRvIrxJqyOYGCa-328" edge="1" parent="1" source="310" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#5E6AD2;strokeWidth=3;edgeStyle=orthogonalEdgeStyle;entryX=1;entryY=0.5;entryDx=0;entryDy=0;exitX=0.836;exitY=0.994;exitDx=0;exitDy=0;exitPerimeter=0;" target="313">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="610" y="620" />
+              <mxPoint x="550" y="620" />
+              <mxPoint x="550" y="985" />
+            </Array>
+            <mxPoint x="610" y="396" as="sourcePoint" />
+            <mxPoint x="510" y="860" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+  <diagram id="butterfly-architecture-page" name="Clean Architecture">
+    <mxGraphModel dx="1414" dy="761" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" background="none" math="0" shadow="0">
+      <root>
+        <mxCell id="400" />
+        <mxCell id="401" parent="400" />
+        <mxCell id="402" parent="401" style="rounded=1;arcSize=20;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#D8E0EA;strokeWidth=2;align=center;" value="" vertex="1">
+          <mxGeometry height="544" width="1020" x="30" y="46" as="geometry" />
+        </mxCell>
+        <mxCell id="403" parent="401" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=18;fontStyle=1;fontColor=#1F2328;" value="Clean Architecture" vertex="1">
+          <mxGeometry height="28" width="420" x="330" y="58" as="geometry" />
+        </mxCell>
+        <mxCell id="404" parent="401" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=13;fontColor=#6B7280;" value="조회 기준으로 저장소에서 데이터를 읽어와 레이어를 거쳐 화면 데이터로 전달" vertex="1">
+          <mxGeometry height="20" width="570" x="255" y="86" as="geometry" />
+        </mxCell>
+        <mxCell id="405" parent="401" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=14;fontStyle=1;fontColor=#6B7280;" value="View Data" vertex="1">
+          <mxGeometry height="20" width="90" x="80" y="118" as="geometry" />
+        </mxCell>
+        <mxCell id="406" parent="401" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=16;fontStyle=1;fontColor=#6B7280;" value="Shared Flow" vertex="1">
+          <mxGeometry height="20" width="125" x="467.5" y="138" as="geometry" />
+        </mxCell>
+        <mxCell id="409" parent="401" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=14;fontStyle=1;fontColor=#6B7280;" value="Infra Layer" vertex="1">
+          <mxGeometry height="20" width="120" x="840" y="118" as="geometry" />
+        </mxCell>
+        <mxCell id="441" parent="401" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=14;fontStyle=1;fontColor=#6B7280;" value="Storage Layer" vertex="1">
+          <mxGeometry height="20" width="120" x="840" y="385" as="geometry" />
+        </mxCell>
+        <mxCell id="410" parent="401" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#F7F9FC;strokeColor=#A7B4C6;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=16;align=center;" value="Todo" vertex="1">
+          <mxGeometry height="56" width="130" x="60" y="138" as="geometry" />
+        </mxCell>
+        <mxCell id="411" parent="401" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#F7F9FC;strokeColor=#A7B4C6;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=16;align=center;" value="WebPage" vertex="1">
+          <mxGeometry height="56" width="130" x="60" y="208" as="geometry" />
+        </mxCell>
+        <mxCell id="412" parent="401" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#F7F9FC;strokeColor=#A7B4C6;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=16;align=center;" value="Push Notification" vertex="1">
+          <mxGeometry height="56" width="130" x="60" y="278" as="geometry" />
+        </mxCell>
+        <mxCell id="413" parent="401" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#F7F9FC;strokeColor=#A7B4C6;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=16;align=center;" value="User Info" vertex="1">
+          <mxGeometry height="56" width="130" x="60" y="348" as="geometry" />
+        </mxCell>
+        <mxCell id="414" parent="401" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#F7F9FC;strokeColor=#A7B4C6;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=16;align=center;" value="User Settings" vertex="1">
+          <mxGeometry height="56" width="130" x="60" y="418" as="geometry" />
+        </mxCell>
+        <mxCell id="443" parent="401" style="rounded=1;arcSize=20;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#D8E0EA;strokeWidth=2;" value="" vertex="1">
+          <mxGeometry height="320" width="280" x="390" y="158" as="geometry" />
+        </mxCell>
+        <mxCell id="438" parent="401" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#EAF2FF;strokeColor=#0A84FF;strokeWidth=2;fontColor=#0B1F33;fontStyle=1;fontSize=16;align=center;" value="Presentation Layer&lt;br&gt;상태 변환 / 화면 전달" vertex="1">
+          <mxGeometry height="56" width="170" x="445" y="403" as="geometry" />
+        </mxCell>
+        <mxCell id="439" parent="401" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#EAF2FF;strokeColor=#0A84FF;strokeWidth=2;fontColor=#0B1F33;fontStyle=1;fontSize=16;align=center;" value="Domain Layer&lt;br&gt;비즈니스 규칙" vertex="1">
+          <mxGeometry height="56" width="170" x="445" y="294" as="geometry" />
+        </mxCell>
+        <mxCell id="440" parent="401" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#EAF2FF;strokeColor=#0A84FF;strokeWidth=2;fontColor=#0B1F33;fontStyle=1;fontSize=16;align=center;" value="Data Layer&lt;br&gt;데이터 접근 / 변환" vertex="1">
+          <mxGeometry height="56" width="170" x="445" y="184" as="geometry" />
+        </mxCell>
+        <mxCell id="416" parent="401" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#A7B4C6;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=16;align=center;" value="Firestore" vertex="1">
+          <mxGeometry height="56" width="120" x="840" y="138" as="geometry" />
+        </mxCell>
+        <mxCell id="417" parent="401" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#A7B4C6;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=16;align=center;" value="Cloud&lt;div&gt;Function&lt;/div&gt;" vertex="1">
+          <mxGeometry height="56" width="120" x="840" y="217" as="geometry" />
+        </mxCell>
+        <mxCell id="418" parent="401" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#A7B4C6;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=16;align=center;" value="Metadata Source" vertex="1">
+          <mxGeometry height="56" width="120" x="840" y="296" as="geometry" />
+        </mxCell>
+        <mxCell id="419" parent="401" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#A7B4C6;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=16;align=center;" value="Image Cache" vertex="1">
+          <mxGeometry height="56" width="120" x="840" y="408" as="geometry" />
+        </mxCell>
+        <mxCell id="420" parent="401" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#A7B4C6;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=16;align=center;" value="Local Preferences" vertex="1">
+          <mxGeometry height="56" width="120" x="840" y="486" as="geometry" />
+        </mxCell>
+        <mxCell id="421" parent="401" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=13;fontColor=#6B7280;" value="Todo / WebPage / Push Notification / User Data" vertex="1">
+          <mxGeometry height="18" width="180" x="810" y="194" as="geometry" />
+        </mxCell>
+        <mxCell id="422" parent="401" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=13;fontColor=#6B7280;" value="Todo delete / undo, push 처리" vertex="1">
+          <mxGeometry height="18" width="180" x="810" y="273" as="geometry" />
+        </mxCell>
+        <mxCell id="423" parent="401" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=13;fontColor=#6B7280;" value="WebPage image collect / restore" vertex="1">
+          <mxGeometry height="18" width="180" x="810" y="353" as="geometry" />
+        </mxCell>
+        <mxCell id="424" parent="401" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=13;fontColor=#6B7280;" value="WebPage image file" vertex="1">
+          <mxGeometry height="18" width="120" x="840" y="464" as="geometry" />
+        </mxCell>
+        <mxCell id="425" parent="401" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=13;fontColor=#6B7280;" value="Theme / search / filter / display option" vertex="1">
+          <mxGeometry height="18" width="130" x="835" y="545" as="geometry" />
+        </mxCell>
+        <mxCell id="426" parent="401" style="rounded=1;arcSize=16;whiteSpace=wrap;html=1;fillColor=#F7F9FC;strokeColor=#D8E0EA;strokeWidth=2;fontColor=#4B5563;fontSize=14;align=center;" value="저장과 갱신도 같은 레이어를 사용" vertex="1">
+          <mxGeometry height="38" width="320" x="370" y="524" as="geometry" />
+        </mxCell>
+        <mxCell id="427" edge="1" parent="401" source="440" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0A84FF;strokeWidth=3;align=center;" target="439">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="428" edge="1" parent="401" source="439" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0A84FF;strokeWidth=3;align=center;" target="438">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="429" edge="1" parent="401" source="438" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#5E6AD2;strokeWidth=3;align=center;edgeStyle=orthogonalEdgeStyle;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" target="410">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="430" edge="1" parent="401" source="438" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#5E6AD2;strokeWidth=3;align=center;edgeStyle=orthogonalEdgeStyle;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" target="411">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="431" edge="1" parent="401" source="438" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#5E6AD2;strokeWidth=3;align=center;edgeStyle=orthogonalEdgeStyle;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" target="412">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="432" edge="1" parent="401" source="438" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#5E6AD2;strokeWidth=3;align=center;edgeStyle=orthogonalEdgeStyle;" target="413">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="433" edge="1" parent="401" source="438" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#5E6AD2;strokeWidth=3;align=center;edgeStyle=orthogonalEdgeStyle;" target="414">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="434" edge="1" parent="401" source="416" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0A84FF;strokeWidth=3;align=center;edgeStyle=orthogonalEdgeStyle;" target="440">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="435" edge="1" parent="401" source="417" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0A84FF;strokeWidth=3;align=center;edgeStyle=orthogonalEdgeStyle;" target="440">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="436" edge="1" parent="401" source="418" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0A84FF;strokeWidth=3;align=center;edgeStyle=orthogonalEdgeStyle;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" target="440">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="437" edge="1" parent="401" source="419" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0A84FF;strokeWidth=3;align=center;edgeStyle=orthogonalEdgeStyle;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" target="440">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="442" edge="1" parent="401" source="420" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0A84FF;strokeWidth=3;align=center;edgeStyle=orthogonalEdgeStyle;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" target="440">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+  <diagram id="todo-representative-flow-page" name="Todo Representative Flow">
+    <mxGraphModel dx="764" dy="411" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" background="none" math="0" shadow="0">
+      <root>
+        <mxCell id="500" />
+        <mxCell id="501" parent="500" />
+        <mxCell id="502" parent="501" style="rounded=1;arcSize=20;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#D8E0EA;strokeWidth=2;" value="" vertex="1">
+          <mxGeometry height="268" width="1075" x="45" y="52" as="geometry" />
+        </mxCell>
+        <mxCell id="503" parent="501" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=18;fontStyle=1;fontColor=#1F2328;" value="ex: Todo Representative Flow" vertex="1">
+          <mxGeometry height="28" width="340" x="412.5" y="52" as="geometry" />
+        </mxCell>
+        <mxCell id="505" parent="501" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=14;fontStyle=1;fontColor=#6B7280;" value="Presentation" vertex="1">
+          <mxGeometry height="20" width="140" x="90" y="112" as="geometry" />
+        </mxCell>
+        <mxCell id="506" parent="501" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=14;fontStyle=1;fontColor=#6B7280;" value="Domain" vertex="1">
+          <mxGeometry height="20" width="140" x="395" y="112" as="geometry" />
+        </mxCell>
+        <mxCell id="507" parent="501" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=14;fontStyle=1;fontColor=#6B7280;" value="Data" vertex="1">
+          <mxGeometry height="20" width="140" x="690" y="116" as="geometry" />
+        </mxCell>
+        <mxCell id="508" parent="501" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=14;fontStyle=1;fontColor=#6B7280;" value="Infra" vertex="1">
+          <mxGeometry height="20" width="140" x="945" y="112" as="geometry" />
+        </mxCell>
+        <mxCell id="509" link="https://github.com/opficdev/SwiftUI_DevLog/blob/main/DevLog/Presentation/ViewModel/TodoDetailViewModel.swift" parent="501" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#EAF2FF;strokeColor=#0A84FF;strokeWidth=2;fontColor=#0B1F33;fontStyle=1;fontSize=16;align=center;" value="TodoDetailViewModel" vertex="1">
+          <mxGeometry height="62" width="170" x="75" y="138" as="geometry" />
+        </mxCell>
+        <mxCell id="510" parent="501" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=12;fontColor=#6B7280;" value="화면 상태 생성" vertex="1">
+          <mxGeometry height="18" width="130" x="95" y="282" as="geometry" />
+        </mxCell>
+        <mxCell id="511" link="https://github.com/opficdev/SwiftUI_DevLog/blob/main/DevLog/Domain/UseCase/Todo/Fetch/FetchTodoByIDUseCaseImpl.swift" parent="501" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#A7B4C6;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=16;align=center;" value="&lt;font&gt;FetchTodoByIDUseCase&lt;/font&gt;" vertex="1">
+          <mxGeometry height="62" width="240" x="340" y="138" as="geometry" />
+        </mxCell>
+        <mxCell id="512" parent="501" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=12;fontColor=#6B7280;" value="도메인 규칙 적용" vertex="1">
+          <mxGeometry height="18" width="130" x="395" y="282" as="geometry" />
+        </mxCell>
+        <mxCell id="513" link="https://github.com/opficdev/SwiftUI_DevLog/blob/main/DevLog/Data/Repository/TodoRepositoryImpl.swift" parent="501" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#EAF2FF;strokeColor=#0A84FF;strokeWidth=2;fontColor=#0B1F33;fontStyle=1;fontSize=16;align=center;" value="TodoRepository" vertex="1">
+          <mxGeometry height="62" width="170" x="675" y="138" as="geometry" />
+        </mxCell>
+        <mxCell id="514" parent="501" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=12;fontColor=#6B7280;" value="데이터 해석 / 변환" vertex="1">
+          <mxGeometry height="18" width="140" x="687" y="282" as="geometry" />
+        </mxCell>
+        <mxCell id="515" link="https://github.com/opficdev/SwiftUI_DevLog/blob/main/DevLog/Infra/Service/TodoService.swift" parent="501" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#A7B4C6;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=16;align=center;" value="TodoService" vertex="1">
+          <mxGeometry height="62" width="150" x="940" y="138" as="geometry" />
+        </mxCell>
+        <mxCell id="516" parent="501" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=12;fontColor=#6B7280;" value="Firestore 접근" vertex="1">
+          <mxGeometry height="18" width="120" x="940" y="282" as="geometry" />
+        </mxCell>
+        <mxCell id="519" edge="1" parent="501" source="509" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0A84FF;strokeWidth=3;" target="511">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="520" edge="1" parent="501" source="511" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0A84FF;strokeWidth=3;" target="513">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="521" edge="1" parent="501" source="513" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0A84FF;strokeWidth=3;" target="515">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="522" edge="1" parent="501" source="515" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#5E6AD2;strokeWidth=3;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=1;entryDx=0;entryDy=0;" target="513">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="1015" y="280" />
+              <mxPoint x="760" y="280" />
+            </Array>
+            <mxPoint x="1025" y="154" as="sourcePoint" />
+            <mxPoint x="770" y="158" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="523" edge="1" parent="501" source="513" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#5E6AD2;strokeWidth=3;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=1;entryDx=0;entryDy=0;" target="511">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="760" y="280" />
+              <mxPoint x="460" y="280" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="524" edge="1" parent="501" source="511" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#5E6AD2;strokeWidth=3;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=1;entryDx=0;entryDy=0;" target="509">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="460" y="280" />
+              <mxPoint x="160" y="280" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #396
- closed #397

## 📝 작업 내용

### 📌 요약
- Today 위젯의 표시 정보 및 빈 상태 UI 개선
- Heatmap 위젯의 월 단위 표시를 분기 단위 표시로 확장
- 위젯 Large 크기 지원 제거 및 Small / Medium 구성으로 정리

### 🔍 상세
- Today 위젯에서 `Todo` 명칭 제거 및 Medium 크기에서 실제 할 일 항목 표시
- 데이터 연결 전 상태를 안내 문구 중심에서 스켈레톤 UI 중심으로 변경
- Heatmap 위젯 스냅샷 기준을 이번 달에서 이번 분기로 변경
- Heatmap Medium 위젯에서 3개월 분기 히트맵 표시
- Heatmap Small 위젯에서 현재 월 히트맵 표시
- 히트맵 셀 크기와 월 간격을 위젯 높이 및 사용 가능한 너비 기준으로 계산하도록 분리
- 위젯 데이터 스냅샷 생성 및 분기 기준 계산 테스트 수정
- 앱 데이터 흐름을 정리한 문서 추가

## 📸 영상 / 이미지 (Optional)

<table>
  <tr>
    <td>
      <img alt="image" src="https://github.com/user-attachments/assets/88410405-b959-4efc-9069-c807338b0029" />
    </td>
    <td>
      <img alt="image" src="https://github.com/user-attachments/assets/772257fd-f1ba-44e8-84d9-2effdc672563" />
    </td>
    <td>
      <img alt="image" src="https://github.com/user-attachments/assets/460f19e3-0a78-46ca-827f-e35685874061" />
    </td>
    <td>
      <img alt="image" src="https://github.com/user-attachments/assets/54f267e4-4798-4574-8b85-be61a7384a76" />
    </td>
  </tr>
  <tr>
    <td align="center" colspan="2">플레이스홀더</td>
    <td align="center" colspan="2">실제 데이터</td>
  </tr>
</table>
