### PR TITLE
[#406] 위젯에 로컬라이제이션을 구현한다

### DIFF
--- a/DevLog.xcodeproj/project.pbxproj
+++ b/DevLog.xcodeproj/project.pbxproj
@@ -275,7 +275,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 2640;
-				LastUpgradeCheck = 2600;
+				LastUpgradeCheck = 2640;
 				TargetAttributes = {
 					DF3416442E45F67C00F9312B = {
 						CreatedOnToolsVersion = 16.3;
@@ -295,6 +295,7 @@
 			knownRegions = (
 				ko,
 				en,
+				Base,
 			);
 			mainGroup = DFD48AF72DC4D6E2005905C5;
 			minimizedProjectReferenceProxies = 1;
@@ -603,6 +604,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
@@ -671,6 +673,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";

--- a/DevLog.xcodeproj/xcshareddata/xcschemes/DevLog.xcscheme
+++ b/DevLog.xcodeproj/xcshareddata/xcschemes/DevLog.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "2600"
+   LastUpgradeVersion = "2640"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/DevLog.xcodeproj/xcshareddata/xcschemes/DevLogWidgetExtension.xcscheme
+++ b/DevLog.xcodeproj/xcshareddata/xcschemes/DevLogWidgetExtension.xcscheme
@@ -58,8 +58,18 @@
       allowLocationSimulation = "YES"
       launchAutomaticallySubstyle = "2"
       queueDebuggingEnableBacktraceRecording = "Yes">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <RemoteRunnable
+         runnableDebuggingMode = "2"
+         BundleIdentifier = "com.apple.springboard">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DFD3A96F2F8E89DD001DA7CD"
+            BuildableName = "DevLogWidgetExtension.appex"
+            BlueprintName = "DevLogWidgetExtension"
+            ReferencedContainer = "container:DevLog.xcodeproj">
+         </BuildableReference>
+      </RemoteRunnable>
+      <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "DFD48AFF2DC4D6E2005905C5"
@@ -67,7 +77,7 @@
             BlueprintName = "DevLog"
             ReferencedContainer = "container:DevLog.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </MacroExpansion>
       <EnvironmentVariables>
          <EnvironmentVariable
             key = "_XCWidgetKind"

--- a/DevLog.xcodeproj/xcshareddata/xcschemes/DevLog_Unit.xcscheme
+++ b/DevLog.xcodeproj/xcshareddata/xcschemes/DevLog_Unit.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "2600"
+   LastUpgradeVersion = "2640"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/DevLogWidget/Heatmap/HeatmapWidget.swift
+++ b/DevLogWidget/Heatmap/HeatmapWidget.swift
@@ -23,7 +23,7 @@ struct HeatmapWidget: Widget {
                 .widgetURL(WidgetDeepLink.heatmapURL)
         }
         .configurationDisplayName("Heatmap")
-        .description("활동 히트맵을 표시합니다.")
+        .description("widget_heatmap_description")
         .supportedFamilies([.systemSmall, .systemMedium])
     }
 }

--- a/DevLogWidget/Heatmap/HeatmapWidgetConfigurationIntent.swift
+++ b/DevLogWidget/Heatmap/HeatmapWidgetConfigurationIntent.swift
@@ -10,5 +10,5 @@ import WidgetKit
 
 struct HeatmapWidgetConfigurationIntent: WidgetConfigurationIntent {
     static var title: LocalizedStringResource = "Heatmap"
-    static var description = IntentDescription("활동 히트맵을 표시합니다.")
+    static var description = IntentDescription("widget_heatmap_description")
 }

--- a/DevLogWidget/Heatmap/HeatmapWidgetEntryView.swift
+++ b/DevLogWidget/Heatmap/HeatmapWidgetEntryView.swift
@@ -28,7 +28,7 @@ struct HeatmapWidgetEntryView: View {
         switch widgetFamily {
         case .systemSmall:
             VStack(alignment: .leading, spacing: 4) {
-                header(title: "이번 달 히트맵")
+                header(title: "widget_heatmap_current_month_title")
                 WidgetHeatmapGrid(
                     months: currentMonths(from: snapshot),
                     selectedActivityKindRawValues: snapshot.selectedActivityKindRawValues,
@@ -38,7 +38,7 @@ struct HeatmapWidgetEntryView: View {
             }
         case .systemMedium:
             VStack(alignment: .leading, spacing: 8) {
-                header(title: "이번 분기 히트맵")
+                header(title: "widget_heatmap_current_quarter_title")
                 WidgetHeatmapGrid(
                     months: snapshot.months,
                     selectedActivityKindRawValues: snapshot.selectedActivityKindRawValues,
@@ -58,7 +58,7 @@ struct HeatmapWidgetEntryView: View {
         switch widgetFamily {
         case .systemSmall:
             VStack(alignment: .leading, spacing: 8) {
-                header(title: "이번 달 히트맵")
+                header(title: "widget_heatmap_current_month_title")
                 WidgetHeatmapPlaceholderGrid(
                     months: shape.currentMonths,
                     showsMonthTitles: false
@@ -66,7 +66,7 @@ struct HeatmapWidgetEntryView: View {
             }
         case .systemMedium:
             VStack(alignment: .leading, spacing: 8) {
-                header(title: "이번 분기 히트맵")
+                header(title: "widget_heatmap_current_quarter_title")
                 WidgetHeatmapPlaceholderGrid(
                     months: shape.quarterMonths,
                     showsMonthTitles: true
@@ -77,7 +77,7 @@ struct HeatmapWidgetEntryView: View {
         }
     }
 
-    private func header(title: String) -> some View {
+    private func header(title: LocalizedStringKey) -> some View {
         HStack(alignment: .firstTextBaseline, spacing: 6) {
             Text(title)
                 .font(.headline)

--- a/DevLogWidget/Heatmap/WidgetHeatmapGrid.swift
+++ b/DevLogWidget/Heatmap/WidgetHeatmapGrid.swift
@@ -74,10 +74,10 @@ struct WidgetHeatmapPlaceholderGrid: View {
 private struct WidgetHeatmapWeekdayLabels: View {
     let layout: WidgetHeatmapLayout
     private let orderedWeekdays = Array(1...7)
-    private let weekdayLabels = [
-        2: "월",
-        4: "수",
-        6: "금"
+    private let weekdayLocalizedStringKeys: [Int: LocalizedStringKey] = [
+        2: "widget_heatmap_weekday_monday",
+        4: "widget_heatmap_weekday_wednesday",
+        6: "widget_heatmap_weekday_friday"
     ]
 
     var body: some View {
@@ -91,8 +91,8 @@ private struct WidgetHeatmapWeekdayLabels: View {
 
     @ViewBuilder
     private func weekdayLabel(for weekday: Int) -> some View {
-        if let label = weekdayLabels[weekday] {
-            Text(label)
+        if let localizedStringKey = weekdayLocalizedStringKeys[weekday] {
+            Text(localizedStringKey)
                 .font(.caption2)
                 .foregroundStyle(.secondary)
                 .frame(

--- a/DevLogWidget/Heatmap/WidgetHeatmapGrid.swift
+++ b/DevLogWidget/Heatmap/WidgetHeatmapGrid.swift
@@ -22,19 +22,15 @@ struct WidgetHeatmapGrid: View {
                 showsMonthTitles: showsMonthTitles
             )
 
-            HStack(alignment: .top, spacing: layout.weekdayLabelSpacing) {
-                WidgetHeatmapWeekdayLabels(layout: layout)
-
-                HStack(alignment: .top, spacing: layout.monthSpacing) {
-                    ForEach(months, id: \.monthStart) { month in
-                        WidgetHeatmapMonthGrid(
-                            month: month,
-                            layout: layout,
-                            selectedActivityKindRawValues: selectedActivityKindRawValues,
-                            maxCount: maxCount,
-                            showsMonthTitle: showsMonthTitles
-                        )
-                    }
+            HStack(alignment: .top, spacing: layout.monthSpacing) {
+                ForEach(months, id: \.monthStart) { month in
+                    WidgetHeatmapMonthGrid(
+                        month: month,
+                        layout: layout,
+                        selectedActivityKindRawValues: selectedActivityKindRawValues,
+                        maxCount: maxCount,
+                        showsMonthTitle: showsMonthTitles
+                    )
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
@@ -67,45 +63,6 @@ struct WidgetHeatmapPlaceholderGrid: View {
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-        }
-    }
-}
-
-private struct WidgetHeatmapWeekdayLabels: View {
-    let layout: WidgetHeatmapLayout
-    private let orderedWeekdays = Array(1...7)
-    private let weekdayLocalizedStringKeys: [Int: LocalizedStringKey] = [
-        2: "widget_heatmap_weekday_monday",
-        4: "widget_heatmap_weekday_wednesday",
-        6: "widget_heatmap_weekday_friday"
-    ]
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: layout.cellSpacing) {
-            ForEach(orderedWeekdays, id: \.self) { weekday in
-                weekdayLabel(for: weekday)
-            }
-        }
-        .padding(.top, layout.weekdayTopPadding)
-    }
-
-    @ViewBuilder
-    private func weekdayLabel(for weekday: Int) -> some View {
-        if let localizedStringKey = weekdayLocalizedStringKeys[weekday] {
-            Text(localizedStringKey)
-                .font(.caption2)
-                .foregroundStyle(.secondary)
-                .frame(
-                    width: layout.weekdayLabelWidth,
-                    height: layout.cellSize,
-                    alignment: .leading
-                )
-        } else {
-            Color.clear
-                .frame(
-                    width: layout.weekdayLabelWidth,
-                    height: layout.cellSize
-                )
         }
     }
 }

--- a/DevLogWidget/Heatmap/WidgetHeatmapLayout.swift
+++ b/DevLogWidget/Heatmap/WidgetHeatmapLayout.swift
@@ -12,8 +12,6 @@ struct WidgetHeatmapLayout {
     let cellSpacing: CGFloat
     let monthSpacing: CGFloat
     let monthTitleSpacing: CGFloat
-    let weekdayLabelSpacing: CGFloat = Self.baseWeekdayLabelSpacing
-    let weekdayLabelWidth: CGFloat = Self.baseWeekdayLabelWidth
     let showsMonthTitles: Bool
 
     init(
@@ -37,10 +35,6 @@ struct WidgetHeatmapLayout {
         )
     }
 
-    var weekdayTopPadding: CGFloat {
-        showsMonthTitles ? cellSize + monthTitleSpacing : 0
-    }
-
     var cellCornerRadius: CGFloat {
         max(2, cellSize * 0.2)
     }
@@ -49,8 +43,6 @@ struct WidgetHeatmapLayout {
     private static let baseMonthSpacing: CGFloat = 10
     private static let maxMonthSpacing: CGFloat = 26
     private static let baseMonthTitleSpacing: CGFloat = 4
-    private static let baseWeekdayLabelSpacing: CGFloat = 5
-    private static let baseWeekdayLabelWidth: CGFloat = 14
 
     private static func resolvedMonthTitleSpacing(showsMonthTitles: Bool) -> CGFloat {
         // 월 제목을 표시하는 Medium에서만 제목과 셀 사이 간격을 확보한다.
@@ -99,10 +91,8 @@ struct WidgetHeatmapLayout {
     ) -> CGFloat {
         // 셀 크기는 높이 기준으로 고정하고, 남는 가로폭만 월 간격 계산에 사용한다.
         let sanitizedWeekCounts = sanitizedWeekCounts(weekCounts)
-        // 요일 라벨 영역, 전체 셀 컬럼, 월 내부 주차 spacing을 더해 기본 너비를 구한다.
-        let contentWidth = baseWeekdayLabelWidth
-            + baseWeekdayLabelSpacing
-            + cellSize * CGFloat(totalColumns(in: sanitizedWeekCounts))
+        // 전체 셀 컬럼과 월 내부 주차 spacing을 더해 기본 너비를 구한다.
+        let contentWidth = cellSize * CGFloat(totalColumns(in: sanitizedWeekCounts))
             + baseCellSpacing * CGFloat(totalColumnSpacings(in: sanitizedWeekCounts))
         // 기본 너비보다 위젯이 넓을 때만 월 간격에 분배할 여유 폭이 생긴다.
         return max(0, availableWidth - contentWidth)

--- a/DevLogWidget/Resource/Localizable.xcstrings
+++ b/DevLogWidget/Resource/Localizable.xcstrings
@@ -1,0 +1,154 @@
+{
+  "sourceLanguage" : "ko",
+  "strings" : {
+    "#%lld" : {
+
+    },
+    "%lld" : {
+
+    },
+    "Heatmap" : {
+
+    },
+    "Today" : {
+
+    },
+    "widget_heatmap_current_month_title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This Month Heatmap"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이번 달 히트맵"
+          }
+        }
+      }
+    },
+    "widget_heatmap_current_quarter_title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This Quarter Heatmap"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이번 분기 히트맵"
+          }
+        }
+      }
+    },
+    "widget_heatmap_weekday_friday" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fri"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "금"
+          }
+        }
+      }
+    },
+    "widget_heatmap_weekday_monday" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mon"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "월"
+          }
+        }
+      }
+    },
+    "widget_heatmap_weekday_wednesday" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wed"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "수"
+          }
+        }
+      }
+    },
+    "widget_heatmap_description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shows your activity heatmap."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "활동 히트맵을 표시합니다."
+          }
+        }
+      }
+    },
+    "widget_today_description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shows today's Todo list."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오늘 기준 Todo 목록을 표시합니다."
+          }
+        }
+      }
+    },
+    "widget_today_empty_message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No tasks for today.\nTake a short break!"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오늘은 할 일이 없어요.\n잠시 휴식을 취해보세요!"
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.0"
+}

--- a/DevLogWidget/Resource/Localizable.xcstrings
+++ b/DevLogWidget/Resource/Localizable.xcstrings
@@ -47,57 +47,6 @@
         }
       }
     },
