### PR TITLE
[#416] NavigationSplitView를 적용한다

### DIFF
--- a/DevLog/Presentation/Structure/Todo/SystemTodoCategoryItem.swift
+++ b/DevLog/Presentation/Structure/Todo/SystemTodoCategoryItem.swift
@@ -42,16 +42,16 @@ struct SystemTodoCategoryItem: Identifiable, Hashable {
         }
     }
 
-    var color: Color {
+    var color: UIColor {
         switch systemTodoCategory {
-        case .issue: return .red
-        case .feature: return .green
-        case .improvement: return .cyan
-        case .review: return .orange
-        case .test: return .purple
-        case .doc: return .yellow
-        case .research: return .teal
-        case .etc: return .gray
+        case .issue: return .systemRed
+        case .feature: return .systemGreen
+        case .improvement: return .systemCyan
+        case .review: return .systemOrange
+        case .test: return .systemPurple
+        case .doc: return .systemYellow
+        case .research: return .systemTeal
+        case .etc: return .systemGray
         }
     }
 }

--- a/DevLog/Presentation/Structure/Todo/TodoCategoryItem.swift
+++ b/DevLog/Presentation/Structure/Todo/TodoCategoryItem.swift
@@ -64,7 +64,7 @@ struct TodoCategoryItem: Identifiable, Hashable {
     var color: Color {
         switch category {
         case .system(let systemTodoCategory):
-            return SystemTodoCategoryItem(from: systemTodoCategory).color
+            return Color(SystemTodoCategoryItem(from: systemTodoCategory).color)
         case .user(let userTodoCategory):
             return UserTodoCategoryItem(from: userTodoCategory).color
         }

--- a/DevLog/Presentation/ViewModel/PushNotificationListViewModel.swift
+++ b/DevLog/Presentation/ViewModel/PushNotificationListViewModel.swift
@@ -21,6 +21,7 @@ final class PushNotificationListViewModel: Store {
         var hasMore: Bool = false
         var nextCursor: PushNotificationCursor?
         var query: PushNotificationQuery
+        var selectedNotificationId: String?
         var selectedTodoId: TodoIdItem?
     }
 
@@ -42,8 +43,7 @@ final class PushNotificationListViewModel: Store {
         case setTimeFilter(PushNotificationQuery.TimeFilter)
         case toggleUnreadOnly
         case resetFilters
-        case tapNotification(PushNotificationItem)
-        case setSelectedTodoId(TodoIdItem?)
+        case selectNotification(String?)
     }
 
     enum SideEffect {
@@ -97,10 +97,10 @@ final class PushNotificationListViewModel: Store {
 
         switch action {
         case .deleteNotification, .toggleRead, .undoDelete, .setAlert, .toggleSortOption,
-                .setTimeFilter, .toggleUnreadOnly, .resetFilters, .tapNotification:
+                .setTimeFilter, .toggleUnreadOnly, .resetFilters, .selectNotification:
             effects = reduceByUser(action, state: &state)
 
-        case .fetchNotifications, .setToast, .setSelectedTodoId, .loadNextPage:
+        case .fetchNotifications, .setToast, .loadNextPage:
             effects = reduceByView(action, state: &state)
 
         case .setLoading, .appendNotifications, .resetPagination, .setHasMore,
@@ -221,9 +221,19 @@ private extension PushNotificationListViewModel {
             updateQueryUseCase.execute(state.query)
             state.nextCursor = nil
             return [.fetchNotifications(state.query, cursor: nil)]
-        case .tapNotification(let item):
+        case .selectNotification(let notificationId):
+            state.selectedNotificationId = notificationId
+            guard let notificationId else {
+                state.selectedTodoId = nil
+                return []
+            }
+            guard let index = state.notifications.firstIndex(where: { $0.id == notificationId }) else {
+                state.selectedTodoId = nil
+                return []
+            }
+            let item = state.notifications[index]
             state.selectedTodoId = TodoIdItem(id: item.todoId)
-            if let index = state.notifications.firstIndex(where: { $0.id == item.id }), !item.isRead {
+            if !item.isRead {
                 state.notifications[index].isRead.toggle()
                 return [.toggleRead(item.todoId)]
             }
@@ -247,8 +257,6 @@ private extension PushNotificationListViewModel {
                 state.notifications.removeAll { $0.isHidden }
                 self.undoNotificationId = nil
             }
-        case .setSelectedTodoId(let todoId):
-            state.selectedTodoId = todoId
         default:
             break
         }

--- a/DevLog/Resource/Localizable.xcstrings
+++ b/DevLog/Resource/Localizable.xcstrings
@@ -1931,6 +1931,23 @@
         }
       }
     },
+    "today_select_detail" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Select a todo."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Todo를 선택해주세요."
+          }
+        }
+      }
+    },
     "today_due_overdue" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/DevLog/Resource/Localizable.xcstrings
+++ b/DevLog/Resource/Localizable.xcstrings
@@ -1064,6 +1064,23 @@
         }
       }
     },
+    "push_notifications_select_detail" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Select a notification."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "알림을 선택해주세요."
+          }
+        }
+      }
+    },
     "push_period" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/DevLog/Resource/Localizable.xcstrings
+++ b/DevLog/Resource/Localizable.xcstrings
@@ -425,6 +425,23 @@
         }
       }
     },
+    "home_select_detail" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Select an item."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "항목을 선택해주세요."
+          }
+        }
+      }
+    },
     "home_recent_title" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/DevLog/UI/Common/MainView.swift
