### PR TITLE
[#444] PushNotificationListView의 내비게이선바의 경계선의 양 끝이 잘리는 현상을 해결한다

### DIFF
--- a/DevLog/UI/PushNotification/PushNotificationListView.swift
+++ b/DevLog/UI/PushNotification/PushNotificationListView.swift
@@ -30,8 +30,8 @@ struct PushNotificationListView: View {
                 .onAppear { viewModel.send(.fetchNotifications) }
                 .refreshable { viewModel.send(.fetchNotifications) }
                 .navigationTitle(String(localized: "nav_push_notifications"))
+                .listStyle(.plain)
         }
-        .listStyle(.sidebar)
         .background(Color(.secondarySystemBackground).ignoresSafeArea())
         .alert(
             "",
@@ -104,7 +104,7 @@ struct PushNotificationListView: View {
                 id: \.1.id
             ) { index, notification in
                 notificationListRow(notification, index: index, notifications: notifications)
-                .listRowInsets(EdgeInsets())
+                    .listRowInsets(EdgeInsets(top: 0, leading: 8, bottom: 0, trailing: 8))
                     .listSectionSeparator(.hidden, edges: .top)
                     .listRowBackground(Color.clear)
             }

--- a/DevLog/UI/PushNotification/PushNotificationListView.swift
+++ b/DevLog/UI/PushNotification/PushNotificationListView.swift
@@ -92,12 +92,9 @@ struct PushNotificationListView: View {
     private var notificationList: some View {
         let notifications = viewModel.state.notifications.filter { !$0.isHidden }
         if notifications.isEmpty {
-            HStack {
-                Spacer()
-                Text(String(localized: "push_notifications_empty"))
-                    .foregroundStyle(Color.gray)
-                Spacer()
-            }
+            Text(String(localized: "push_notifications_empty"))
+                .foregroundStyle(Color.gray)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else {
             List(
                 Array(zip(notifications.indices, notifications)),

--- a/DevLog/UI/PushNotification/PushNotificationListView.swift
+++ b/DevLog/UI/PushNotification/PushNotificationListView.swift
@@ -105,8 +105,8 @@ struct PushNotificationListView: View {
             ) { index, notification in
                 notificationListRow(notification, index: index, notifications: notifications)
                 .listRowInsets(EdgeInsets())
-                .listSectionSeparator(.hidden, edges: .top)
-                .listRowBackground(Color.clear)
+                    .listSectionSeparator(.hidden, edges: .top)
+                    .listRowBackground(Color.clear)
             }
         }
     }

--- a/DevLog/UI/PushNotification/PushNotificationListView.swift
+++ b/DevLog/UI/PushNotification/PushNotificationListView.swift
@@ -20,7 +20,16 @@ struct PushNotificationListView: View {
 
     var body: some View {
         NavigationStack {
-            notificationListContent
+            notificationList
+                .background(NavigationBarConfigurator(.secondarySystemBackground, alwaysVisible: true))
+                .onScrollOffsetChange { offset in
+                    guard isScrollTrackingEnabled else { return }
+                    headerOffset = max(0, -offset)
+                }
+                .safeAreaInset(edge: .top) { safeAreaHeader }
+                .onAppear { viewModel.send(.fetchNotifications) }
+                .refreshable { viewModel.send(.fetchNotifications) }
+                .navigationTitle(String(localized: "nav_push_notifications"))
         }
         .listStyle(.sidebar)
         .background(Color(.secondarySystemBackground).ignoresSafeArea())
@@ -77,19 +86,6 @@ struct PushNotificationListView: View {
                 LoadingView()
             }
         }
-    }
-
-    private var notificationListContent: some View {
-        notificationList
-            .background(NavigationBarConfigurator(.secondarySystemBackground, alwaysVisible: true))
-            .onScrollOffsetChange { offset in
-                guard isScrollTrackingEnabled else { return }
-                headerOffset = max(0, -offset)
-            }
-            .safeAreaInset(edge: .top) { safeAreaHeader }
-            .onAppear { viewModel.send(.fetchNotifications) }
-            .refreshable { viewModel.send(.fetchNotifications) }
-            .navigationTitle(String(localized: "nav_push_notifications"))
     }
 
     @ViewBuilder


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #444

## 🎯 의도
- 내비게이션바와 리스트를 구분해주는 seperator 양쪽에 패딩이 적용되는 문제 해결

## 📝 작업 내용

### 📌 요약
- 알림 리스트 스타일을 `plain`으로 변경
- 알림 row 좌우 inset 조정
- 별도 래핑 뷰 제거를 통한 리스트 구성 단순화
- 푸시알림 기록 데이터가 없을 시 헤더가 중앙으로 내려오는 UI 버그 해결

### 🔍 상세
- `NavigationStack` 내부에서 리스트 modifier를 직접 적용하도록 구조 정리
- `sidebar` 스타일 제거 후 `plain` 스타일 적용으로 알림 리스트 표현 방식 조정
- row 좌우 inset을 8pt로 지정하여 기본 리스트 패딩 적용
- 푸시알림 기록 데이터가 없을 때 보여주는 텍스트의 `frame`을 최대로 잡게 하여 헤더 위치가 이동하지 않도록 해결

## 📸 영상 / 이미지 (Optional)