-    "widget_heatmap_weekday_friday" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fri"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "금"
-          }
-        }
-      }
-    },
-    "widget_heatmap_weekday_monday" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mon"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "월"
-          }
-        }
-      }
-    },
-    "widget_heatmap_weekday_wednesday" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wed"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "수"
-          }
-        }
-      }
-    },
     "widget_heatmap_description" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/DevLogWidget/Resource/Localizable.xcstrings
+++ b/DevLogWidget/Resource/Localizable.xcstrings
@@ -19,7 +19,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "This Month Heatmap"
+            "value" : "This Month"
           }
         },
         "ko" : {
@@ -36,7 +36,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "This Quarter Heatmap"
+            "value" : "This Quarter"
           }
         },
         "ko" : {

--- a/DevLogWidget/Today/TodayTodoWidget.swift
+++ b/DevLogWidget/Today/TodayTodoWidget.swift
@@ -22,7 +22,7 @@ struct TodayTodoWidget: Widget {
                 .containerBackground(.fill.tertiary, for: .widget)
                 .widgetURL(WidgetDeepLink.todayTodoURL)
         }
-        .description("오늘 기준 Todo 목록을 표시합니다.")
+        .description("widget_today_description")
         .configurationDisplayName("Today")
         .supportedFamilies([.systemSmall, .systemMedium])
     }