+++ b/DevLog/UI/Common/MainView.swift
@@ -11,6 +11,7 @@ struct MainView: View {
     @Environment(\.diContainer) var container: DIContainer
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @State var viewModel: MainViewModel
+    @State private var homeDetailDestination: HomeDetailDestination?
     @State private var todoIdToPresent: TodoIdItem?
     @Binding var selectedTab: MainTab
 
@@ -102,7 +103,7 @@ struct MainView: View {
                 } content: {
                     homeView
                 } detail: {
-                    EmptyView()
+                    homeDetailView
                 }
             case .today:
                 NavigationSplitView {
@@ -198,7 +199,15 @@ struct MainView: View {
     }
 
     private var homeView: some View {
-        HomeView(viewModel: HomeViewModel(
+        HomeView(
+            viewModel: makeHomeViewModel(),
+            homeDetailDestination: $homeDetailDestination,
+            isCompactLayout: isCompactLayout
+        )
+    }
+
+    private func makeHomeViewModel() -> HomeViewModel {
+        HomeViewModel(
             fetchPreferencesUseCase: container.resolve(FetchTodoCategoryPreferencesUseCase.self),
             updatePreferencesUseCase: container.resolve(UpdateTodoCategoryPreferencesUseCase.self),
             addWebPageUseCase: container.resolve(AddWebPageUseCase.self),
@@ -208,7 +217,67 @@ struct MainView: View {
             fetchTodosUseCase: container.resolve(FetchTodosUseCase.self),
             fetchWebPagesUseCase: container.resolve(FetchWebPagesUseCase.self),
             networkConnectivityUseCase: container.resolve(ObserveNetworkConnectivityUseCase.self)
-        ))
+        )
+    }
+
+    @ViewBuilder
+    private var homeDetailView: some View {
+        Group {
+            switch homeDetailDestination {
+            case .category(let item):
+                TodoListView(
+                    viewModel: TodoListViewModel(
+                        fetchTodosUseCase: container.resolve(FetchTodosUseCase.self),
+                        fetchTodoByIdUseCase: container.resolve(FetchTodoByIdUseCase.self),
+                        upsertTodoUseCase: container.resolve(UpsertTodoUseCase.self),
+                        deleteTodoUseCase: container.resolve(DeleteTodoUseCase.self),
+                        undoDeleteTodoUseCase: container.resolve(UndoDeleteTodoUseCase.self),
+                        category: item.todoCategory
+                    ),
+                    todoIdToPresent: Binding(
+                        get: {
+                            if case .todo(let item) = homeDetailDestination {
+                                item
+                            } else {
+                                nil
+                            }
+                        },
+                        set: { item in
+                            if let item {
+                                homeDetailDestination = .todo(item)
+                            }
+                        }
+                    ),
+                    isCompactLayout: false
+                )
+                .id(item.id)
+            case .todo(let item):
+                TodoDetailView(viewModel: TodoDetailViewModel(
+                    fetchTodoUseCase: container.resolve(FetchTodoByIdUseCase.self),
+                    fetchReferenceItemsUseCase: container.resolve(FetchReferenceItemsUseCase.self),
+                    upsertUseCase: container.resolve(UpsertTodoUseCase.self),
+                    todoId: item.id
+                ))
+                .id(item.id)
+            case .webPage(let item):
+                WebView(url: item.url)
+                    .navigationBarTitleDisplayMode(.inline)
+                    .ignoresSafeArea()
+                    .toolbar {
+                        ToolbarItem(placement: .principal) {
+                            Text(item.title)
+                                .bold()
+                        }
+                    }
+            case .none:
+                ContentUnavailableView(
+                    String(localized: "home_select_detail"),
+                    systemImage: "house"
+                )
+                .background(Color(.secondarySystemBackground))
+            }
+        }
+        .background(Color(.secondarySystemBackground).ignoresSafeArea())
     }
 
     private var todayView: some View {

--- a/DevLog/UI/Common/MainView.swift
+++ b/DevLog/UI/Common/MainView.swift
@@ -11,8 +11,8 @@ struct MainView: View {
     @Environment(\.diContainer) var container: DIContainer
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @State var viewModel: MainViewModel
-    @State private var homeNavigationState = HomeNavigationState()
-    @State private var todayNavigationState = TodayNavigationState()
+    @State private var homeNavigationRouter = NavigationRouter<HomeRoute>()
+    @State private var todayNavigationRouter = NavigationRouter<TodayRoute>()
     @State private var todoIdToPresent: TodoIdItem?
     @Binding var selectedTab: MainTab
 
@@ -106,7 +106,7 @@ struct MainView: View {
                 } detail: {
                     homeRegularDetailView
                 }
-                .environment(homeNavigationState)
+                .environment(homeNavigationRouter)
             case .today:
                 NavigationSplitView {
                     mainSidebar
@@ -115,7 +115,7 @@ struct MainView: View {
                 } detail: {
                     todayRegularDetailView
                 }
-                .environment(todayNavigationState)
+                .environment(todayNavigationRouter)
             case .notification:
                 let viewModel = makePushNotificationListViewModel()
                 NavigationSplitView {
@@ -205,7 +205,7 @@ struct MainView: View {
     private var homeView: some View {
         Group {
             if isCompactLayout {
-                NavigationStack(path: $homeNavigationState.path) {
+                NavigationStack(path: $homeNavigationRouter.path) {
                     homeContentView
                         .navigationDestination(for: HomeRoute.self) { homeRoute in
                             homeDestinationView(homeRoute)
@@ -215,7 +215,7 @@ struct MainView: View {
                 homeContentView
             }
         }
-        .environment(homeNavigationState)
+        .environment(homeNavigationRouter)
     }
 
     private var homeContentView: some View {
@@ -241,8 +241,8 @@ struct MainView: View {
 
     private var homeDetailPath: Binding<[HomeRoute]> {
         Binding(
-            get: { homeNavigationState.detailPath },
-            set: { homeNavigationState.detailPath = $0 }
+            get: { homeNavigationRouter.detailPath },
+            set: { homeNavigationRouter.detailPath = $0 }
         )
     }
 
@@ -250,7 +250,7 @@ struct MainView: View {
     private var homeRegularDetailView: some View {
         NavigationStack(path: homeDetailPath) {
             Group {
-                if let homeRoute = homeNavigationState.root {
+                if let homeRoute = homeNavigationRouter.root {
                     homeDestinationView(homeRoute)
                 } else {
                     ContentUnavailableView(
@@ -316,7 +316,7 @@ struct MainView: View {
     private var todayView: some View {
         Group {
             if isCompactLayout {
-                NavigationStack(path: $todayNavigationState.path) {
+                NavigationStack(path: $todayNavigationRouter.path) {
                     todayContentView
                         .navigationDestination(for: TodayRoute.self) { todayRoute in
                             todayDestinationView(todayRoute)
@@ -326,7 +326,7 @@ struct MainView: View {
                 todayContentView
             }
         }
-        .environment(todayNavigationState)
+        .environment(todayNavigationRouter)
     }
 
     private var todayContentView: some View {
@@ -348,8 +348,8 @@ struct MainView: View {
 
     private var todayDetailPath: Binding<[TodayRoute]> {
         Binding(
-            get: { todayNavigationState.detailPath },
-            set: { todayNavigationState.detailPath = $0 }
+            get: { todayNavigationRouter.detailPath },
+            set: { todayNavigationRouter.detailPath = $0 }
         )
     }
 
@@ -357,7 +357,7 @@ struct MainView: View {
     private var todayRegularDetailView: some View {
         NavigationStack(path: todayDetailPath) {
             Group {
-                if let todayRoute = todayNavigationState.root {
+                if let todayRoute = todayNavigationRouter.root {
                     todayDestinationView(todayRoute)
                 } else {
                     ContentUnavailableView(

--- a/DevLog/UI/Common/MainView.swift
+++ b/DevLog/UI/Common/MainView.swift
@@ -11,6 +11,7 @@ struct MainView: View {
     @Environment(\.diContainer) var container: DIContainer
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @State var viewModel: MainViewModel
+    @State private var todoIdToPresent: TodoIdItem?
     @Binding var selectedTab: MainTab
 
     var body: some View {
@@ -118,11 +119,12 @@ struct MainView: View {
                 } content: {
                     PushNotificationListView(
                         viewModel: viewModel,
+                        todoIdToPresent: $todoIdToPresent,
                         isCompactLayout: isCompactLayout
                     )
                 } detail: {
                     Group {
-                        if let todoId = viewModel.state.selectedTodoId?.id {
+                        if let todoId = todoIdToPresent?.id {
                             TodoDetailView(viewModel: TodoDetailViewModel(
                                 fetchTodoUseCase: container.resolve(FetchTodoByIdUseCase.self),
                                 fetchReferenceItemsUseCase: container.resolve(FetchReferenceItemsUseCase.self),
@@ -222,6 +224,7 @@ struct MainView: View {
     private var notificationView: some View {
         PushNotificationListView(
             viewModel: makePushNotificationListViewModel(),
+            todoIdToPresent: $todoIdToPresent,
             isCompactLayout: isCompactLayout
         )
     }

--- a/DevLog/UI/Common/MainView.swift
+++ b/DevLog/UI/Common/MainView.swift
@@ -12,6 +12,7 @@ struct MainView: View {
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @State var viewModel: MainViewModel
     @State private var homeNavigationState = HomeNavigationState()
+    @State private var todayNavigationState = TodayNavigationState()
     @State private var todoIdToPresent: TodoIdItem?
     @Binding var selectedTab: MainTab
 
@@ -112,8 +113,9 @@ struct MainView: View {
                 } content: {
                     todayView
                 } detail: {
-                    EmptyView()
+                    todayRegularDetailView
                 }
+                .environment(todayNavigationState)
             case .notification:
                 let viewModel = makePushNotificationListViewModel()
                 NavigationSplitView {
@@ -310,14 +312,75 @@ struct MainView: View {
         )
     }
 
+    @ViewBuilder
     private var todayView: some View {
-        TodayView(viewModel: TodayViewModel(
+        Group {
+            if isCompactLayout {
+                NavigationStack(path: $todayNavigationState.path) {
+                    todayContentView
+                        .navigationDestination(for: TodayRoute.self) { todayRoute in
+                            todayDestinationView(todayRoute)
+                        }
+                }
+            } else {
+                todayContentView
+            }
+        }
+        .environment(todayNavigationState)
+    }
+
+    private var todayContentView: some View {
+        TodayView(
+            viewModel: makeTodayViewModel(),
+            isCompactLayout: isCompactLayout
+        )
+    }
+
+    private func makeTodayViewModel() -> TodayViewModel {
+        TodayViewModel(
             fetchTodosUseCase: container.resolve(FetchTodosUseCase.self),
             fetchTodoByIdUseCase: container.resolve(FetchTodoByIdUseCase.self),
             upsertTodoUseCase: container.resolve(UpsertTodoUseCase.self),
             fetchTodayDisplayOptionsUseCase: container.resolve(FetchTodayDisplayOptionsUseCase.self),
             updateTodayDisplayOptionsUseCase: container.resolve(UpdateTodayDisplayOptionsUseCase.self)
-        ))
+        )
+    }
+
+    private var todayDetailPath: Binding<[TodayRoute]> {
+        Binding(
+            get: { todayNavigationState.detailPath },
+            set: { todayNavigationState.detailPath = $0 }
+        )
+    }
+
+    @ViewBuilder
+    private var todayRegularDetailView: some View {
+        NavigationStack(path: todayDetailPath) {
+            Group {
+                if let todayRoute = todayNavigationState.root {
+                    todayDestinationView(todayRoute)
+                } else {
+                    ContentUnavailableView(
+                        String(localized: "today_select_detail"),
+                        systemImage: "sun.max"
+                    )
+                    .background(Color(.secondarySystemBackground))
+                }
+            }
+            .navigationDestination(for: TodayRoute.self) { todayRoute in
+                todayDestinationView(todayRoute)
+            }
+        }
+        .background(Color(.secondarySystemBackground).ignoresSafeArea())
+    }
+
+    @ViewBuilder
+    private func todayDestinationView(_ todayRoute: TodayRoute) -> some View {
+        switch todayRoute {
+        case .todo(let item):
+            TodoDetailView(viewModel: makeTodoDetailViewModel(todoId: item.id))
+                .id(item.id)
+        }
     }
 
     private var notificationView: some View {

--- a/DevLog/UI/Common/MainView.swift
+++ b/DevLog/UI/Common/MainView.swift
@@ -84,19 +84,81 @@ struct MainView: View {
         }
     }
 
+    @ViewBuilder
     private var sidebarView: some View {
-        NavigationSplitView {
-            List(selection: sidebarSelection) {
-                sidebarRow(.home)
-                sidebarRow(.today)
-                sidebarRow(.notification)
-                sidebarRow(.profile)
+        switch selectedTab.mainTabSplitStyle {
+        case .detailOnly:
+            NavigationSplitView {
+                mainSidebar
+            } detail: {
+                selectedTabView
             }
-            .listStyle(.sidebar)
-            .navigationTitle(Text(verbatim: "DevLog"))
-        } detail: {
-            selectedTabView
+        case .contentDetail:
+            switch selectedTab {
+            case .home:
+                NavigationSplitView {
+                    mainSidebar
+                } content: {
+                    homeView
+                } detail: {
+                    EmptyView()
+                }
+            case .today:
+                NavigationSplitView {
+                    mainSidebar
+                } content: {
+                    todayView
+                } detail: {
+                    EmptyView()
+                }
+            case .notification:
+                let viewModel = makePushNotificationListViewModel()
+                NavigationSplitView {
+                    mainSidebar
+                } content: {
+                    PushNotificationListView(
+                        viewModel: viewModel,
+                        isCompactLayout: isCompactLayout
+                    )
+                } detail: {
+                    Group {
+                        if let todoId = viewModel.state.selectedTodoId?.id {
+                            TodoDetailView(viewModel: TodoDetailViewModel(
+                                fetchTodoUseCase: container.resolve(FetchTodoByIdUseCase.self),
+                                fetchReferenceItemsUseCase: container.resolve(FetchReferenceItemsUseCase.self),
+                                upsertUseCase: container.resolve(UpsertTodoUseCase.self),
+                                todoId: todoId,
+                                showEditButton: false
+                            ))
+                            .id(todoId)
+                        } else {
+                            ContentUnavailableView(
+                                String(localized: "push_notifications_select_detail"),
+                                systemImage: "bell.badge"
+                            )
+                            .background(Color(.secondarySystemBackground))
+                        }
+                    }
+                    .background(Color(.secondarySystemBackground).ignoresSafeArea())
+                }
+            case .profile:
+                NavigationSplitView {
+                    mainSidebar
+                } detail: {
+                    selectedTabView
+                }
+            }
         }
+    }
+
+    private var mainSidebar: some View {
+        List(selection: sidebarSelection) {
+            sidebarRow(.home)
+            sidebarRow(.today)
+            sidebarRow(.notification)
+            sidebarRow(.profile)
+        }
+        .listStyle(.sidebar)
     }
 
     @ViewBuilder
@@ -158,14 +220,21 @@ struct MainView: View {
     }
 
     private var notificationView: some View {
-        PushNotificationListView(viewModel: PushNotificationListViewModel(
+        PushNotificationListView(
+            viewModel: makePushNotificationListViewModel(),
+            isCompactLayout: isCompactLayout
+        )
+    }
+
+    private func makePushNotificationListViewModel() -> PushNotificationListViewModel {
+        PushNotificationListViewModel(
             fetchUseCase: container.resolve(FetchPushNotificationsUseCase.self),
             deleteUseCase: container.resolve(DeletePushNotificationUseCase.self),
             undoDeleteUseCase: container.resolve(UndoDeletePushNotificationUseCase.self),
             toggleReadUseCase: container.resolve(TogglePushNotificationReadUseCase.self),
             fetchQueryUseCase: container.resolve(FetchPushNotificationQueryUseCase.self),
             updateQueryUseCase: container.resolve(UpdatePushNotificationQueryUseCase.self)
-        ))
+        )
     }
 
     private var profileView: some View {
@@ -180,7 +249,21 @@ struct MainView: View {
     }
 }
 
+private enum MainTabSplitStyle {
+    case detailOnly
+    case contentDetail
+}
+
 private extension MainTab {
+    var mainTabSplitStyle: MainTabSplitStyle {
+        switch self {
+        case .home, .today, .notification:
+            .contentDetail
+        case .profile:
+            .detailOnly
+        }
+    }
+
     var title: String {
         switch self {
         case .home:

--- a/DevLog/UI/Common/MainView.swift
+++ b/DevLog/UI/Common/MainView.swift
@@ -9,80 +9,201 @@ import SwiftUI
 
 struct MainView: View {
     @Environment(\.diContainer) var container: DIContainer
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @State var viewModel: MainViewModel
     @Binding var selectedTab: MainTab
 
     var body: some View {
+        content
+            .onAppear {
+                viewModel.send(.onAppear)
+            }
+            .alert(
+                viewModel.state.alertTitle,
+                isPresented: Binding(
+                    get: { viewModel.state.showAlert },
+                    set: { viewModel.send(.setAlert($0)) }
+                )
+            ) {
+                Button(String(localized: "common_close"), role: .cancel) { }
+            } message: {
+                Text(viewModel.state.alertMessage)
+            }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if isCompactLayout {
+            tabView
+        } else {
+            sidebarView
+        }
+    }
+
+    private var isCompactLayout: Bool {
+        horizontalSizeClass == .compact
+    }
+
+    private var sidebarSelection: Binding<MainTab?> {
+        Binding(
+            get: { selectedTab },
+            set: { tab in
+                if let tab {
+                    selectedTab = tab
+                }
+            }
+        )
+    }
+
+    private var tabView: some View {
         TabView(selection: $selectedTab) {
-            HomeView(viewModel: HomeViewModel(
-                fetchPreferencesUseCase: container.resolve(FetchTodoCategoryPreferencesUseCase.self),
-                updatePreferencesUseCase: container.resolve(UpdateTodoCategoryPreferencesUseCase.self),
-                addWebPageUseCase: container.resolve(AddWebPageUseCase.self),
-                deleteWebPageUseCase: container.resolve(DeleteWebPageUseCase.self),
-                undoDeleteWebPageUseCase: container.resolve(UndoDeleteWebPageUseCase.self),
-                upsertTodoUseCase: container.resolve(UpsertTodoUseCase.self),
-                fetchTodosUseCase: container.resolve(FetchTodosUseCase.self),
-                fetchWebPagesUseCase: container.resolve(FetchWebPagesUseCase.self),
-                networkConnectivityUseCase: container.resolve(ObserveNetworkConnectivityUseCase.self)
-            ))
+            homeView
             .tabItem {
-                Image(systemName: "house.fill")
-                Text(String(localized: "nav_home"))
+                tabLabel(.home)
             }
             .tag(MainTab.home)
-            TodayView(viewModel: TodayViewModel(
-                fetchTodosUseCase: container.resolve(FetchTodosUseCase.self),
-                fetchTodoByIdUseCase: container.resolve(FetchTodoByIdUseCase.self),
-                upsertTodoUseCase: container.resolve(UpsertTodoUseCase.self),
-                fetchTodayDisplayOptionsUseCase: container.resolve(FetchTodayDisplayOptionsUseCase.self),
-                updateTodayDisplayOptionsUseCase: container.resolve(UpdateTodayDisplayOptionsUseCase.self)
-            ))
+
+            todayView
             .tabItem {
-                Image(systemName: "sun.max.fill")
-                Text(String(localized: "nav_today"))
+                tabLabel(.today)
             }
             .tag(MainTab.today)
-            PushNotificationListView(viewModel: PushNotificationListViewModel(
-                fetchUseCase: container.resolve(FetchPushNotificationsUseCase.self),
-                deleteUseCase: container.resolve(DeletePushNotificationUseCase.self),
-                undoDeleteUseCase: container.resolve(UndoDeletePushNotificationUseCase.self),
-                toggleReadUseCase: container.resolve(TogglePushNotificationReadUseCase.self),
-                fetchQueryUseCase: container.resolve(FetchPushNotificationQueryUseCase.self),
-                updateQueryUseCase: container.resolve(UpdatePushNotificationQueryUseCase.self)
-            ))
+
+            notificationView
             .tabItem {
-                Image(systemName: "bell.fill")
-                Text(String(localized: "nav_notifications"))
+                tabLabel(.notification)
             }
             .badge(viewModel.state.unreadPushCount)
             .tag(MainTab.notification)
-            ProfileView(viewModel: ProfileViewModel(
-                fetchUserDataUseCase: container.resolve(FetchUserDataUseCase.self),
-                fetchTodosUseCase: container.resolve(FetchTodosUseCase.self),
-                upsertStatusMessageUseCase: container.resolve(UpsertStatusMessageUseCase.self),
-                networkConnectivityUseCase: container.resolve(ObserveNetworkConnectivityUseCase.self),
-                fetchHeatmapActivityTypesUseCase: container.resolve(FetchHeatmapActivityTypesUseCase.self),
-                updateHeatmapActivityTypesUseCase: container.resolve(UpdateHeatmapActivityTypesUseCase.self)
-            ))
+
+            profileView
             .tabItem {
-                Image(systemName: "person.crop.circle.fill")
-                Text(String(localized: "nav_profile"))
+                tabLabel(.profile)
             }
             .tag(MainTab.profile)
         }
-        .onAppear {
-            viewModel.send(.onAppear)
+    }
+
+    private var sidebarView: some View {
+        NavigationSplitView {
+            List(selection: sidebarSelection) {
+                sidebarRow(.home)
+                sidebarRow(.today)
+                sidebarRow(.notification)
+                sidebarRow(.profile)
+            }
+            .listStyle(.sidebar)
+            .navigationTitle(Text(verbatim: "DevLog"))
+        } detail: {
+            selectedTabView
         }
-        .alert(
-            viewModel.state.alertTitle,
-            isPresented: Binding(
-                get: { viewModel.state.showAlert },
-                set: { viewModel.send(.setAlert($0)) }
-            )
-        ) {
-            Button(String(localized: "common_close"), role: .cancel) { }
-        } message: {
-            Text(viewModel.state.alertMessage)
+    }
+
+    @ViewBuilder
+    private var selectedTabView: some View {
+        switch selectedTab {
+        case .home:
+            homeView
+        case .today:
+            todayView
+        case .notification:
+            notificationView
+        case .profile:
+            profileView
+        }
+    }
+
+    @ViewBuilder
+    private func sidebarRow(_ tab: MainTab) -> some View {
+        if tab == .notification {
+            tabLabel(tab)
+                .badge(viewModel.state.unreadPushCount)
+                .tag(tab)
+        } else {
+            tabLabel(tab)
+                .tag(tab)
+        }
+    }
+
+    private func tabLabel(_ tab: MainTab) -> some View {
+        Label {
+            Text(tab.title)
+        } icon: {
+            Image(systemName: tab.symbolName)
+        }
+    }
+
+    private var homeView: some View {
+        HomeView(viewModel: HomeViewModel(
+            fetchPreferencesUseCase: container.resolve(FetchTodoCategoryPreferencesUseCase.self),
+            updatePreferencesUseCase: container.resolve(UpdateTodoCategoryPreferencesUseCase.self),
+            addWebPageUseCase: container.resolve(AddWebPageUseCase.self),
+            deleteWebPageUseCase: container.resolve(DeleteWebPageUseCase.self),
+            undoDeleteWebPageUseCase: container.resolve(UndoDeleteWebPageUseCase.self),
+            upsertTodoUseCase: container.resolve(UpsertTodoUseCase.self),
+            fetchTodosUseCase: container.resolve(FetchTodosUseCase.self),
+            fetchWebPagesUseCase: container.resolve(FetchWebPagesUseCase.self),
+            networkConnectivityUseCase: container.resolve(ObserveNetworkConnectivityUseCase.self)
+        ))
+    }
+
+    private var todayView: some View {
+        TodayView(viewModel: TodayViewModel(
+            fetchTodosUseCase: container.resolve(FetchTodosUseCase.self),
+            fetchTodoByIdUseCase: container.resolve(FetchTodoByIdUseCase.self),
+            upsertTodoUseCase: container.resolve(UpsertTodoUseCase.self),
+            fetchTodayDisplayOptionsUseCase: container.resolve(FetchTodayDisplayOptionsUseCase.self),
+            updateTodayDisplayOptionsUseCase: container.resolve(UpdateTodayDisplayOptionsUseCase.self)
+        ))
+    }
+
+    private var notificationView: some View {
+        PushNotificationListView(viewModel: PushNotificationListViewModel(
+            fetchUseCase: container.resolve(FetchPushNotificationsUseCase.self),
+            deleteUseCase: container.resolve(DeletePushNotificationUseCase.self),
+            undoDeleteUseCase: container.resolve(UndoDeletePushNotificationUseCase.self),
+            toggleReadUseCase: container.resolve(TogglePushNotificationReadUseCase.self),
+            fetchQueryUseCase: container.resolve(FetchPushNotificationQueryUseCase.self),
+            updateQueryUseCase: container.resolve(UpdatePushNotificationQueryUseCase.self)
+        ))
+    }
+
+    private var profileView: some View {
+        ProfileView(viewModel: ProfileViewModel(
+            fetchUserDataUseCase: container.resolve(FetchUserDataUseCase.self),
+            fetchTodosUseCase: container.resolve(FetchTodosUseCase.self),
+            upsertStatusMessageUseCase: container.resolve(UpsertStatusMessageUseCase.self),
+            networkConnectivityUseCase: container.resolve(ObserveNetworkConnectivityUseCase.self),
+            fetchHeatmapActivityTypesUseCase: container.resolve(FetchHeatmapActivityTypesUseCase.self),
+            updateHeatmapActivityTypesUseCase: container.resolve(UpdateHeatmapActivityTypesUseCase.self)
+        ))
+    }
+}
+
+private extension MainTab {
+    var title: String {
+        switch self {
+        case .home:
+            String(localized: "nav_home")
+        case .today:
+            String(localized: "nav_today")
+        case .notification:
+            String(localized: "nav_notifications")
+        case .profile:
+            String(localized: "nav_profile")
+        }
+    }
+
+    var symbolName: String {
+        switch self {
+        case .home:
+            "house.fill"
+        case .today:
+            "sun.max.fill"
+        case .notification:
+            "bell.fill"
+        case .profile:
+            "person.crop.circle.fill"
         }
     }
 }

--- a/DevLog/UI/Common/MainView.swift
+++ b/DevLog/UI/Common/MainView.swift
@@ -142,7 +142,6 @@ struct MainView: View {
                                 String(localized: "push_notifications_select_detail"),
                                 systemImage: "bell.badge"
                             )
-                            .background(Color(.secondarySystemBackground))
                         }
                     }
                     .background(Color(.secondarySystemBackground).ignoresSafeArea())
@@ -257,7 +256,6 @@ struct MainView: View {
                         String(localized: "home_select_detail"),
                         systemImage: "house"
                     )
-                    .background(Color(.secondarySystemBackground))
                 }
             }
             .navigationDestination(for: HomeRoute.self) { homeRoute in
@@ -364,7 +362,6 @@ struct MainView: View {
                         String(localized: "today_select_detail"),
                         systemImage: "sun.max"
                     )
-                    .background(Color(.secondarySystemBackground))
                 }
             }
             .navigationDestination(for: TodayRoute.self) { todayRoute in

--- a/DevLog/UI/Common/MainView.swift
+++ b/DevLog/UI/Common/MainView.swift
@@ -58,29 +58,29 @@ struct MainView: View {
     private var tabView: some View {
         TabView(selection: $selectedTab) {
             homeView
-            .tabItem {
-                tabLabel(.home)
-            }
-            .tag(MainTab.home)
+                .tabItem {
+                    tabLabel(.home)
+                }
+                .tag(MainTab.home)
 
             todayView
-            .tabItem {
-                tabLabel(.today)
-            }
-            .tag(MainTab.today)
+                .tabItem {
+                    tabLabel(.today)
+                }
+                .tag(MainTab.today)
 
             notificationView
-            .tabItem {
-                tabLabel(.notification)
-            }
-            .badge(viewModel.state.unreadPushCount)
-            .tag(MainTab.notification)
+                .tabItem {
+                    tabLabel(.notification)
+                }
+                .badge(viewModel.state.unreadPushCount)
+                .tag(MainTab.notification)
 
             profileView
-            .tabItem {
-                tabLabel(.profile)
-            }
-            .tag(MainTab.profile)
+                .tabItem {
+                    tabLabel(.profile)
+                }
+                .tag(MainTab.profile)
         }
     }
 

--- a/DevLog/UI/Common/MainView.swift
+++ b/DevLog/UI/Common/MainView.swift
@@ -11,7 +11,7 @@ struct MainView: View {
     @Environment(\.diContainer) var container: DIContainer
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @State var viewModel: MainViewModel
-    @State private var homeDetailDestination: HomeDetailDestination?
+    @State private var homeNavigationState = HomeNavigationState()
     @State private var todoIdToPresent: TodoIdItem?
     @Binding var selectedTab: MainTab
 
@@ -103,8 +103,9 @@ struct MainView: View {
                 } content: {
                     homeView
                 } detail: {
-                    homeDetailView
+                    homeRegularDetailView
                 }
+                .environment(homeNavigationState)
             case .today:
                 NavigationSplitView {
                     mainSidebar
@@ -198,10 +199,26 @@ struct MainView: View {
         }
     }
 
+    @ViewBuilder
     private var homeView: some View {
+        Group {
+            if isCompactLayout {
+                NavigationStack(path: $homeNavigationState.path) {
+                    homeContentView
+                        .navigationDestination(for: HomeRoute.self) { homeRoute in
+                            homeDestinationView(homeRoute)
+                        }
+                }
+            } else {
+                homeContentView
+            }
+        }
+        .environment(homeNavigationState)
+    }
+
+    private var homeContentView: some View {
         HomeView(
             viewModel: makeHomeViewModel(),
-            homeDetailDestination: $homeDetailDestination,
             isCompactLayout: isCompactLayout
         )
     }
@@ -220,64 +237,77 @@ struct MainView: View {
         )
     }
 
+    private var homeDetailPath: Binding<[HomeRoute]> {
+        Binding(
+            get: { homeNavigationState.detailPath },
+            set: { homeNavigationState.detailPath = $0 }
+        )
+    }
+
     @ViewBuilder
-    private var homeDetailView: some View {
-        Group {
-            switch homeDetailDestination {
-            case .category(let item):
-                TodoListView(
-                    viewModel: TodoListViewModel(
-                        fetchTodosUseCase: container.resolve(FetchTodosUseCase.self),
-                        fetchTodoByIdUseCase: container.resolve(FetchTodoByIdUseCase.self),
-                        upsertTodoUseCase: container.resolve(UpsertTodoUseCase.self),
-                        deleteTodoUseCase: container.resolve(DeleteTodoUseCase.self),
-                        undoDeleteTodoUseCase: container.resolve(UndoDeleteTodoUseCase.self),
-                        category: item.todoCategory
-                    ),
-                    todoIdToPresent: Binding(
-                        get: {
-                            if case .todo(let item) = homeDetailDestination {
-                                item
-                            } else {
-                                nil
-                            }
-                        },
-                        set: { item in
-                            if let item {
-                                homeDetailDestination = .todo(item)
-                            }
-                        }
-                    ),
-                    isCompactLayout: false
-                )
-                .id(item.id)
-            case .todo(let item):
-                TodoDetailView(viewModel: TodoDetailViewModel(
-                    fetchTodoUseCase: container.resolve(FetchTodoByIdUseCase.self),
-                    fetchReferenceItemsUseCase: container.resolve(FetchReferenceItemsUseCase.self),
-                    upsertUseCase: container.resolve(UpsertTodoUseCase.self),
-                    todoId: item.id
-                ))
-                .id(item.id)
-            case .webPage(let item):
-                WebView(url: item.url)
-                    .navigationBarTitleDisplayMode(.inline)
-                    .ignoresSafeArea()
-                    .toolbar {
-                        ToolbarItem(placement: .principal) {
-                            Text(item.title)
-                                .bold()
-                        }
-                    }
-            case .none:
-                ContentUnavailableView(
-                    String(localized: "home_select_detail"),
-                    systemImage: "house"
-                )
-                .background(Color(.secondarySystemBackground))
+    private var homeRegularDetailView: some View {
+        NavigationStack(path: homeDetailPath) {
+            Group {
+                if let homeRoute = homeNavigationState.root {
+                    homeDestinationView(homeRoute)
+                } else {
+                    ContentUnavailableView(
+                        String(localized: "home_select_detail"),
+                        systemImage: "house"
+                    )
+                    .background(Color(.secondarySystemBackground))
+                }
+            }
+            .navigationDestination(for: HomeRoute.self) { homeRoute in
+                homeDestinationView(homeRoute)
             }
         }
         .background(Color(.secondarySystemBackground).ignoresSafeArea())
+    }
+
+    @ViewBuilder
+    private func homeDestinationView(_ homeRoute: HomeRoute) -> some View {
+        switch homeRoute {
+        case .category(let item):
+            TodoListView(
+                viewModel: makeTodoListViewModel(category: item.todoCategory)
+            )
+            .id(item.id)
+        case .todo(let item):
+            TodoDetailView(viewModel: makeTodoDetailViewModel(todoId: item.id))
+            .id(item.id)
+        case .webPage(let item):
+            WebView(url: item.url)
+                .navigationBarTitleDisplayMode(.inline)
+                .ignoresSafeArea()
+                .toolbar(.hidden, for: .tabBar)
+                .toolbar {
+                    ToolbarItem(placement: .principal) {
+                        Text(item.title)
+                            .bold()
+                    }
+                }
+        }
+    }
+
+    private func makeTodoListViewModel(category: TodoCategory) -> TodoListViewModel {
+        TodoListViewModel(
+            fetchTodosUseCase: container.resolve(FetchTodosUseCase.self),
+            fetchTodoByIdUseCase: container.resolve(FetchTodoByIdUseCase.self),
+            upsertTodoUseCase: container.resolve(UpsertTodoUseCase.self),
+            deleteTodoUseCase: container.resolve(DeleteTodoUseCase.self),
+            undoDeleteTodoUseCase: container.resolve(UndoDeleteTodoUseCase.self),
+            category: category
+        )
+    }
+
+    private func makeTodoDetailViewModel(todoId: String) -> TodoDetailViewModel {
+        TodoDetailViewModel(
+            fetchTodoUseCase: container.resolve(FetchTodoByIdUseCase.self),
+            fetchReferenceItemsUseCase: container.resolve(FetchReferenceItemsUseCase.self),
+            upsertUseCase: container.resolve(UpsertTodoUseCase.self),
+            todoId: todoId
+        )
     }
 
     private var todayView: some View {

--- a/DevLog/UI/Common/NavigationRouter.swift
+++ b/DevLog/UI/Common/NavigationRouter.swift
@@ -8,12 +8,31 @@
 import SwiftUI
 
 @Observable
-final class NavigationRouter {
-    var path = NavigationPath()
+final class NavigationRouter<Route: Hashable> {
+    var path: [Route] = []
 
-    func push(_ element: any Hashable) {
-        Task { @MainActor in
-            path.append(element)
+    var root: Route? {
+        path.first
+    }
+
+    var detailPath: [Route] {
+        get {
+            Array(path.dropFirst())
         }
+        set {
+            if let route = root {
+                path = [route] + newValue
+            } else {
+                path = newValue
+            }
+        }
+    }
+
+    func show(_ route: Route) {
+        path = [route]
+    }
+
+    func push(_ route: Route) {
+        path.append(route)
     }
 }

--- a/DevLog/UI/Home/HomeView.swift
+++ b/DevLog/UI/Home/HomeView.swift
@@ -11,6 +11,8 @@ struct HomeView: View {
     @Environment(\.diContainer) var container: any DIContainer
     @State private var router = NavigationRouter()
     @State var viewModel: HomeViewModel
+    @Binding var homeDetailDestination: HomeDetailDestination?
+    let isCompactLayout: Bool
     @ScaledMetric(relativeTo: .largeTitle) private var labelWidth = CGFloat(34)
 
     var body: some View {
@@ -25,14 +27,31 @@ struct HomeView: View {
             .navigationDestination(for: Path.self) { path in
                 switch path {
                 case .category(let item):
-                    TodoListView(viewModel: TodoListViewModel(
-                        fetchTodosUseCase: container.resolve(FetchTodosUseCase.self),
-                        fetchTodoByIdUseCase: container.resolve(FetchTodoByIdUseCase.self),
-                        upsertTodoUseCase: container.resolve(UpsertTodoUseCase.self),
-                        deleteTodoUseCase: container.resolve(DeleteTodoUseCase.self),
-                        undoDeleteTodoUseCase: container.resolve(UndoDeleteTodoUseCase.self),
-                        category: item.todoCategory
-                    ))
+                    TodoListView(
+                        viewModel: TodoListViewModel(
+                            fetchTodosUseCase: container.resolve(FetchTodosUseCase.self),
+                            fetchTodoByIdUseCase: container.resolve(FetchTodoByIdUseCase.self),
+                            upsertTodoUseCase: container.resolve(UpsertTodoUseCase.self),
+                            deleteTodoUseCase: container.resolve(DeleteTodoUseCase.self),
+                            undoDeleteTodoUseCase: container.resolve(UndoDeleteTodoUseCase.self),
+                            category: item.todoCategory
+                        ),
+                        todoIdToPresent: Binding(
+                            get: {
+                                if case .todo(let item) = homeDetailDestination {
+                                    item
+                                } else {
+                                    nil
+                                }
+                            },
+                            set: { item in
+                                if let item {
+                                    homeDetailDestination = .todo(item)
+                                }
+                            }
+                        ),
+                        isCompactLayout: isCompactLayout
+                    )
                     .environment(router)
                 case .detail(let todoId):
                     TodoDetailView(viewModel: TodoDetailViewModel(
@@ -168,13 +187,7 @@ struct HomeView: View {
             } else {
                 let preferences = viewModel.state.preferences
                 ForEach(preferences.filter { $0.isVisible }, id: \.id) { item in
-                    NavigationLink(value: Path.category(item)) {
-                        labelImage(
-                            text: item.localizedName,
-                            systemName: item.symbolName,
-                            imageColor: item.color
-                        )
-                    }
+                    todoCategoryRow(item)
                 }
             }
         }, header: {
@@ -209,9 +222,7 @@ struct HomeView: View {
                 }
             } else {
                 ForEach(viewModel.state.recentTodos, id: \.id) { todo in
-                    NavigationLink(value: Path.detail(todo.id)) {
-                        RecentTodoRow(todo: todo)
-                    }
+                    recentTodoRow(todo)
                 }
             }
         } header: {
@@ -290,9 +301,63 @@ struct HomeView: View {
         }
     }
 
+    @ViewBuilder
+    private func todoCategoryRow(_ item: TodoCategoryItem) -> some View {
+        if isCompactLayout {
+            NavigationLink(value: Path.category(item)) {
+                labelImage(
+                    text: item.localizedName,
+                    systemName: item.symbolName,
+                    imageColor: item.color
+                )
+            }
+        } else {
+            Button {
+                homeDetailDestination = .category(item)
+            } label: {
+                labelImage(
+                    text: item.localizedName,
+                    systemName: item.symbolName,
+                    imageColor: item.color
+                )
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
+    @ViewBuilder
+    private func recentTodoRow(_ item: RecentTodoItem) -> some View {
+        if isCompactLayout {
+            NavigationLink(value: Path.detail(item.id)) {
+                RecentTodoRow(todo: item)
+            }
+        } else {
+            Button {
+                homeDetailDestination = .todo(TodoIdItem(id: item.id))
+            } label: {
+                RecentTodoRow(todo: item)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
+    @ViewBuilder
     private func webResultRow(_ item: WebPageItem) -> some View {
-        NavigationLink(value: Path.web(item)) {
-            WebItemRow(item: item, showsChevron: false)
+        Group {
+            if isCompactLayout {
+                NavigationLink(value: Path.web(item)) {
+                    WebItemRow(item: item, showsChevron: false)
+                }
+            } else {
+                Button {
+                    homeDetailDestination = .webPage(item)
+                } label: {
+                    WebItemRow(item: item, showsChevron: false)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .buttonStyle(.plain)
+            }
         }
         .swipeActions(edge: .trailing, allowsFullSwipe: true) {
             Button(role: .destructive) {
@@ -381,6 +446,7 @@ struct HomeView: View {
             Spacer()
         }
         .padding(.vertical, -6)
+        .contentShape(.rect)
     }
 
     private enum Path: Hashable {
@@ -388,6 +454,12 @@ struct HomeView: View {
         case detail(String)
         case web(WebPageItem)
     }
+}
+
+enum HomeDetailDestination: Hashable {
+    case category(TodoCategoryItem)
+    case todo(TodoIdItem)
+    case webPage(WebPageItem)
 }
 
 private struct RecentTodoRow: View {

--- a/DevLog/UI/Home/HomeView.swift
+++ b/DevLog/UI/Home/HomeView.swift
@@ -9,147 +9,95 @@ import SwiftUI
 
 struct HomeView: View {
     @Environment(\.diContainer) var container: any DIContainer
-    @State private var router = NavigationRouter()
+    @Environment(HomeNavigationState.self) var homeNavigationState
     @State var viewModel: HomeViewModel
-    @Binding var homeDetailDestination: HomeDetailDestination?
     let isCompactLayout: Bool
     @ScaledMetric(relativeTo: .largeTitle) private var labelWidth = CGFloat(34)
 
     var body: some View {
-        NavigationStack(path: $router.path) {
-            List {
-                todoSection
-                recentTodoSection
-                webPageSection
-            }
-            .listStyle(.insetGrouped)
-            .navigationTitle(String(localized: "nav_home"))
-            .navigationDestination(for: Path.self) { path in
-                switch path {
-                case .category(let item):
-                    TodoListView(
-                        viewModel: TodoListViewModel(
-                            fetchTodosUseCase: container.resolve(FetchTodosUseCase.self),
-                            fetchTodoByIdUseCase: container.resolve(FetchTodoByIdUseCase.self),
-                            upsertTodoUseCase: container.resolve(UpsertTodoUseCase.self),
-                            deleteTodoUseCase: container.resolve(DeleteTodoUseCase.self),
-                            undoDeleteTodoUseCase: container.resolve(UndoDeleteTodoUseCase.self),
-                            category: item.todoCategory
-                        ),
-                        todoIdToPresent: Binding(
-                            get: {
-                                if case .todo(let item) = homeDetailDestination {
-                                    item
-                                } else {
-                                    nil
-                                }
-                            },
-                            set: { item in
-                                if let item {
-                                    homeDetailDestination = .todo(item)
-                                }
-                            }
-                        ),
-                        isCompactLayout: isCompactLayout
-                    )
-                    .environment(router)
-                case .detail(let todoId):
-                    TodoDetailView(viewModel: TodoDetailViewModel(
-                        fetchTodoUseCase: container.resolve(FetchTodoByIdUseCase.self),
-                        fetchReferenceItemsUseCase: container.resolve(FetchReferenceItemsUseCase.self),
-                        upsertUseCase: container.resolve(UpsertTodoUseCase.self),
-                        todoId: todoId
-                    ))
-                case .web(let page):
-                    WebView(url: page.url)
-                        .navigationBarTitleDisplayMode(.inline)
-                        .ignoresSafeArea()
-                        .toolbar(.hidden, for: .tabBar)
-                        .toolbar {
-                            ToolbarItem(placement: .principal) {
-                                Text(page.title)
-                                    .bold()
-                            }
-                        }
-                }
-            }
-            .toolbar { toolbar }
-            .sheet(isPresented: Binding(
-                get: { viewModel.state.reorderTodo },
-                set: { viewModel.send(.setPresentation(.reorderTodo, $0)) }
-            )) {
-                TodoManageView(
-                    viewModel: TodoManageViewModel(viewModel.state.preferences),
-                    onDismiss: { array in
-                        viewModel.send(.setPresentation(.reorderTodo, false))
-                        withAnimation {
-                            viewModel.send(.orderTodoCategory(array))
-                        }
+        List {
+            todoSection
+            recentTodoSection
+            webPageSection
+        }
+        .listStyle(.insetGrouped)
+        .navigationTitle(String(localized: "nav_home"))
+        .toolbar { toolbar }
+        .sheet(isPresented: Binding(
+            get: { viewModel.state.reorderTodo },
+            set: { viewModel.send(.setPresentation(.reorderTodo, $0)) }
+        )) {
+            TodoManageView(
+                viewModel: TodoManageViewModel(viewModel.state.preferences),
+                onDismiss: { array in
+                    viewModel.send(.setPresentation(.reorderTodo, false))
+                    withAnimation {
+                        viewModel.send(.orderTodoCategory(array))
                     }
+                }
+            )
+        }
+        .sheet(isPresented: Binding(
+            get: { viewModel.state.showContentPicker },
+            set: { _, _ in }
+        )) {
+            contentPicker
+        }
+        .fullScreenCover(isPresented: Binding(
+            get: { viewModel.state.showTodoEditor },
+            set: { viewModel.send(.setPresentation(.todoEditor, $0)) }
+        )) {
+            if let selectedCategory = viewModel.state.selectedTodoCategory {
+                TodoEditorView(
+                    viewModel: TodoEditorViewModel(
+                        category: selectedCategory,
+                        fetchPreferencesUseCase: container.resolve(FetchTodoCategoryPreferencesUseCase.self),
+                        fetchReferenceItemsUseCase: container.resolve(FetchReferenceItemsUseCase.self)
+                    ),
+                    onSubmit: { viewModel.send(.addTodo($0)) }
                 )
             }
-            .sheet(isPresented: Binding(
-                get: { viewModel.state.showContentPicker },
-                set: { _, _ in }
-            )) {
-                contentPicker
-            }
-            .fullScreenCover(isPresented: Binding(
-                get: { viewModel.state.showTodoEditor },
-                set: { viewModel.send(.setPresentation(.todoEditor, $0)) }
-            )) {
-                if let selectedCategory = viewModel.state.selectedTodoCategory {
-                    TodoEditorView(
-                        viewModel: TodoEditorViewModel(
-                            category: selectedCategory,
-                            fetchPreferencesUseCase: container.resolve(FetchTodoCategoryPreferencesUseCase.self),
-                            fetchReferenceItemsUseCase: container.resolve(FetchReferenceItemsUseCase.self)
-                        ),
-                        onSubmit: { viewModel.send(.addTodo($0)) }
-                    )
-                }
-            }
-            .fullScreenCover(isPresented: Binding(
-                get: { viewModel.state.showSearchView },
-                set: { viewModel.send(.setPresentation(.searchView, $0)) }
-            )) {
-                SearchView(viewModel: SearchViewModel(
-                    fetchWebPagesUseCase: container.resolve(FetchWebPagesUseCase.self),
-                    fetchTodosUseCase: container.resolve(FetchTodosUseCase.self),
-                    fetchRecentSearchQueriesUseCase: container.resolve(FetchRecentSearchQueriesUseCase.self),
-                    updateRecentSearchQueriesUseCase: container.resolve(UpdateRecentSearchQueriesUseCase.self)
-                ))
-            }
-            .alert(
-                viewModel.state.alertTitle,
-                isPresented: Binding(
-                    get: { viewModel.state.showAlert },
-                    set: { viewModel.send(.setAlert(isPresented: $0)) }
-                )
-            ) {
-                alertButtons
-            } message: {
-                Text(viewModel.state.alertMessage)
-            }
-            .toast(
-                isPresented: Binding(
-                    get: { viewModel.state.showToast },
-                    set: { viewModel.send(.setToast(isPresented: $0)) }
-                ),
-                duration: 5,
-                action: { viewModel.send(.undoDeleteWebPage) }
-            ) {
-                Label(viewModel.state.toastMessage, systemImage: "arrow.uturn.left")
-                    .font(.caption)
-                    .multilineTextAlignment(.center)
-            }
-            .onAppear {
-                viewModel.send(.onAppear)
-            }
-            .overlay {
-                if viewModel.state.isAppending {
-                    LoadingView()
-                }
+        }
+        .fullScreenCover(isPresented: Binding(
+            get: { viewModel.state.showSearchView },
+            set: { viewModel.send(.setPresentation(.searchView, $0)) }
+        )) {
+            SearchView(viewModel: SearchViewModel(
+                fetchWebPagesUseCase: container.resolve(FetchWebPagesUseCase.self),
+                fetchTodosUseCase: container.resolve(FetchTodosUseCase.self),
+                fetchRecentSearchQueriesUseCase: container.resolve(FetchRecentSearchQueriesUseCase.self),
+                updateRecentSearchQueriesUseCase: container.resolve(UpdateRecentSearchQueriesUseCase.self)
+            ))
+        }
+        .alert(
+            viewModel.state.alertTitle,
+            isPresented: Binding(
+                get: { viewModel.state.showAlert },
+                set: { viewModel.send(.setAlert(isPresented: $0)) }
+            )
+        ) {
+            alertButtons
+        } message: {
+            Text(viewModel.state.alertMessage)
+        }
+        .toast(
+            isPresented: Binding(
+                get: { viewModel.state.showToast },
+                set: { viewModel.send(.setToast(isPresented: $0)) }
+            ),
+            duration: 5,
+            action: { viewModel.send(.undoDeleteWebPage) }
+        ) {
+            Label(viewModel.state.toastMessage, systemImage: "arrow.uturn.left")
+                .font(.caption)
+                .multilineTextAlignment(.center)
+        }
+        .onAppear {
+            viewModel.send(.onAppear)
+        }
+        .overlay {
+            if viewModel.state.isAppending {
+                LoadingView()
             }
         }
     }
@@ -304,7 +252,7 @@ struct HomeView: View {
     @ViewBuilder
     private func todoCategoryRow(_ item: TodoCategoryItem) -> some View {
         if isCompactLayout {
-            NavigationLink(value: Path.category(item)) {
+            NavigationLink(value: HomeRoute.category(item)) {
                 labelImage(
                     text: item.localizedName,
                     systemName: item.symbolName,
@@ -313,7 +261,7 @@ struct HomeView: View {
             }
         } else {
             Button {
-                homeDetailDestination = .category(item)
+                homeNavigationState.show(.category(item))
             } label: {
                 labelImage(
                     text: item.localizedName,
@@ -328,12 +276,12 @@ struct HomeView: View {
     @ViewBuilder
     private func recentTodoRow(_ item: RecentTodoItem) -> some View {
         if isCompactLayout {
-            NavigationLink(value: Path.detail(item.id)) {
+            NavigationLink(value: HomeRoute.todo(TodoIdItem(id: item.id))) {
                 RecentTodoRow(todo: item)
             }
         } else {
             Button {
-                homeDetailDestination = .todo(TodoIdItem(id: item.id))
+                homeNavigationState.show(.todo(TodoIdItem(id: item.id)))
             } label: {
                 RecentTodoRow(todo: item)
                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -346,12 +294,12 @@ struct HomeView: View {
     private func webResultRow(_ item: WebPageItem) -> some View {
         Group {
             if isCompactLayout {
-                NavigationLink(value: Path.web(item)) {
+                NavigationLink(value: HomeRoute.webPage(item)) {
                     WebItemRow(item: item, showsChevron: false)
                 }
             } else {
                 Button {
-                    homeDetailDestination = .webPage(item)
+                    homeNavigationState.show(.webPage(item))
                 } label: {
                     WebItemRow(item: item, showsChevron: false)
                         .frame(maxWidth: .infinity, alignment: .leading)
@@ -449,14 +397,39 @@ struct HomeView: View {
         .contentShape(.rect)
     }
 
-    private enum Path: Hashable {
-        case category(TodoCategoryItem)
-        case detail(String)
-        case web(WebPageItem)
+}
+
+@Observable
+final class HomeNavigationState {
+    var path: [HomeRoute] = []
+
+    var root: HomeRoute? {
+        path.first
+    }
+
+    var detailPath: [HomeRoute] {
+        get {
+            Array(path.dropFirst())
+        }
+        set {
+            if let homeRoute = root {
+                path = [homeRoute] + newValue
+            } else {
+                path = newValue
+            }
+        }
+    }
+
+    func show(_ homeRoute: HomeRoute) {
+        path = [homeRoute]
+    }
+
+    func push(_ homeRoute: HomeRoute) {
+        path.append(homeRoute)
     }
 }
 
-enum HomeDetailDestination: Hashable {
+enum HomeRoute: Hashable {
     case category(TodoCategoryItem)
     case todo(TodoIdItem)
     case webPage(WebPageItem)

--- a/DevLog/UI/Home/HomeView.swift
+++ b/DevLog/UI/Home/HomeView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct HomeView: View {
     @Environment(\.diContainer) var container: any DIContainer
-    @Environment(HomeNavigationState.self) var homeNavigationState
+    @Environment(NavigationRouter<HomeRoute>.self) private var router
     @State var viewModel: HomeViewModel
     let isCompactLayout: Bool
     @ScaledMetric(relativeTo: .largeTitle) private var labelWidth = CGFloat(34)
@@ -261,7 +261,7 @@ struct HomeView: View {
             }
         } else {
             Button {
-                homeNavigationState.show(.category(item))
+                router.show(.category(item))
             } label: {
                 labelImage(
                     text: item.localizedName,
@@ -281,7 +281,7 @@ struct HomeView: View {
             }
         } else {
             Button {
-                homeNavigationState.show(.todo(TodoIdItem(id: item.id)))
+                router.show(.todo(TodoIdItem(id: item.id)))
             } label: {
                 RecentTodoRow(todo: item)
                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -299,7 +299,7 @@ struct HomeView: View {
                 }
             } else {
                 Button {
-                    homeNavigationState.show(.webPage(item))
+                    router.show(.webPage(item))
                 } label: {
                     WebItemRow(item: item, showsChevron: false)
                         .frame(maxWidth: .infinity, alignment: .leading)
@@ -397,36 +397,6 @@ struct HomeView: View {
         .contentShape(.rect)
     }
 
-}
-
-@Observable
-final class HomeNavigationState {
-    var path: [HomeRoute] = []
-
-    var root: HomeRoute? {
-        path.first
-    }
-
-    var detailPath: [HomeRoute] {
-        get {
-            Array(path.dropFirst())
-        }
-        set {
-            if let homeRoute = root {
-                path = [homeRoute] + newValue
-            } else {
-                path = newValue
-            }
-        }
-    }
-
-    func show(_ homeRoute: HomeRoute) {
-        path = [homeRoute]
-    }
-
-    func push(_ homeRoute: HomeRoute) {
-        path.append(homeRoute)
-    }
 }
 
 enum HomeRoute: Hashable {

--- a/DevLog/UI/Home/TodoListView.swift
+++ b/DevLog/UI/Home/TodoListView.swift
@@ -8,13 +8,15 @@
 import SwiftUI
 
 struct TodoListView: View {
-    @State var viewModel: TodoListViewModel
-    @Environment(NavigationRouter.self) var router
+    @Environment(NavigationRouter.self) var router: NavigationRouter?
     @Environment(\.diContainer) var container: DIContainer
     @Environment(\.colorScheme) private var colorScheme
     @ScaledMetric(relativeTo: .body) private var headerHeight = 41
     @State private var headerOffset: CGFloat = .zero
     @State private var isScrollTrackingEnabled = false
+    @State var viewModel: TodoListViewModel
+    @Binding var todoIdToPresent: TodoIdItem?
+    let isCompactLayout: Bool
 
     var body: some View {
         Group {
@@ -121,10 +123,11 @@ struct TodoListView: View {
         .task { viewModel.send(.onAppear) }
     }
 
+    @ViewBuilder
     private var todoListContent: some View {
         let visibleTodos = viewModel.state.todos.filter { !$0.isHidden }
 
-        return ZStack {
+        ZStack {
             List {
                 Group {
                     if visibleTodos.isEmpty, !viewModel.state.isLoading {
@@ -138,7 +141,7 @@ struct TodoListView: View {
                     } else {
                         ForEach(Array(zip(visibleTodos.indices, visibleTodos)), id: \.1.id) { idx, todo in
                             Button {
-                                router.push(Path.detail(todo.id))
+                                selectTodo(todo.id)
                             } label: {
                                 TodoItemRow(todo)
                             }
@@ -268,7 +271,7 @@ struct TodoListView: View {
                 LazyVStack(spacing: 0) {
                     ForEach(displayedTodos) { todo in
                         Button {
-                            router.push(Path.detail(todo.id))
+                            selectTodo(todo.id)
                         } label: {
                             VStack(spacing: 0) {
                                 TodoItemRow(todo)
@@ -418,7 +421,15 @@ struct TodoListView: View {
             .background(Circle().fill(backgroundColor))
     }
 
-private enum Path: Hashable {
+    private func selectTodo(_ todoId: String) {
+        if isCompactLayout {
+            router?.push(Path.detail(todoId))
+        } else {
+            todoIdToPresent = TodoIdItem(id: todoId)
+        }
+    }
+
+    private enum Path: Hashable {
         case detail(String)
     }
 }

--- a/DevLog/UI/Home/TodoListView.swift
+++ b/DevLog/UI/Home/TodoListView.swift
@@ -8,15 +8,13 @@
 import SwiftUI
 
 struct TodoListView: View {
-    @Environment(NavigationRouter.self) var router: NavigationRouter?
+    @Environment(HomeNavigationState.self) private var homeNavigationState
     @Environment(\.diContainer) var container: DIContainer
     @Environment(\.colorScheme) private var colorScheme
     @ScaledMetric(relativeTo: .body) private var headerHeight = 41
     @State private var headerOffset: CGFloat = .zero
     @State private var isScrollTrackingEnabled = false
     @State var viewModel: TodoListViewModel
-    @Binding var todoIdToPresent: TodoIdItem?
-    let isCompactLayout: Bool
 
     var body: some View {
         Group {
@@ -51,17 +49,6 @@ struct TodoListView: View {
                         )
                     )
                 )
-            }
-        }
-        .navigationDestination(for: Path.self) { path in
-            switch path {
-            case .detail(let todoId):
-                TodoDetailView(viewModel: TodoDetailViewModel(
-                    fetchTodoUseCase: container.resolve(FetchTodoByIdUseCase.self),
-                    fetchReferenceItemsUseCase: container.resolve(FetchReferenceItemsUseCase.self),
-                    upsertUseCase: container.resolve(UpsertTodoUseCase.self),
-                    todoId: todoId
-                ))
             }
         }
         .alert(
@@ -422,14 +409,6 @@ struct TodoListView: View {
     }
 
     private func selectTodo(_ todoId: String) {
-        if isCompactLayout {
-            router?.push(Path.detail(todoId))
-        } else {
-            todoIdToPresent = TodoIdItem(id: todoId)
-        }
-    }
-
-    private enum Path: Hashable {
-        case detail(String)
+        homeNavigationState.push(.todo(TodoIdItem(id: todoId)))
     }
 }

--- a/DevLog/UI/Home/TodoListView.swift
+++ b/DevLog/UI/Home/TodoListView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct TodoListView: View {
-    @Environment(HomeNavigationState.self) private var homeNavigationState
+    @Environment(NavigationRouter<HomeRoute>.self) private var router
     @Environment(\.diContainer) var container: DIContainer
     @Environment(\.colorScheme) private var colorScheme
     @ScaledMetric(relativeTo: .body) private var headerHeight = 41
@@ -409,6 +409,6 @@ struct TodoListView: View {
     }
 
     private func selectTodo(_ todoId: String) {
-        homeNavigationState.push(.todo(TodoIdItem(id: todoId)))
+        router.push(.todo(TodoIdItem(id: todoId)))
     }
 }

--- a/DevLog/UI/Profile/ProfileView.swift
+++ b/DevLog/UI/Profile/ProfileView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct ProfileView: View {
     @State var viewModel: ProfileViewModel
-    @State private var router = NavigationRouter()
+    @State private var router = NavigationRouter<ProfileRoute>()
     @Environment(\.diContainer) private var container
     @FocusState private var focused: Bool
 
@@ -88,14 +88,14 @@ struct ProfileView: View {
                 ToolbarItem(placement: .topBarTrailing) {
                     HStack(spacing: 0) {
                         Button {
-                            router.push(Path.settings)
+                            router.push(.settings)
                         } label: {
                             Image(systemName: "gearshape")
                         }
                     }
                 }
             }
-            .navigationDestination(for: Path.self) { path in
+            .navigationDestination(for: ProfileRoute.self) { path in
                 switch path {
                 case .settings:
                     SettingView(viewModel: SettingViewModel(
@@ -116,6 +116,8 @@ struct ProfileView: View {
                         todoId: todoId,
                         showEditButton: false
                     ))
+                case .theme, .pushNotification, .account:
+                    EmptyView()
                 }
             }
             .onAppear { viewModel.send(.onAppear) }
@@ -350,7 +352,7 @@ struct ProfileView: View {
                 ForEach(activities) { activity in
                     Button {
                         if !activity.isDeleted {
-                            router.push(Path.activity(activity.todoId))
+                            router.push(.activity(activity.todoId))
                         }
                     } label: {
                         let item = TodoCategoryItem(from: activity.category)
@@ -395,8 +397,12 @@ struct ProfileView: View {
         .padding(.top, 4)
     }
 
-    private enum Path: Hashable {
-        case settings
-        case activity(String)
-    }
+}
+
+enum ProfileRoute: Hashable {
+    case settings
+    case activity(String)
+    case theme
+    case pushNotification
+    case account
 }

--- a/DevLog/UI/PushNotification/PushNotificationListView.swift
+++ b/DevLog/UI/PushNotification/PushNotificationListView.swift
@@ -8,18 +8,18 @@
 import SwiftUI
 
 struct PushNotificationListView: View {
-    @State var viewModel: PushNotificationListViewModel
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.diContainer) private var container: DIContainer
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @ScaledMetric(relativeTo: .body) private var headerHeight = 41
+    @ScaledMetric(relativeTo: .largeTitle) private var labelWidth = 34
+    @State var viewModel: PushNotificationListViewModel
     @State private var headerOffset: CGFloat = 0
     @State private var isScrollTrackingEnabled = false
-    @ScaledMetric(relativeTo: .largeTitle) private var labelWidth = CGFloat(34)
 
     var body: some View {
         NavigationSplitView {
             notificationList
-                .listStyle(.sidebar)
                 .background(NavigationBarConfigurator(.secondarySystemBackground, alwaysVisible: true))
                 .onScrollOffsetChange { offset in
                     guard isScrollTrackingEnabled else { return }
@@ -30,7 +30,15 @@ struct PushNotificationListView: View {
                 .refreshable { viewModel.send(.fetchNotifications) }
                 .navigationTitle(String(localized: "nav_push_notifications"))
         } detail: {
-            detailContent
+            if let todoIdItem = viewModel.state.selectedTodoId {
+                todoDetailView(todoId: todoIdItem.id)
+            } else {
+                ContentUnavailableView(
+                    String(localized: "push_notifications_select_detail"),
+                    systemImage: "bell.badge"
+                )
+                .background(Color(.secondarySystemBackground))
+            }
         }
         .background(Color(.secondarySystemBackground).ignoresSafeArea())
         .alert(
@@ -55,11 +63,46 @@ struct PushNotificationListView: View {
                 .multilineTextAlignment(.center)
                 .lineLimit(3)
         }
+        .sheet(item: Binding(
+            get: { isCompactLayout ? viewModel.state.selectedTodoId : nil },
+            set: { item in
+                if item == nil {
+                    viewModel.send(.selectNotification(nil))
+                }
+            }
+        )) { item in
+            NavigationStack {
+                todoDetailView(todoId: item.id)
+                    .toolbar {
+                        ToolbarLeadingButton {
+                            viewModel.send(.selectNotification(nil))
+                        }
+                    }
+            }
+            .background(Color(.secondarySystemBackground))
+            .presentationDragIndicator(.visible)
+        }
         .overlay {
             if viewModel.state.isLoading {
                 LoadingView()
             }
         }
+    }
+
+    private var isCompactLayout: Bool {
+        horizontalSizeClass == .compact
+    }
+
+    @ViewBuilder
+    private func todoDetailView(todoId: String) -> some View {
+        TodoDetailView(viewModel: TodoDetailViewModel(
+            fetchTodoUseCase: container.resolve(FetchTodoByIdUseCase.self),
+            fetchReferenceItemsUseCase: container.resolve(FetchReferenceItemsUseCase.self),
+            upsertUseCase: container.resolve(UpsertTodoUseCase.self),
+            todoId: todoId,
+            showEditButton: false
+        ))
+        .id(todoId)
     }
 
     @ViewBuilder
@@ -75,54 +118,35 @@ struct PushNotificationListView: View {
         } else {
             List(
                 Array(zip(notifications.indices, notifications)),
-                id: \.1.id,
-                selection: Binding(
-                    get: { viewModel.state.selectedNotificationId },
-                    set: { viewModel.send(.selectNotification($0)) }
-                )
+                id: \.1.id
             ) { index, notification in
-                NavigationLink(value: notification.id) {
-                    notificationRow(notification)
-                        .padding(.vertical, 8)
-                        .onAppear {
-                            let lastId = notifications.last?.id
-                            if notification.id == lastId, viewModel.state.hasMore {
-                                viewModel.send(.loadNextPage)
+                Button {
+                    viewModel.send(.selectNotification(notification.id))
+                } label: {
+                    notificationRow(
+                        notification,
+                        isSelected: !isCompactLayout && viewModel.state.selectedNotificationId == notification.id
+                    )
+                    .onAppear {
+                        let lastId = notifications.last?.id
+                        if notification.id == lastId, viewModel.state.hasMore {
+                            viewModel.send(.loadNextPage)
+                        }
+                    }
+                    .overlay(alignment: .top) {
+                        if #available(iOS 26.0, *) {
+                            if index == 0 {
+                                Divider()
+                                    .padding(.horizontal, -16)
                             }
                         }
-                        .overlay(alignment: .top) {
-                            if #available(iOS 26.0, *) {
-                                if index == 0 {
-                                    Divider()
-                                        .padding(.horizontal, -16)
-                                }
-                            }
-                        }
+                    }
                 }
-                .listRowInsets(EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16))
+                .buttonStyle(.plain)
+                .listRowInsets(EdgeInsets())
                 .listSectionSeparator(.hidden, edges: .top)
                 .listRowBackground(Color.clear)
             }
-        }
-    }
-
-    @ViewBuilder
-    private var detailContent: some View {
-        if let todoIdItem = viewModel.state.selectedTodoId {
-            TodoDetailView(viewModel: TodoDetailViewModel(
-                fetchTodoUseCase: container.resolve(FetchTodoByIdUseCase.self),
-                fetchReferenceItemsUseCase: container.resolve(FetchReferenceItemsUseCase.self),
-                upsertUseCase: container.resolve(UpsertTodoUseCase.self),
-                todoId: todoIdItem.id,
-                showEditButton: false
-            ))
-            .id(todoIdItem.id)
-        } else {
-            ContentUnavailableView(
-                String(localized: "push_notifications_select_detail"),
-                systemImage: "bell.badge"
-            )
-            .background(Color(.secondarySystemBackground))
         }
     }
 
@@ -257,7 +281,10 @@ struct PushNotificationListView: View {
     }
 
     // swiftlint:disable function_body_length
-    private func notificationRow(_ item: PushNotificationItem) -> some View {
+    private func notificationRow(
+        _ item: PushNotificationItem,
+        isSelected: Bool
+    ) -> some View {
         HStack {
             VStack {
                 let todoCategoryItem = TodoCategoryItem(from: item.todoCategory)

--- a/DevLog/UI/PushNotification/PushNotificationListView.swift
+++ b/DevLog/UI/PushNotification/PushNotificationListView.swift
@@ -309,7 +309,7 @@ struct PushNotificationListView: View {
                     .lineLimit(1)
                 Text(item.body)
                     .font(.subheadline)
-                    .foregroundStyle(Color.gray)
+                    .foregroundStyle(isSelected ? Color.white : .gray)
                     .lineLimit(1)
             }
             
@@ -318,7 +318,7 @@ struct PushNotificationListView: View {
             TimelineView(.periodic(from: .now, by: 1.0)) { context in
                 Text(timeAgoText(from: item.receivedAt, now: context.date))
                     .font(.caption2)
-                    .foregroundStyle(Color.gray)
+                    .foregroundStyle(isSelected ? Color.white : .gray)
             }
         }
         .padding(8)

--- a/DevLog/UI/PushNotification/PushNotificationListView.swift
+++ b/DevLog/UI/PushNotification/PushNotificationListView.swift
@@ -15,6 +15,7 @@ struct PushNotificationListView: View {
     @State var viewModel: PushNotificationListViewModel
     @State private var headerOffset: CGFloat = 0
     @State private var isScrollTrackingEnabled = false
+    @Binding var todoIdToPresent: TodoIdItem?
     let isCompactLayout: Bool
 
     var body: some View {
@@ -46,10 +47,10 @@ struct PushNotificationListView: View {
                 .lineLimit(3)
         }
         .sheet(item: Binding(
-            get: { isCompactLayout ? viewModel.state.selectedTodoId : nil },
+            get: { isCompactLayout ? todoIdToPresent : nil },
             set: { item in
                 if item == nil {
-                    viewModel.send(.selectNotification(nil))
+                    selectNotification(nil)
                 }
             }
         )) { item in
@@ -64,7 +65,7 @@ struct PushNotificationListView: View {
                 .id(item.id)
                 .toolbar {
                     ToolbarLeadingButton {
-                        viewModel.send(.selectNotification(nil))
+                        selectNotification(nil)
                     }
                 }
             }
@@ -122,7 +123,7 @@ struct PushNotificationListView: View {
     ) -> some View {
         if isCompactLayout {
             Button {
-                viewModel.send(.selectNotification(notification.id))
+                selectNotification(notification.id)
             } label: {
                 notificationRowContent(notification, index: index, notifications: notifications)
             }
@@ -130,11 +131,11 @@ struct PushNotificationListView: View {
         } else {
             notificationRowContent(notification, index: index, notifications: notifications)
                 .onTapGesture {
-                    viewModel.send(.selectNotification(notification.id))
+                    selectNotification(notification.id)
                 }
                 .accessibilityAddTraits(.isButton)
                 .accessibilityAction {
-                    viewModel.send(.selectNotification(notification.id))
+                    selectNotification(notification.id)
                 }
         }
     }
@@ -389,5 +390,10 @@ struct PushNotificationListView: View {
                 Int64(days)
             )
         }
+    }
+
+    private func selectNotification(_ notificationId: String?) {
+        viewModel.send(.selectNotification(notificationId))
+        todoIdToPresent = viewModel.state.selectedTodoId
     }
 }

--- a/DevLog/UI/PushNotification/PushNotificationListView.swift
+++ b/DevLog/UI/PushNotification/PushNotificationListView.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 
 struct PushNotificationListView: View {
-    @State private var router = NavigationRouter()
     @State var viewModel: PushNotificationListViewModel
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.diContainer) private var container: DIContainer
@@ -18,66 +17,47 @@ struct PushNotificationListView: View {
     @ScaledMetric(relativeTo: .largeTitle) private var labelWidth = CGFloat(34)
 
     var body: some View {
-        NavigationStack(path: $router.path) {
+        NavigationSplitView {
             notificationList
-            .listStyle(.plain)
-            .background(NavigationBarConfigurator(.secondarySystemBackground, alwaysVisible: true))
-            .onScrollOffsetChange { offset in
-                guard isScrollTrackingEnabled else { return }
-                headerOffset = max(0, -offset)
-            }
-            .safeAreaInset(edge: .top) { safeAreaHeader }
-            .background(Color(.secondarySystemBackground))
-            .onAppear { viewModel.send(.fetchNotifications) }
-            .refreshable { viewModel.send(.fetchNotifications) }
-            .navigationTitle(String(localized: "nav_push_notifications"))
-            .alert(
-                "",
-                isPresented: Binding(
-                    get: { viewModel.state.showAlert },
-                    set: { viewModel.send(.setAlert(isPresented: $0)) }
-            )) {
-                Button(String(localized: "common_close"), role: .cancel) { }
-            } message: {
-                Text(viewModel.state.alertMessage)
-            }
-            .toast(
-                isPresented: Binding(
-                    get: { viewModel.state.showToast },
-                    set: { viewModel.send(.setToast(isPresented: $0)) }),
-                duration: 5,
-                action: { viewModel.send(.undoDelete) }
-            ) {
-                Label(viewModel.state.toastMessage, systemImage: "arrow.uturn.left")
-                    .font(.caption)
-                    .multilineTextAlignment(.center)
-                    .lineLimit(3)
-            }
-            .sheet(item: Binding(
-                get: { viewModel.state.selectedTodoId },
-                set: { viewModel.send(.setSelectedTodoId($0)) }
-            )) { item in
-                NavigationStack {
-                    TodoDetailView(viewModel: TodoDetailViewModel(
-                        fetchTodoUseCase: container.resolve(FetchTodoByIdUseCase.self),
-                        fetchReferenceItemsUseCase: container.resolve(FetchReferenceItemsUseCase.self),
-                        upsertUseCase: container.resolve(UpsertTodoUseCase.self),
-                        todoId: item.id,
-                        showEditButton: false
-                    ))
-                    .toolbar {
-                        ToolbarLeadingButton {
-                            viewModel.send(.setSelectedTodoId(nil))
-                        }
-                    }
+                .listStyle(.sidebar)
+                .background(NavigationBarConfigurator(.secondarySystemBackground, alwaysVisible: true))
+                .onScrollOffsetChange { offset in
+                    guard isScrollTrackingEnabled else { return }
+                    headerOffset = max(0, -offset)
                 }
-                .background(Color(.secondarySystemBackground))
-                .presentationDragIndicator(.visible)
-            }
-            .overlay {
-                if viewModel.state.isLoading {
-                    LoadingView()
-                }
+                .safeAreaInset(edge: .top) { safeAreaHeader }
+                .onAppear { viewModel.send(.fetchNotifications) }
+                .refreshable { viewModel.send(.fetchNotifications) }
+                .navigationTitle(String(localized: "nav_push_notifications"))
+        } detail: {
+            detailContent
+        }
+        .background(Color(.secondarySystemBackground).ignoresSafeArea())
+        .alert(
+            "",
+            isPresented: Binding(
+                get: { viewModel.state.showAlert },
+                set: { viewModel.send(.setAlert(isPresented: $0)) }
+        )) {
+            Button(String(localized: "common_close"), role: .cancel) { }
+        } message: {
+            Text(viewModel.state.alertMessage)
+        }
+        .toast(
+            isPresented: Binding(
+                get: { viewModel.state.showToast },
+                set: { viewModel.send(.setToast(isPresented: $0)) }),
+            duration: 5,
+            action: { viewModel.send(.undoDelete) }
+        ) {
+            Label(viewModel.state.toastMessage, systemImage: "arrow.uturn.left")
+                .font(.caption)
+                .multilineTextAlignment(.center)
+                .lineLimit(3)
+        }
+        .overlay {
+            if viewModel.state.isLoading {
+                LoadingView()
             }
         }
     }
@@ -123,6 +103,26 @@ struct PushNotificationListView: View {
                 .listSectionSeparator(.hidden, edges: .top)
                 .listRowBackground(Color.clear)
             }
+        }
+    }
+
+    @ViewBuilder
+    private var detailContent: some View {
+        if let todoIdItem = viewModel.state.selectedTodoId {
+            TodoDetailView(viewModel: TodoDetailViewModel(
+                fetchTodoUseCase: container.resolve(FetchTodoByIdUseCase.self),
+                fetchReferenceItemsUseCase: container.resolve(FetchReferenceItemsUseCase.self),
+                upsertUseCase: container.resolve(UpsertTodoUseCase.self),
+                todoId: todoIdItem.id,
+                showEditButton: false
+            ))
+            .id(todoIdItem.id)
+        } else {
+            ContentUnavailableView(
+                String(localized: "push_notifications_select_detail"),
+                systemImage: "bell.badge"
+            )
+            .background(Color(.secondarySystemBackground))
         }
     }
 
@@ -278,6 +278,7 @@ struct PushNotificationListView: View {
             VStack(alignment: .leading, spacing: 5) {
                 Text(item.title)
                     .font(.headline)
+                    .foregroundStyle(Color(.label))
                     .lineLimit(1)
                 Text(item.body)
                     .font(.subheadline)

--- a/DevLog/UI/PushNotification/PushNotificationListView.swift
+++ b/DevLog/UI/PushNotification/PushNotificationListView.swift
@@ -82,50 +82,43 @@ struct PushNotificationListView: View {
         }
     }
 
+    @ViewBuilder
     private var notificationList: some View {
-        let visibleNotifications = viewModel.state.notifications.filter { !$0.isHidden }
-        return List {
-            Group {
-                if visibleNotifications.isEmpty {
-                    HStack {
-                        Spacer()
-                        Text(String(localized: "push_notifications_empty"))
-                            .foregroundStyle(Color.gray)
-                        Spacer()
-                    }
-                    .listRowSeparator(.hidden)
-                } else {
-                    ForEach(
-                        Array(zip(visibleNotifications.indices, visibleNotifications)),
-                        id: \.1.id
-                    ) { index, notification in
-                        Button {
-                            viewModel.send(.tapNotification(notification))
-                        } label: {
-                            notificationRow(notification)
-                                .padding(.vertical, 8)
-                        }
-                        .buttonStyle(.plain)
-                        .onAppear {
-                            let lastId = visibleNotifications.last?.id
-                            if notification.id == lastId, viewModel.state.hasMore {
-                                viewModel.send(.loadNextPage)
-                            }
-                        }
-                        .listRowInsets(EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16))
-                        .overlay(alignment: .top) {
-                            if #available(iOS 26.0, *) {
-                                if index == 0 {
-                                    Divider()
-                                        .padding(.horizontal, -16)
-                                }
-                            }
-                        }
-                    }
-                }
+        let notifications = viewModel.state.notifications.filter { !$0.isHidden }
+        if notifications.isEmpty {
+            HStack {
+                Spacer()
+                Text(String(localized: "push_notifications_empty"))
+                    .foregroundStyle(Color.gray)
+                Spacer()
             }
-            .listSectionSeparator(.hidden, edges: .top)
-            .listRowBackground(Color.clear)
+        } else {
+            List(
+                Array(zip(notifications.indices, notifications)),
+                id: \.1.id,
+                selection: selectedNotificationIdBinding
+            ) { index, notification in
+                notificationRow(notification)
+                    .padding(.vertical, 8)
+                    .tag(notification.id)
+                    .onAppear {
+                        let lastId = notifications.last?.id
+                        if notification.id == lastId, viewModel.state.hasMore {
+                            viewModel.send(.loadNextPage)
+                        }
+                    }
+                    .listRowInsets(EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16))
+                    .overlay(alignment: .top) {
+                        if #available(iOS 26.0, *) {
+                            if index == 0 {
+                                Divider()
+                                    .padding(.horizontal, -16)
+                            }
+                        }
+                    }
+                    .listSectionSeparator(.hidden, edges: .top)
+                    .listRowBackground(Color.clear)
+            }
         }
     }
 

--- a/DevLog/UI/PushNotification/PushNotificationListView.swift
+++ b/DevLog/UI/PushNotification/PushNotificationListView.swift
@@ -305,7 +305,7 @@ struct PushNotificationListView: View {
             VStack(alignment: .leading, spacing: 5) {
                 Text(item.title)
                     .font(.headline)
-                    .foregroundStyle(Color(.label))
+                    .foregroundStyle(isSelected ? Color.white : Color(.label))
                     .lineLimit(1)
                 Text(item.body)
                     .font(.subheadline)
@@ -321,8 +321,12 @@ struct PushNotificationListView: View {
                     .foregroundStyle(Color.gray)
             }
         }
-        .padding(.vertical, 5)
-        .contentShape(.rect)
+        .padding(8)
+        .contentShape(RoundedRectangle(cornerRadius: 8))
+        .background {
+            RoundedRectangle(cornerRadius: 8)
+                .fill(isSelected ? Color.blue : .clear)
+        }
         .swipeActions(edge: .leading) {
             Button {
                 viewModel.send(.toggleRead(item))

--- a/DevLog/UI/PushNotification/PushNotificationListView.swift
+++ b/DevLog/UI/PushNotification/PushNotificationListView.swift
@@ -10,36 +10,18 @@ import SwiftUI
 struct PushNotificationListView: View {
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.diContainer) private var container: DIContainer
-    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @ScaledMetric(relativeTo: .body) private var headerHeight = 41
     @ScaledMetric(relativeTo: .largeTitle) private var labelWidth = 34
     @State var viewModel: PushNotificationListViewModel
     @State private var headerOffset: CGFloat = 0
     @State private var isScrollTrackingEnabled = false
+    let isCompactLayout: Bool
 
     var body: some View {
-        NavigationSplitView {
-            notificationList
-                .background(NavigationBarConfigurator(.secondarySystemBackground, alwaysVisible: true))
-                .onScrollOffsetChange { offset in
-                    guard isScrollTrackingEnabled else { return }
-                    headerOffset = max(0, -offset)
-                }
-                .safeAreaInset(edge: .top) { safeAreaHeader }
-                .onAppear { viewModel.send(.fetchNotifications) }
-                .refreshable { viewModel.send(.fetchNotifications) }
-                .navigationTitle(String(localized: "nav_push_notifications"))
-        } detail: {
-            if let todoIdItem = viewModel.state.selectedTodoId {
-                todoDetailView(todoId: todoIdItem.id)
-            } else {
-                ContentUnavailableView(
-                    String(localized: "push_notifications_select_detail"),
-                    systemImage: "bell.badge"
-                )
-                .background(Color(.secondarySystemBackground))
-            }
+        NavigationStack {
+            notificationListContent
         }
+        .listStyle(.sidebar)
         .background(Color(.secondarySystemBackground).ignoresSafeArea())
         .alert(
             "",
@@ -72,12 +54,19 @@ struct PushNotificationListView: View {
             }
         )) { item in
             NavigationStack {
-                todoDetailView(todoId: item.id)
-                    .toolbar {
-                        ToolbarLeadingButton {
-                            viewModel.send(.selectNotification(nil))
-                        }
+                TodoDetailView(viewModel: TodoDetailViewModel(
+                    fetchTodoUseCase: container.resolve(FetchTodoByIdUseCase.self),
+                    fetchReferenceItemsUseCase: container.resolve(FetchReferenceItemsUseCase.self),
+                    upsertUseCase: container.resolve(UpsertTodoUseCase.self),
+                    todoId: item.id,
+                    showEditButton: false
+                ))
+                .id(item.id)
+                .toolbar {
+                    ToolbarLeadingButton {
+                        viewModel.send(.selectNotification(nil))
                     }
+                }
             }
             .background(Color(.secondarySystemBackground))
             .presentationDragIndicator(.visible)
@@ -89,20 +78,17 @@ struct PushNotificationListView: View {
         }
     }
 
-    private var isCompactLayout: Bool {
-        horizontalSizeClass == .compact
-    }
-
-    @ViewBuilder
-    private func todoDetailView(todoId: String) -> some View {
-        TodoDetailView(viewModel: TodoDetailViewModel(
-            fetchTodoUseCase: container.resolve(FetchTodoByIdUseCase.self),
-            fetchReferenceItemsUseCase: container.resolve(FetchReferenceItemsUseCase.self),
-            upsertUseCase: container.resolve(UpsertTodoUseCase.self),
-            todoId: todoId,
-            showEditButton: false
-        ))
-        .id(todoId)
+    private var notificationListContent: some View {
+        notificationList
+            .background(NavigationBarConfigurator(.secondarySystemBackground, alwaysVisible: true))
+            .onScrollOffsetChange { offset in
+                guard isScrollTrackingEnabled else { return }
+                headerOffset = max(0, -offset)
+            }
+            .safeAreaInset(edge: .top) { safeAreaHeader }
+            .onAppear { viewModel.send(.fetchNotifications) }
+            .refreshable { viewModel.send(.fetchNotifications) }
+            .navigationTitle(String(localized: "nav_push_notifications"))
     }
 
     @ViewBuilder
@@ -120,32 +106,60 @@ struct PushNotificationListView: View {
                 Array(zip(notifications.indices, notifications)),
                 id: \.1.id
             ) { index, notification in
-                Button {
-                    viewModel.send(.selectNotification(notification.id))
-                } label: {
-                    notificationRow(
-                        notification,
-                        isSelected: !isCompactLayout && viewModel.state.selectedNotificationId == notification.id
-                    )
-                    .onAppear {
-                        let lastId = notifications.last?.id
-                        if notification.id == lastId, viewModel.state.hasMore {
-                            viewModel.send(.loadNextPage)
-                        }
-                    }
-                    .overlay(alignment: .top) {
-                        if #available(iOS 26.0, *) {
-                            if index == 0 {
-                                Divider()
-                                    .padding(.horizontal, -16)
-                            }
-                        }
-                    }
-                }
-                .buttonStyle(.plain)
+                notificationListRow(notification, index: index, notifications: notifications)
                 .listRowInsets(EdgeInsets())
                 .listSectionSeparator(.hidden, edges: .top)
                 .listRowBackground(Color.clear)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func notificationListRow(
+        _ notification: PushNotificationItem,
+        index: Int,
+        notifications: [PushNotificationItem]
+    ) -> some View {
+        if isCompactLayout {
+            Button {
+                viewModel.send(.selectNotification(notification.id))
+            } label: {
+                notificationRowContent(notification, index: index, notifications: notifications)
+            }
+            .buttonStyle(.plain)
+        } else {
+            notificationRowContent(notification, index: index, notifications: notifications)
+                .onTapGesture {
+                    viewModel.send(.selectNotification(notification.id))
+                }
+                .accessibilityAddTraits(.isButton)
+                .accessibilityAction {
+                    viewModel.send(.selectNotification(notification.id))
+                }
+        }
+    }
+
+    private func notificationRowContent(
+        _ notification: PushNotificationItem,
+        index: Int,
+        notifications: [PushNotificationItem]
+    ) -> some View {
+        notificationRow(
+            notification,
+            isSelected: !isCompactLayout && viewModel.state.selectedNotificationId == notification.id
+        )
+        .onAppear {
+            let lastId = notifications.last?.id
+            if notification.id == lastId, viewModel.state.hasMore {
+                viewModel.send(.loadNextPage)
+            }
+        }
+        .overlay(alignment: .top) {
+            if #available(iOS 26.0, *) {
+                if index == 0 {
+                    Divider()
+                        .padding(.horizontal, -16)
+                }
             }
         }
     }

--- a/DevLog/UI/PushNotification/PushNotificationListView.swift
+++ b/DevLog/UI/PushNotification/PushNotificationListView.swift
@@ -96,28 +96,32 @@ struct PushNotificationListView: View {
             List(
                 Array(zip(notifications.indices, notifications)),
                 id: \.1.id,
-                selection: selectedNotificationIdBinding
+                selection: Binding(
+                    get: { viewModel.state.selectedNotificationId },
+                    set: { viewModel.send(.selectNotification($0)) }
+                )
             ) { index, notification in
-                notificationRow(notification)
-                    .padding(.vertical, 8)
-                    .tag(notification.id)
-                    .onAppear {
-                        let lastId = notifications.last?.id
-                        if notification.id == lastId, viewModel.state.hasMore {
-                            viewModel.send(.loadNextPage)
-                        }
-                    }
-                    .listRowInsets(EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16))
-                    .overlay(alignment: .top) {
-                        if #available(iOS 26.0, *) {
-                            if index == 0 {
-                                Divider()
-                                    .padding(.horizontal, -16)
+                NavigationLink(value: notification.id) {
+                    notificationRow(notification)
+                        .padding(.vertical, 8)
+                        .onAppear {
+                            let lastId = notifications.last?.id
+                            if notification.id == lastId, viewModel.state.hasMore {
+                                viewModel.send(.loadNextPage)
                             }
                         }
-                    }
-                    .listSectionSeparator(.hidden, edges: .top)
-                    .listRowBackground(Color.clear)
+                        .overlay(alignment: .top) {
+                            if #available(iOS 26.0, *) {
+                                if index == 0 {
+                                    Divider()
+                                        .padding(.horizontal, -16)
+                                }
+                            }
+                        }
+                }
+                .listRowInsets(EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16))
+                .listSectionSeparator(.hidden, edges: .top)
+                .listRowBackground(Color.clear)
             }
         }
     }

--- a/DevLog/UI/Search/SearchView.swift
+++ b/DevLog/UI/Search/SearchView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct SearchView: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.diContainer) private var container: DIContainer
-    @State private var router = NavigationRouter()
+    @State private var router = NavigationRouter<Path>()
     @State var viewModel: SearchViewModel
 
     var body: some View {

--- a/DevLog/UI/Setting/SettingView.swift
+++ b/DevLog/UI/Setting/SettingView.swift
@@ -9,15 +9,15 @@ import SwiftUI
 
 struct SettingView: View {
     @Environment(\.diContainer) var container: DIContainer
+    @Environment(NavigationRouter<ProfileRoute>.self) private var router
     @State var viewModel: SettingViewModel
-    @Environment(NavigationRouter.self) var router
 
     var body: some View {
         let connected = viewModel.state.isNetworkConnected
         Form {
             Section {
                 Button {
-                    router.push(Path.theme)
+                    router.push(.theme)
                 } label: {
                     HStack {
                         Text(String(localized: "settings_theme"))
@@ -29,7 +29,7 @@ struct SettingView: View {
                 }
 
                 Button {
-                    router.push(Path.pushNotification)
+                    router.push(.pushNotification)
                 } label: {
                     Text(String(localized: "settings_notifications"))
                         .foregroundStyle(connected ? Color.primary : Color.secondary)
@@ -83,7 +83,7 @@ struct SettingView: View {
             
             Section {
                 Button {
-                    router.push(Path.account)
+                    router.push(.account)
                 } label: {
                     Text(String(localized: "settings_account"))
                 }
@@ -110,7 +110,7 @@ struct SettingView: View {
         }
         .navigationTitle(String(localized: "nav_settings"))
         .navigationBarTitleDisplayMode(.inline)
-        .navigationDestination(for: Path.self) { path in
+        .navigationDestination(for: ProfileRoute.self) { path in
             switch path {
             case .theme:
                 ThemeView(
@@ -134,6 +134,8 @@ struct SettingView: View {
                         unlinkProviderUseCase: container.resolve(UnlinkAuthProviderUseCase.self)
                     )
                 )
+            case .settings, .activity:
+                EmptyView()
             }
         }
         .alert(
@@ -154,10 +156,6 @@ struct SettingView: View {
         .onAppear {
             viewModel.send(.updateDirSize)
         }
-    }
-
-    private enum Path: Hashable {
-        case theme, pushNotification, account
     }
 
     @ViewBuilder

--- a/DevLog/UI/Today/TodayView.swift
+++ b/DevLog/UI/Today/TodayView.swift
@@ -8,54 +8,41 @@
 import SwiftUI
 
 struct TodayView: View {
-    @Environment(\.diContainer) private var container: any DIContainer
-    @State private var router = NavigationRouter()
+    @Environment(TodayNavigationState.self) private var todayNavigationState
     @State var viewModel: TodayViewModel
+    let isCompactLayout: Bool
 
     var body: some View {
-        NavigationStack(path: $router.path) {
-            List {
-                summarySection
-                if viewModel.sections.isEmpty, !viewModel.state.isLoading {
-                    emptySection
-                } else {
-                    ForEach(viewModel.sections) { section in
-                        todoSection(section.title, items: section.items)
-                    }
+        List {
+            summarySection
+            if viewModel.sections.isEmpty, !viewModel.state.isLoading {
+                emptySection
+            } else {
+                ForEach(viewModel.sections) { section in
+                    todoSection(section.title, items: section.items)
                 }
             }
-            .listStyle(.insetGrouped)
-            .navigationTitle(String(localized: "nav_today"))
-            .toolbar { toolbarContent }
-            .navigationDestination(for: Path.self) { path in
-                switch path {
-                case .detail(let todoId):
-                    TodoDetailView(viewModel: TodoDetailViewModel(
-                        fetchTodoUseCase: container.resolve(FetchTodoByIdUseCase.self),
-                        fetchReferenceItemsUseCase: container.resolve(FetchReferenceItemsUseCase.self),
-                        upsertUseCase: container.resolve(UpsertTodoUseCase.self),
-                        todoId: todoId
-                    ))
-                }
-            }
-            .background(NavigationBarConfigurator())
-            .refreshable { viewModel.send(.refresh) }
-            .onAppear { viewModel.send(.onAppear) }
-            .alert(
-                viewModel.state.alertTitle,
-                isPresented: Binding(
-                    get: { viewModel.state.showAlert },
-                    set: { viewModel.send(.setAlert($0)) }
-                )
-            ) {
-                Button(String(localized: "common_close"), role: .cancel) { }
-            } message: {
-                Text(viewModel.state.alertMessage)
-            }
-            .overlay {
-                if viewModel.state.isLoading {
-                    LoadingView()
-                }
+        }
+        .listStyle(.insetGrouped)
+        .navigationTitle(String(localized: "nav_today"))
+        .toolbar { toolbarContent }
+        .background(NavigationBarConfigurator())
+        .refreshable { viewModel.send(.refresh) }
+        .onAppear { viewModel.send(.onAppear) }
+        .alert(
+            viewModel.state.alertTitle,
+            isPresented: Binding(
+                get: { viewModel.state.showAlert },
+                set: { viewModel.send(.setAlert($0)) }
+            )
+        ) {
+            Button(String(localized: "common_close"), role: .cancel) { }
+        } message: {
+            Text(viewModel.state.alertMessage)
+        }
+        .overlay {
+            if viewModel.state.isLoading {
+                LoadingView()
             }
         }
     }
@@ -145,10 +132,7 @@ struct TodayView: View {
         if !items.isEmpty {
             Section {
                 ForEach(items) { item in
-                    NavigationLink(value: Path.detail(item.id)) {
-                        TodayTodoRow(item: item)
-                            .listRowInsets(EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16))
-                    }
+                    todoRow(item)
                     .swipeActions(edge: .leading, allowsFullSwipe: false) {
                         Button {
                             viewModel.send(.togglePinned(item))
@@ -170,6 +154,25 @@ struct TodayView: View {
                 Text(title)
                     .listRowInsets(EdgeInsets())
             }
+        }
+    }
+
+    @ViewBuilder
+    private func todoRow(_ item: TodayTodoItem) -> some View {
+        if isCompactLayout {
+            NavigationLink(value: TodayRoute.todo(TodoIdItem(id: item.id))) {
+                TodayTodoRow(item: item)
+                    .listRowInsets(EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16))
+            }
+        } else {
+            Button {
+                todayNavigationState.show(.todo(TodoIdItem(id: item.id)))
+            } label: {
+                TodayTodoRow(item: item)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .listRowInsets(EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16))
+            }
+            .buttonStyle(.plain)
         }
     }
 
@@ -208,10 +211,40 @@ struct TodayView: View {
         let title: String
         let message: String
     }
+}
 
-    private enum Path: Hashable {
-        case detail(String)
+@Observable
+final class TodayNavigationState {
+    var path: [TodayRoute] = []
+
+    var root: TodayRoute? {
+        path.first
     }
+
+    var detailPath: [TodayRoute] {
+        get {
+            Array(path.dropFirst())
+        }
+        set {
+            if let todayRoute = root {
+                path = [todayRoute] + newValue
+            } else {
+                path = newValue
+            }
+        }
+    }
+
+    func show(_ todayRoute: TodayRoute) {
+        path = [todayRoute]
+    }
+
+    func push(_ todayRoute: TodayRoute) {
+        path.append(todayRoute)
+    }
+}
+
+enum TodayRoute: Hashable {
+    case todo(TodoIdItem)
 }
 
 private extension TodayDisplayOptions.DueDateVisibility {

--- a/DevLog/UI/Today/TodayView.swift
+++ b/DevLog/UI/Today/TodayView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct TodayView: View {
-    @Environment(TodayNavigationState.self) private var todayNavigationState
+    @Environment(NavigationRouter<TodayRoute>.self) private var router
     @State var viewModel: TodayViewModel
     let isCompactLayout: Bool
 
@@ -166,7 +166,7 @@ struct TodayView: View {
             }
         } else {
             Button {
-                todayNavigationState.show(.todo(TodoIdItem(id: item.id)))
+                router.show(.todo(TodoIdItem(id: item.id)))
             } label: {
                 TodayTodoRow(item: item)
                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -210,36 +210,6 @@ struct TodayView: View {
     private struct EmptyStateContent {
         let title: String
         let message: String
-    }
-}
-
-@Observable
-final class TodayNavigationState {
-    var path: [TodayRoute] = []
-
-    var root: TodayRoute? {
-        path.first
-    }
-
-    var detailPath: [TodayRoute] {
-        get {
-            Array(path.dropFirst())
-        }
-        set {
-            if let todayRoute = root {
-                path = [todayRoute] + newValue
-            } else {
-                path = newValue
-            }
-        }
-    }
-
-    func show(_ todayRoute: TodayRoute) {
-        path = [todayRoute]
-    }
-
-    func push(_ todayRoute: TodayRoute) {
-        path.append(todayRoute)
     }
 }
 


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #416

## 📝 작업 내용

### 📌 요약
- compact UI에서는 기존 아이폰용 TabView/NavigationStack 흐름 유지
- regular UI에서는 MainView에 NavigationSplitView 기반 사이드바 구조 적용
- Home, Today, Push Notification은 3단 구조로 구성하고 Profile은 2단 구조 유지

### 🔍 상세
- MainView에서 horizontalSizeClass 기준으로 compact UI와 regular UI 분기
- Home의 Todo 카테고리, 최근 수정 Todo, Web Page 선택을 regular UI의 detail 컬럼으로 표시하도록 구성
- Today의 Todo 선택을 regular UI의 detail 컬럼으로 표시하도록 구성
- PushNotificationListView에서 compact UI는 기존처럼 sheet로 Todo 상세 표시, regular UI는 detail 컬럼으로 표시
- 푸시 알림 선택 상태를 selectedNotificationId와 selectedTodoId로 분리해 선택 row 스타일과 상세 표시 연동
- NavigationRouter를 Route 제네릭 기반으로 정리해 화면별 내비게이션 path 타입 명시
- Home, Today, Push Notification의 미선택 detail 상태 문구 추가
- 시스템 Todo 카테고리 색상을 UIColor 기반으로 변환해 SwiftUI 주변 스타일에 따른 색상 변화 완화

## 📸 영상 / 이미지 (Optional)
<table>
<tr>
<td>
<img width="947" height="783" alt="image" src="https://github.com/user-attachments/assets/d5dabde4-feed-42bc-a21e-400f8c8a9ee1" />

</td>
<td>
<img width="947" height="783" alt="image" src="https://github.com/user-attachments/assets/63999b54-8ff1-4315-bbdc-406c8458e842" />
</td>
<td>
<img width="947" height="783" alt="image" src="https://github.com/user-attachments/assets/6676c417-1d65-4a72-bfbe-9abea953c6cc" />
</td>
<td>
<img width="947" height="783" alt="image" src="https://github.com/user-attachments/assets/a10d6ce0-fb9c-4adf-ad38-7ebf2e93211e" />
</td>
</tr>
</table>