### PR TITLE
[#411] 위젯이 배포가능하도록 CI 코드를 수정한다

### DIFF
--- a/.github/workflows/sync-code-signing.yml
+++ b/.github/workflows/sync-code-signing.yml
@@ -2,6 +2,15 @@ name: iOS Code Signing
 
 on:
   workflow_dispatch:
+    inputs:
+      force:
+        description: Force regenerate profiles
+        required: true
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
 
 env:
   RUBY_VERSION: "3.2"
@@ -13,6 +22,7 @@ env:
   MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
   MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
   MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
+  MATCH_FORCE: ${{ inputs.force }}
 
 permissions:
   contents: read

--- a/.github/workflows/sync-code-signing.yml
+++ b/.github/workflows/sync-code-signing.yml
@@ -1,0 +1,42 @@
+name: iOS Code Signing
+
+on:
+  workflow_dispatch:
+
+env:
+  RUBY_VERSION: "3.2"
+  APP_STORE_TEAM_ID: ${{ secrets.APP_STORE_TEAM_ID }}
+  ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+  ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+  ASC_KEY_PATH: fastlane/AuthKey.p8
+  SPACESHIP_CONNECT_API_IN_HOUSE: "false"
+  MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
+  MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+  MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
+
+permissions:
+  contents: read
+
+jobs:
+  sync-appstore-profiles:
+    runs-on: macos-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: ${{ env.RUBY_VERSION }}
+
+      - name: Write App Store Connect API key
+        env:
+          ASC_KEY_CONTENT: ${{ secrets.ASC_KEY_CONTENT }}
+        run: |
+          printf '%s' "$ASC_KEY_CONTENT" | base64 -D > "$ASC_KEY_PATH"
+
+      - name: Sync App Store profiles
+        run: bundle exec fastlane sync_appstore_profiles

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,6 +1,9 @@
 XCODE_PROJ = "DevLog.xcodeproj"
 APP_IDENTIFIER = "opfic.DevLog"
+WIDGET_IDENTIFIER = "opfic.DevLog.DevLogWidget"
+APP_IDENTIFIERS = [APP_IDENTIFIER, WIDGET_IDENTIFIER]
 TARGET_NAME = "DevLog"
+WIDGET_TARGET_NAME = "DevLogWidgetExtension"
 TESTFLIGHT_BUILD_OUTPUT_DIRECTORY = File.expand_path("testflight_build", __dir__)
 TESTFLIGHT_IPA_OUTPUT_PATH = File.join(TESTFLIGHT_BUILD_OUTPUT_DIRECTORY, "#{TARGET_NAME}.ipa")
 
@@ -76,23 +79,32 @@ platform :ios do
     match(
       api_key: api_key,
       type: "appstore",
+      app_identifier: APP_IDENTIFIERS,
       readonly: ENV["CI"] == "true"
     )
 
     if ENV["CI"] == "true"
-      provisioning_profile_specifier = lane_context[SharedValues::MATCH_PROVISIONING_PROFILE_MAPPING][APP_IDENTIFIER].to_s
-      UI.user_error!("Missing App Store provisioning profile mapping for #{APP_IDENTIFIER}") if provisioning_profile_specifier.empty?
+      profile_mapping = lane_context[SharedValues::MATCH_PROVISIONING_PROFILE_MAPPING]
+      signing_targets = {
+        TARGET_NAME => APP_IDENTIFIER,
+        WIDGET_TARGET_NAME => WIDGET_IDENTIFIER
+      }
 
-      update_code_signing_settings(
-        use_automatic_signing: false,
-        path: XCODE_PROJ,
-        sdk: "iphoneos*",
-        team_id: ENV["APP_STORE_TEAM_ID"],
-        targets: [TARGET_NAME],
-        build_configurations: ["Release"],
-        code_sign_identity: "Apple Distribution",
-        profile_name: provisioning_profile_specifier
-      )
+      signing_targets.each do |target_name, app_identifier|
+        provisioning_profile_specifier = profile_mapping[app_identifier].to_s
+        UI.user_error!("Missing App Store provisioning profile mapping for #{app_identifier}") if provisioning_profile_specifier.empty?
+
+        update_code_signing_settings(
+          use_automatic_signing: false,
+          path: XCODE_PROJ,
+          sdk: "iphoneos*",
+          team_id: ENV["APP_STORE_TEAM_ID"],
+          targets: [target_name],
+          build_configurations: ["Release"],
+          code_sign_identity: "Apple Distribution",
+          profile_name: provisioning_profile_specifier
+        )
+      end
     end
 
     build_app(

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -131,12 +131,13 @@ platform :ios do
 
   lane :sync_appstore_profiles do
     api_key = asc_api_key
+    match_force = ENV.fetch("MATCH_FORCE", "false") == "true"
 
     match(
       api_key: api_key,
       type: "appstore",
       app_identifier: APP_IDENTIFIERS,
-      force: true,
+      force: match_force,
       readonly: false
     )
   end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -129,6 +129,18 @@ platform :ios do
     build_for_store
   end
 
+  lane :sync_appstore_profiles do
+    api_key = asc_api_key
+
+    match(
+      api_key: api_key,
+      type: "appstore",
+      app_identifier: APP_IDENTIFIERS,
+      force: true,
+      readonly: false
+    )
+  end
+
   lane :upload_testflight_build do
     api_key = asc_api_key
     # lane_context는 같은 fastlane 실행 내에서만 유지되므로, 별도 CI step에서는 고정 ipa 경로를 사용한다.

--- a/fastlane/Matchfile
+++ b/fastlane/Matchfile
@@ -3,7 +3,10 @@ git_url(ENV["MATCH_GIT_URL"])
 storage_mode("git")
 git_branch("main")
 type("appstore")
-app_identifier(["opfic.DevLog"])
+app_identifier([
+  "opfic.DevLog",
+  "opfic.DevLog.DevLogWidget"
+])
 team_id(ENV["APP_STORE_TEAM_ID"])
 readonly(ENV["CI"] == "true")
 


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #411

## 📝 작업 내용

### 📌 요약

TestFlight 배포 시 앱과 위젯 App Store 프로파일을 함께 동기화하고 적용하도록 fastlane 설정 확장

### 🔍 상세

- `opfic.DevLog.DevLogWidget` bundle identifier를 match 대상에 추가
- `DevLog`, `DevLogWidgetExtension` 타겟별 provisioning profile 적용 로직 추가
- GitHub Actions에서 App Store 프로파일을 수동 동기화할 수 있는 `iOS Code Signing` workflow 추가
- `sync_appstore_profiles` lane을 통해 앱/위젯 App Store 프로파일 갱신 가능하도록 구성
- `ruby -c fastlane/Fastfile` 및 workflow YAML 파싱 확인

## 📸 영상 / 이미지 (Optional)