### PR TITLE
[#414] 앱 쪽 히트맵에서 요일 레이블을 제거한다

### DIFF
--- a/DevLog/Resource/Localizable.xcstrings
+++ b/DevLog/Resource/Localizable.xcstrings
@@ -979,57 +979,6 @@
         }
       }
     },
-    "profile_weekday_fri" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fri"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "금"
-          }
-        }
-      }
-    },
-    "profile_weekday_mon" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mon"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "월"
-          }
-        }
-      }
-    },
-    "profile_weekday_wed" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wed"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "수"
-          }
-        }
-      }
-    },
     "profile_year" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/DevLog/UI/Profile/HeatmapView.swift
+++ b/DevLog/UI/Profile/HeatmapView.swift
@@ -21,75 +21,19 @@ struct HeatmapView: View {
             weekCounts: quarter.months.map(\.weeks.count)
         )
 
-        HStack(alignment: .top, spacing: 0) {
-            weekdayLabel(layout: layout)
-            HStack(alignment: .top, spacing: layout.monthSpacing) {
-                ForEach(quarter.months) { month in
-                    MonthCompactHeatmapView(
-                        month: month,
-                        maxCount: maxCount,
-                        layout: layout,
-                        selectedActivityKinds: selectedActivityKinds,
-                        selectedDay: selectedDay,
-                        onSelectDay: onSelectDay
-                    )
-                }
+        HStack(alignment: .top, spacing: layout.monthSpacing) {
+            ForEach(quarter.months) { month in
+                MonthCompactHeatmapView(
+                    month: month,
+                    maxCount: maxCount,
+                    layout: layout,
+                    selectedActivityKinds: selectedActivityKinds,
+                    selectedDay: selectedDay,
+                    onSelectDay: onSelectDay
+                )
             }
         }
         .padding(.vertical, 2)
-    }
-
-    @ViewBuilder
-    private func weekdayLabel(layout: HeatmapLayout) -> some View {
-        let labels: [Int: String] = [
-            2: String(localized: "profile_weekday_mon"),
-            4: String(localized: "profile_weekday_wed"),
-            6: String(localized: "profile_weekday_fri")
-        ]
-        let orderedWeekdays = Array(1...7)
-        let labelFontSize = smallestWeekdayLabelFontSize(
-            labels: Array(labels.values),
-            layout: layout
-        )
-
-        VStack(alignment: .leading, spacing: layout.cellSpacing) {
-            ForEach(orderedWeekdays, id: \.self) { weekday in
-                if let label = labels[weekday] {
-                    Text(label)
-                        .font(.system(size: labelFontSize))
-                        .allowsTightening(true)
-                        .foregroundStyle(.secondary)
-                        .frame(
-                            width: layout.cellSize,
-                            height: layout.cellSize,
-                            alignment: .leading
-                        )
-                } else {
-                    Color.clear
-                        .frame(
-                            width: layout.cellSize,
-                            height: layout.cellSize
-                        )
-                }
-            }
-        }
-        .padding(.top, layout.weekdayTopPadding)
-    }
-
-    private func smallestWeekdayLabelFontSize(labels: [String], layout: HeatmapLayout) -> CGFloat {
-        let captionFont = UIFont.preferredFont(forTextStyle: .caption2)
-        let availableWidth = max(layout.cellSize, 1)
-
-        let fittedSizes = labels.map { label in
-            let textWidth = max(
-                (label as NSString).size(withAttributes: [.font: captionFont]).width,
-                1
-            )
-            let widthRatio = availableWidth / textWidth
-            return captionFont.pointSize * min(widthRatio, 1)
-        }
-
-        return max((fittedSizes.min() ?? captionFont.pointSize).rounded(.down), 1)
     }
 
     private var availableWidth: CGFloat {
@@ -142,11 +86,7 @@ private struct HeatmapLayout {
         }
         let fixedWidth = monthSpacing * CGFloat(max(sanitizedWeekCounts.count - 1, 0))
             + cellSpacing * CGFloat(totalColumnSpacings)
-        cellSize = max(0, availableWidth - fixedWidth) / CGFloat(totalColumns + 1)
-    }
-
-    var weekdayTopPadding: CGFloat {
-        cellSize + monthTitleSpacing
+        cellSize = max(0, availableWidth - fixedWidth) / CGFloat(totalColumns)
     }
 
     var cellCornerRadius: CGFloat {

--- a/DevLog/UI/Profile/HeatmapView.swift
+++ b/DevLog/UI/Profile/HeatmapView.swift
@@ -79,12 +79,11 @@ private struct HeatmapLayout {
     let monthTitleSpacing: CGFloat = 6
 
     init(availableWidth: CGFloat, weekCounts: [Int]) {
-        let sanitizedWeekCounts = weekCounts.filter { 0 < $0 }
-        let totalColumns = max(sanitizedWeekCounts.reduce(0, +), 1)
-        let totalColumnSpacings = sanitizedWeekCounts.reduce(0) { partialResult, count in
+        let totalColumns = max(weekCounts.reduce(0, +), 1)
+        let totalColumnSpacings = weekCounts.reduce(0) { partialResult, count in
             partialResult + max(count - 1, 0)
         }
-        let fixedWidth = monthSpacing * CGFloat(max(sanitizedWeekCounts.count - 1, 0))
+        let fixedWidth = monthSpacing * CGFloat(max(weekCounts.count - 1, 0))
             + cellSpacing * CGFloat(totalColumnSpacings)
         cellSize = max(0, availableWidth - fixedWidth) / CGFloat(totalColumns)
     }


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #414

## 📝 작업 내용

### 📌 요약
- Profile 히트맵 요일 라벨 제거
- 요일 라벨 제거에 따른 불필요 레이아웃 계산 및 지역화 키 제거

### 🔍 상세
- `HeatmapView`의 요일 라벨 렌더링 경로 제거
- 요일 라벨 영역 예약용 1컬럼 너비 계산 제거
- 미사용 `profile_weekday_fri`, `profile_weekday_mon`, `profile_weekday_wed` 지역화 키 제거

## 📸 영상 / 이미지 (Optional)