### PR TITLE
[#399] 위젯 탭 내비게이션을 연결한다

### DIFF
--- a/DevLog/App/RootView.swift
+++ b/DevLog/App/RootView.swift
@@ -11,15 +11,19 @@ struct RootView: View {
     @Environment(\.diContainer) var container: DIContainer
     @State var viewModel: RootViewModel
     @State private var selectedRoute: AppRoute?
+    @State private var selectedMainTab = MainTab.home
 
     var body: some View {
         ZStack {
             Color(UIColor.systemGroupedBackground).ignoresSafeArea()
             if let signIn = viewModel.state.signIn {
                 if signIn {
-                    MainView(viewModel: MainViewModel(
-                        unreadPushCountUseCase: container.resolve(ObserveUnreadPushCountUseCase.self)
-                    ))
+                    MainView(
+                        viewModel: MainViewModel(
+                            unreadPushCountUseCase: container.resolve(ObserveUnreadPushCountUseCase.self)
+                        ),
+                        selectedTab: $selectedMainTab
+                    )
                 } else {
                     LoginView(viewModel: LoginViewModel(
                         signInUseCase: container.resolve(SignInUseCase.self))
@@ -29,6 +33,19 @@ struct RootView: View {
         }
         .preferredColorScheme(viewModel.state.theme.colorScheme)
         .onAppear { viewModel.send(.onAppear) }
+        .onChange(of: viewModel.state.signIn) { _, value in
+            guard value == false else { return }
+            selectedMainTab = .home
+        }
+        .onOpenURL { url in
+            guard let mainTab = MainTab(widgetURL: url) else { return }
+            switch viewModel.state.signIn {
+            case .some(false):
+                selectedMainTab = .home
+            case .some(true), .none:
+                selectedMainTab = mainTab
+            }
+        }
         .alert(viewModel.state.alertTitle, isPresented: Binding(
             get: { viewModel.state.showAlert },
             set: { viewModel.send(.setAlert($0)) }

--- a/DevLog/App/Routing/MainTab.swift
+++ b/DevLog/App/Routing/MainTab.swift
@@ -1,0 +1,28 @@
+//
+//  MainTab.swift
+//  DevLog
+//
+//  Created by opfic on 4/30/26.
+//
+
+import Foundation
+
+enum MainTab: Hashable {
+    case home
+    case today
+    case notification
+    case profile
+
+    init?(widgetURL: URL) {
+        guard widgetURL.scheme?.lowercased() == WidgetDeepLink.scheme.lowercased() else { return nil }
+
+        switch widgetURL.host {
+        case WidgetDeepLink.todayTodoHost:
+            self = .today
+        case WidgetDeepLink.heatmapHost:
+            self = .profile
+        default:
+            return nil
+        }
+    }
+}

--- a/DevLog/UI/Common/MainView.swift
+++ b/DevLog/UI/Common/MainView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct MainView: View {
     @Environment(\.diContainer) var container: DIContainer
     @State var viewModel: MainViewModel
-    @State private var selectedTab = MainTab.home
+    @Binding var selectedTab: MainTab
 
     var body: some View {
         TabView(selection: $selectedTab) {
@@ -72,10 +72,6 @@ struct MainView: View {
         }
         .onAppear {
             viewModel.send(.onAppear)
-        }
-        .onOpenURL { url in
-            guard let mainTab = MainTab(widgetURL: url) else { return }
-            selectedTab = mainTab
         }
         .alert(
             viewModel.state.alertTitle,

--- a/DevLog/UI/Common/MainView.swift
+++ b/DevLog/UI/Common/MainView.swift
@@ -10,9 +10,10 @@ import SwiftUI
 struct MainView: View {
     @Environment(\.diContainer) var container: DIContainer
     @State var viewModel: MainViewModel
+    @State private var selectedTab = MainTab.home
 
     var body: some View {
-        TabView {
+        TabView(selection: $selectedTab) {
             HomeView(viewModel: HomeViewModel(
                 fetchPreferencesUseCase: container.resolve(FetchTodoCategoryPreferencesUseCase.self),
                 updatePreferencesUseCase: container.resolve(UpdateTodoCategoryPreferencesUseCase.self),
@@ -28,6 +29,7 @@ struct MainView: View {
                 Image(systemName: "house.fill")
                 Text(String(localized: "nav_home"))
             }
+            .tag(MainTab.home)
             TodayView(viewModel: TodayViewModel(
                 fetchTodosUseCase: container.resolve(FetchTodosUseCase.self),
                 fetchTodoByIdUseCase: container.resolve(FetchTodoByIdUseCase.self),
@@ -39,6 +41,7 @@ struct MainView: View {
                 Image(systemName: "sun.max.fill")
                 Text(String(localized: "nav_today"))
             }
+            .tag(MainTab.today)
             PushNotificationListView(viewModel: PushNotificationListViewModel(
                 fetchUseCase: container.resolve(FetchPushNotificationsUseCase.self),
                 deleteUseCase: container.resolve(DeletePushNotificationUseCase.self),
@@ -52,6 +55,7 @@ struct MainView: View {
                 Text(String(localized: "nav_notifications"))
             }
             .badge(viewModel.state.unreadPushCount)
+            .tag(MainTab.notification)
             ProfileView(viewModel: ProfileViewModel(
                 fetchUserDataUseCase: container.resolve(FetchUserDataUseCase.self),
                 fetchTodosUseCase: container.resolve(FetchTodosUseCase.self),
@@ -64,9 +68,14 @@ struct MainView: View {
                 Image(systemName: "person.crop.circle.fill")
                 Text(String(localized: "nav_profile"))
             }
+            .tag(MainTab.profile)
         }
         .onAppear {
             viewModel.send(.onAppear)
+        }
+        .onOpenURL { url in
+            guard let mainTab = MainTab(widgetURL: url) else { return }
+            selectedTab = mainTab
         }
         .alert(
             viewModel.state.alertTitle,

--- a/DevLogWidget/Heatmap/HeatmapWidget.swift
+++ b/DevLogWidget/Heatmap/HeatmapWidget.swift
@@ -20,6 +20,7 @@ struct HeatmapWidget: Widget {
         ) { entry in
             HeatmapWidgetEntryView(entry: entry)
                 .containerBackground(.fill.tertiary, for: .widget)
+                .widgetURL(WidgetDeepLink.heatmapURL)
         }
         .configurationDisplayName("Heatmap")
         .description("활동 히트맵을 표시합니다.")

--- a/DevLogWidget/Today/TodayTodoWidget.swift
+++ b/DevLogWidget/Today/TodayTodoWidget.swift
@@ -20,6 +20,7 @@ struct TodayTodoWidget: Widget {
         ) { entry in
             TodayTodoWidgetEntryView(entry: entry)
                 .containerBackground(.fill.tertiary, for: .widget)
+                .widgetURL(WidgetDeepLink.todayTodoURL)
         }
         .description("오늘 기준 Todo 목록을 표시합니다.")
         .configurationDisplayName("Today")

--- a/WidgetShared/WidgetDeepLink.swift
+++ b/WidgetShared/WidgetDeepLink.swift
@@ -1,0 +1,26 @@
+//
+//  WidgetDeepLink.swift
+//  DevLog
+//
+//  Created by opfic on 4/30/26.
+//
+
+import Foundation
+
+enum WidgetDeepLink {
+    static let scheme = "DevLog"
+    static let todayTodoHost = "today"
+    static let heatmapHost = "profile"
+
+    static var todayTodoURL: URL {
+        url(host: todayTodoHost)
+    }
+
+    static var heatmapURL: URL {
+        url(host: heatmapHost)
+    }
+
+    private static func url(host: String) -> URL {
+        URL(string: "\(scheme)://\(host)")!
+    }
+}

--- a/WidgetShared/WidgetDeepLink.swift
+++ b/WidgetShared/WidgetDeepLink.swift
@@ -12,15 +12,18 @@ enum WidgetDeepLink {
     static let todayTodoHost = "today"
     static let heatmapHost = "profile"
 
-    static var todayTodoURL: URL {
+    static var todayTodoURL: URL? {
         url(host: todayTodoHost)
     }
 
-    static var heatmapURL: URL {
+    static var heatmapURL: URL? {
         url(host: heatmapHost)
     }
 
-    private static func url(host: String) -> URL {
-        URL(string: "\(scheme)://\(host)")!
+    private static func url(host: String) -> URL? {
+        var urlComponents = URLComponents()
+        urlComponents.scheme = scheme
+        urlComponents.host = host
+        return urlComponents.url
     }
 }


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #399

## 📝 작업 내용

### 📌 요약
- Today 위젯 탭 시 TodayView로 이동하도록 딥링크 연결
- Heatmap 위젯 탭 시 ProfileView로 이동하도록 딥링크 연결

### 🔍 상세
- 위젯별 진입 URL을 정의하는 `WidgetDeepLink` 추가
- 위젯 URL을 앱 탭으로 변환하는 `MainTab` 추가
- `MainView`의 `TabView`에 선택 상태와 탭 태그 적용
- 로그인된 메인 화면에서만 위젯 URL 이벤트를 처리하도록 구성
- Today/Heatmap 위젯에 각각 `widgetURL` 지정

## 📸 영상 / 이미지 (Optional)

<table>
<tr>
<td>
<video src="https://github.com/user-attachments/assets/a276548e-1bc8-4616-b861-bdf47eb2adf3">
</td>
<td>
<video src="https://github.com/user-attachments/assets/1623f8ac-9f63-461c-b275-d95a8a682c7b">
</td>
</tr>
<tr>
<td align="center">
투데이
</td>
<td align="center">
히트맵
</td>
</tr>
</table>

