### PR TITLE
[#4!0] HomeView의 LoadingView를 즉시 뜨도록 수정한다

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -1,6 +1,16 @@
 name: iOS TestFlight
 
 on:
+  workflow_dispatch:
+    inputs:
+      upload_to_app_store_connect:
+        description: Upload to App Store Connect
+        required: true
+        default: "false"
+        type: choice
+        options:
+          - "false"
+          - "true"
   pull_request:
     types:
       - closed
@@ -25,15 +35,20 @@ permissions:
 
 jobs:
   testflight:
-    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'develop' && (contains(github.event.pull_request.labels.*.name, 'qa') || contains(github.event.pull_request.labels.*.name, 'qa-local'))
+    if: github.event_name == 'workflow_dispatch' || (github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'develop' && (contains(github.event.pull_request.labels.*.name, 'qa') || contains(github.event.pull_request.labels.*.name, 'qa-local')))
     runs-on: macos-latest
     timeout-minutes: 45
 
     steps:
       - name: Checkout merge commit
+        if: github.event_name == 'pull_request'
         uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.merge_commit_sha }}
+
+      - name: Checkout current ref
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/checkout@v5
 
       - name: Install private config files
         uses: ./.github/actions/install-private-config
@@ -78,10 +93,10 @@ jobs:
       - name: Build for TestFlight
         run: bundle exec fastlane testflight_build_only
 
-      - name: Skip TestFlight Upload for Local QA Label
-        if: contains(github.event.pull_request.labels.*.name, 'qa-local')
-        run: echo "Skipping TestFlight upload for PR labeled qa-local"
+      - name: Skip TestFlight Upload
+        if: (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'qa-local')) || (github.event_name == 'workflow_dispatch' && inputs.upload_to_app_store_connect != 'true')
+        run: echo "Skipping TestFlight upload"
 
       - name: Upload to TestFlight
-        if: contains(github.event.pull_request.labels.*.name, 'qa') && !contains(github.event.pull_request.labels.*.name, 'qa-local')
+        if: (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'qa') && !contains(github.event.pull_request.labels.*.name, 'qa-local')) || (github.event_name == 'workflow_dispatch' && inputs.upload_to_app_store_connect == 'true')
         run: bundle exec fastlane upload_testflight_build

--- a/DevLog/Presentation/ViewModel/HomeViewModel.swift
+++ b/DevLog/Presentation/ViewModel/HomeViewModel.swift
@@ -160,10 +160,10 @@ final class HomeViewModel: Store {
     func run(_ effect: SideEffect) {
         switch effect {
         case .fetchTodoCategoryPreferences:
-            beginLoading(for: .preferences, mode: .delayed)
+            beginLoading(for: .preferences, mode: .immediate)
             Task {
                 do {
-                    defer { endLoading(for: .preferences, mode: .delayed) }
+                    defer { endLoading(for: .preferences, mode: .immediate) }
                     let preferences = try await fetchPreferencesUseCase.execute()
                     send(.setTodoCategory(preferences.map(TodoCategoryItem.init(from:))))
                 } catch {
@@ -195,10 +195,10 @@ final class HomeViewModel: Store {
                 }
             }
         case .fetchRecentTodos:
-            beginLoading(for: .recentTodos, mode: .delayed)
+            beginLoading(for: .recentTodos, mode: .immediate)
             Task {
                 do {
-                    defer { endLoading(for: .recentTodos, mode: .delayed) }
+                    defer { endLoading(for: .recentTodos, mode: .immediate) }
                     let page = try await fetchRecentTodos()
                     let items = page.items
                         .filter { $0.createdAt != $0.updatedAt }
@@ -243,10 +243,10 @@ final class HomeViewModel: Store {
                 }
             }
         case .fetchWebPages:
-            beginLoading(for: .webPage, mode: .delayed)
+            beginLoading(for: .webPage, mode: .immediate)
             Task {
                 do {
-                    defer { endLoading(for: .webPage, mode: .delayed) }
+                    defer { endLoading(for: .webPage, mode: .immediate) }
                     let pages = try await fetchWebPagesUseCase.execute("")
                     send(.updateWebPages(pages.map { WebPageItem(from: $0) }))
                 } catch {


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #410

## 📝 작업 내용

### 📌 요약

HomeView의 섹션별 LoadingView가 지연 없이 바로 표시되도록 로딩 상태 전환 방식 수정

### 🔍 상세

- Todo 카테고리, 최근 수정 Todo, 웹페이지 섹션의 로딩 상태를 delayed에서 immediate로 변경
- 각 섹션의 데이터 조회 시작 시 LoadingView가 즉시 표시되도록 개선
- iOS TestFlight workflow를 수동 실행할 수 있도록 workflow_dispatch 추가
- 수동 실행 시 App Store Connect 업로드 여부를 `upload_to_app_store_connect` 입력값으로 선택할 수 있도록 구성
- Xcode Local MCP 빌드 확인
- workflow YAML 파싱 확인

## 📸 영상 / 이미지 (Optional)

<table>
<tr>
<td>
<video src="https://github.com/user-attachments/assets/67f957d9-9966-46a4-9b96-a2cabf0e9088">
</td>
</tr>
<tr>
<td align="center">
LoadingView가 바로 뜸
</td>
</tr>
</table>