--- a/DevLogWidget/Today/TodayTodoWidgetConfigurationIntent.swift
+++ b/DevLogWidget/Today/TodayTodoWidgetConfigurationIntent.swift
@@ -10,5 +10,5 @@ import WidgetKit
 
 struct TodayTodoWidgetConfigurationIntent: WidgetConfigurationIntent {
     static var title: LocalizedStringResource = "Today"
-    static var description = IntentDescription("오늘 기준 Todo 목록을 표시합니다.")
+    static var description = IntentDescription("widget_today_description")
 }

--- a/DevLogWidget/Today/TodayTodoWidgetEntryView.swift
+++ b/DevLogWidget/Today/TodayTodoWidgetEntryView.swift
@@ -41,7 +41,7 @@ struct TodayTodoWidgetEntryView: View {
                 if let item = displayedItems(from: snapshot).first {
                     todoRow(item)
                 } else {
-                    Text("오늘은 할 일이 없어요.\n잠시 휴식을 취해보세요!")
+                    Text("widget_today_empty_message")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                         .lineLimit(2)
@@ -51,7 +51,7 @@ struct TodayTodoWidgetEntryView: View {
             let items = displayedItems(from: snapshot)
             VStack(alignment: .leading, spacing: 6) {
                 if items.isEmpty {
-                    Text("오늘은 할 일이 없어요.\n잠시 휴식을 취해보세요!")
+                    Text("widget_today_empty_message")
                         .multilineTextAlignment(.center)
                         .font(.caption)
                         .foregroundStyle(.secondary)


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #406

## 📝 작업 내용

### 📌 요약
위젯에 노출되는 고정 문자열의 위젯 전용 String Catalog 기반 현지화 적용

### 🔍 상세
- `DevLogWidget/Resource/Localizable.xcstrings` 추가
- Today 위젯 설명 및 빈 상태 안내 문구 현지화 적용
- Heatmap 위젯 설명, 제목, 요일 라벨 현지화 적용
- 한국어 및 영어 번역 값 등록
- Base 지역화 및 Missing Localizability 정적 분석 설정 반영
- Xcode 26.4 scheme 업그레이드 메타데이터 반영

## 📸 영상 / 이미지 (Optional)

<img width=50% alt="image" src="https://github.com/user-attachments/assets/f46451fb-4d2f-4057-a33e-9a032d3debc9" />
