### PR TITLE
[#449] 메인 리드미의 섹션 위치를 수정한다

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,38 @@ Todo, 저장 링크, 오늘 할 일, 받은 알림, 누적 활동을 하나의 �
 - 분기별 활동 히트맵 제공
 - Google, GitHub, Apple 로그인 및 계정 연동
 
+## 아키텍처
+
+MVVM을 기반으로 하되, ViewModel 상태 관리에는 MVI 형태의 단방향 흐름을 차용한 구조  
+화면, 상태, 비즈니스 로직, 외부 의존성 분리를 위한 `MVVM + Clean Architecture` 기반 구성
+
+<table>
+  <tr>
+    <td align="center">
+      <img alt="App Architecture" src="./docs/App.png" />
+    </td>
+  </tr>
+  <tr>
+    <td align="center">앱 아키텍처</td>
+  </tr>
+  <tr>
+    <td align="center">
+      <img alt="Store Protocol" src="./docs/store-protocol.png" />
+    </td>
+  </tr>
+  <tr>
+    <td align="center">Store 프로토콜</td>
+  </tr>
+  <tr>
+    <td align="center">
+      <img alt="Widget Architecture" src="./docs/Widget.png" />
+    </td>
+  </tr>
+  <tr>
+    <td align="center">위젯 데이터 아키텍처</td>
+  </tr>
+</table>
+
 ## 주요 기능
 
 ### 로그인 및 계정 관리
@@ -120,37 +152,6 @@ Todo, 저장 링크, 오늘 할 일, 받은 알림, 누적 활동을 하나의 �
 | Utility | GoogleSignIn, OrderedCollections |
 | Tooling | Xcode, Swift Package Manager, SwiftLint, Fastlane |
 
-## 아키텍처
-
-MVVM을 기반으로 하되, ViewModel 상태 관리에는 MVI 형태의 단방향 흐름을 차용한 구조  
-화면, 상태, 비즈니스 로직, 외부 의존성 분리를 위한 `MVVM + Clean Architecture` 기반 구성
-
-<table>
-  <tr>
-    <td align="center">
-      <img alt="App Architecture" src="./docs/App.png" />
-    </td>
-  </tr>
-  <tr>
-    <td align="center">앱 아키텍처</td>
-  </tr>
-  <tr>
-    <td align="center">
-      <img alt="Store Protocol" src="./docs/store-protocol.png" />
-    </td>
-  </tr>
-  <tr>
-    <td align="center">Store 프로토콜</td>
-  </tr>
-  <tr>
-    <td align="center">
-      <img alt="Widget Architecture" src="./docs/Widget.png" />
-    </td>
-  </tr>
-  <tr>
-    <td align="center">위젯 데이터 아키텍처</td>
-  </tr>
-</table>
 
 ## 프로젝트 구조
 

--- a/docs/DevLog.drawio
+++ b/docs/DevLog.drawio
@@ -103,431 +103,162 @@
     </mxGraphModel>
   </diagram>
   <diagram id="delete-flow-page" name="Delete Undo Flow">
-    <mxGraphModel dx="1285" dy="692" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="900" pageHeight="1200" background="none" math="0" shadow="0">
+    <mxGraphModel dx="1414" dy="850" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1280" pageHeight="600" background="#ffffff" math="0" shadow="0">
       <root>
         <mxCell id="0" />
         <mxCell id="1" parent="0" />
-        <mxCell id="100" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=18;fontStyle=1;fontColor=#1F2328;" value="개선 전" vertex="1">
-          <mxGeometry height="28" width="120" x="360" y="24" as="geometry" />
+        <mxCell id="du-request-device" link="https://github.com/opficdev/SwiftUI_DevLog/blob/main/DevLog/Presentation/ViewModel/PushNotificationListViewModel.swift" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#EAF2FF;strokeColor=#0A84FF;strokeWidth=2;fontColor=#0B1F33;fontSize=13;align=center;" value="&lt;b&gt;iOS Client&lt;/b&gt;" vertex="1">
+          <mxGeometry height="70" width="200" x="80" y="250" as="geometry" />
         </mxCell>
-        <mxCell id="101" parent="1" style="rounded=1;arcSize=20;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#D8E0EA;strokeWidth=2;" value="" vertex="1">
-          <mxGeometry height="300" width="760" x="40" y="60" as="geometry" />
+        <mxCell id="du-functions" link="https://github.com/opficdev/SwiftUI_DevLog/blob/main/Firebase/functions/src/notification/deletion.ts" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#DCFCE7;strokeColor=#16A34A;strokeWidth=2;fontColor=#14532D;fontSize=13;align=center;" value="&lt;b&gt;Cloud Functions&lt;/b&gt;&lt;br&gt;&lt;span style=&quot;font-weight: normal;&quot;&gt;삭제·Undo 요청 처리&lt;/span&gt;" vertex="1">
+          <mxGeometry height="70" width="200" x="390" y="250" as="geometry" />
         </mxCell>
-        <mxCell id="102" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#F8FAFC;strokeColor=#B8C4D6;strokeWidth=2;" value="" vertex="1">
-          <mxGeometry height="206" width="346" x="68" y="112" as="geometry" />
+        <mxCell id="du-firestore" link="https://github.com/opficdev/SwiftUI_DevLog/blob/main/Firebase/functions/src/notification/deletion.ts" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#64748B;strokeWidth=2;fontColor=#1F2328;fontSize=13;align=center;" value="&lt;b&gt;Firestore 알림 문서&lt;/b&gt;&lt;br&gt;&lt;span style=&quot;font-weight: normal;&quot;&gt;삭제 상태 저장·해제&lt;/span&gt;" vertex="1">
+          <mxGeometry height="70" width="200" x="710" y="250" as="geometry" />
         </mxCell>
-        <mxCell id="103" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#F8FAFC;strokeColor=#B8C4D6;strokeWidth=2;" value="" vertex="1">
-          <mxGeometry height="170" width="190" x="560" y="126" as="geometry" />
+        <mxCell id="du-request-list" link="https://github.com/opficdev/SwiftUI_DevLog/blob/main/DevLog/Presentation/ViewModel/PushNotificationListViewModel.swift" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#F5F3FF;strokeColor=#7C3AED;strokeWidth=2;fontColor=#1F2328;fontSize=13;align=center;" value="&lt;b&gt;요청 기기 리스트&lt;/b&gt;&lt;br&gt;&lt;span style=&quot;font-weight: normal;&quot;&gt;서버 재조회로 동기화&lt;/span&gt;" vertex="1">
+          <mxGeometry height="70" width="200" x="1020" y="150" as="geometry" />
         </mxCell>
-        <mxCell id="104" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=14;fontStyle=1;fontColor=#6B7280;" value="Client" vertex="1">
-          <mxGeometry height="22" width="80" x="201" y="90" as="geometry" />
+        <mxCell id="du-other-list" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#F5F3FF;strokeColor=#7C3AED;strokeWidth=2;fontColor=#1F2328;fontSize=13;align=center;" value="&lt;b&gt;다른 기기 리스트&lt;/b&gt;&lt;br&gt;&lt;span style=&quot;font-weight: normal;&quot;&gt;같은 삭제 상태 반영&lt;/span&gt;" vertex="1">
+          <mxGeometry height="70" width="200" x="1020" y="350" as="geometry" />
         </mxCell>
-        <mxCell id="105" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=14;fontStyle=1;fontColor=#6B7280;" value="Server" vertex="1">
-          <mxGeometry height="22" width="80" x="615" y="126" as="geometry" />
-        </mxCell>
-        <mxCell id="106" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;fontSize=13;fontStyle=1;fontColor=#C2410C;" value="삭제 책임: Client" vertex="1">
-          <mxGeometry height="22" width="120" x="96" y="120" as="geometry" />
-        </mxCell>
-        <mxCell id="107" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#A7B4C6;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=18;" value="사용자" vertex="1">
-          <mxGeometry height="42" width="96" x="102" y="152" as="geometry" />
-        </mxCell>
-        <mxCell id="108" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#EAF2FF;strokeColor=#0A84FF;strokeWidth=2;fontColor=#0B1F33;fontStyle=1;fontSize=18;" value="ViewModel" vertex="1">
-          <mxGeometry height="44" width="112" x="286" y="150" as="geometry" />
-        </mxCell>
-        <mxCell id="109" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#A7B4C6;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=18;" value="Toast" vertex="1">
-          <mxGeometry height="42" width="84" x="300" y="262" as="geometry" />
-        </mxCell>
-        <mxCell id="110" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#A7B4C6;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=18;" value="로컬 리스트" vertex="1">
-          <mxGeometry height="42" width="108" x="110" y="260" as="geometry" />
-        </mxCell>
-        <mxCell id="111" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#A7B4C6;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=18;" value="Cloud Functions" vertex="1">
-          <mxGeometry height="44" width="126" x="592" y="150" as="geometry" />
-        </mxCell>
-        <mxCell id="112" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#A7B4C6;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=18;" value="Firestore" vertex="1">
-          <mxGeometry height="42" width="108" x="601" y="240" as="geometry" />
-        </mxCell>
-        <mxCell id="113" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=10;fontColor=#6B7280;" value="삭제 요청" vertex="1">
-          <mxGeometry height="22" width="82" x="187" y="152" as="geometry" />
-        </mxCell>
-        <mxCell id="114" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=8;fontColor=#6B7280;" value="Undo 토스트 표시" vertex="1">
-          <mxGeometry height="22" width="104" x="258" y="220" as="geometry" />
-        </mxCell>
-        <mxCell id="115" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=10;fontColor=#6B7280;" value="Undo 대상 로컬 보관" vertex="1">
-          <mxGeometry height="22" width="84" x="174" y="205" as="geometry" />
-        </mxCell>
-        <mxCell id="116" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=10;fontColor=#6B7280;" value="Undo 선택" vertex="1">
-          <mxGeometry height="22" width="82" x="345" y="226" as="geometry" />
-        </mxCell>
-        <mxCell id="117" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=10;fontColor=#6B7280;" value="복원 / 제거 결정" vertex="1">
-          <mxGeometry height="22" width="118" x="204" y="260" as="geometry" />
-        </mxCell>
-        <mxCell id="118" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=10;fontColor=#6B7280;" value="삭제 요청" vertex="1">
-          <mxGeometry height="22" width="100" x="437" y="150" as="geometry" />
-        </mxCell>
-        <mxCell id="119" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=10;fontColor=#6B7280;" value="데이터 수정" vertex="1">
-          <mxGeometry height="22" width="66" x="649" y="194" as="geometry" />
-        </mxCell>
-        <mxCell id="120" edge="1" parent="1" source="107" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#5E6AD2;strokeWidth=3;" target="108">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-        <mxCell id="121" edge="1" parent="1" source="108" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0A84FF;strokeWidth=3;" target="109">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-        <mxCell id="122" edge="1" parent="1" source="108" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0A84FF;strokeWidth=3;exitX=0.06;exitY=0.988;exitDx=0;exitDy=0;exitPerimeter=0;entryX=1;entryY=0;entryDx=0;entryDy=0;" target="110">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-        <mxCell id="123" edge="1" parent="1" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#5E6AD2;strokeWidth=3;">
-          <mxGeometry relative="1" as="geometry">
-            <mxPoint x="361" y="262" as="sourcePoint" />
-            <mxPoint x="361" y="194" as="targetPoint" />
+        <mxCell id="du-edge-request-functions" edge="1" parent="1" source="du-request-device" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0A84FF;strokeWidth=3;labelBackgroundColor=#FFFFFF;fontSize=12;" target="du-functions" value="삭제·Undo 요청">
+          <mxGeometry relative="1" x="-0.0909" y="15" as="geometry">
+            <mxPoint as="offset" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="124" edge="1" parent="1" source="110" style="curved=1;endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#5E6AD2;strokeWidth=3;exitX=0.998;exitY=0.46;exitDx=0;exitDy=0;exitPerimeter=0;" target="108">
-          <mxGeometry relative="1" as="geometry">
-            <Array as="points" />
+        <mxCell id="du-edge-functions-firestore" edge="1" parent="1" source="du-functions" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#16A34A;strokeWidth=3;labelBackgroundColor=#FFFFFF;fontSize=12;" target="du-firestore" value="삭제 상태 저장&lt;div&gt;Undo 시 상태 해제&lt;/div&gt;">
+          <mxGeometry relative="1" x="-0.0909" y="29" as="geometry">
+            <mxPoint as="offset" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="125" edge="1" parent="1" source="108" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0A84FF;strokeWidth=3;" target="111">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-        <mxCell id="126" edge="1" parent="1" source="111" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0A84FF;strokeWidth=3;" target="112">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-        <mxCell id="127" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=18;fontStyle=1;fontColor=#1F2328;" value="개선 후" vertex="1">
-          <mxGeometry height="28" width="110" x="365" y="404" as="geometry" />
-        </mxCell>
-        <mxCell id="128" parent="1" style="rounded=1;arcSize=20;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#D8E0EA;strokeWidth=2;" value="" vertex="1">
-          <mxGeometry height="300" width="760" x="40" y="440" as="geometry" />
-        </mxCell>
-        <mxCell id="129" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#F8FAFC;strokeColor=#B8C4D6;strokeWidth=2;" value="" vertex="1">
-          <mxGeometry height="176" width="346" x="68" y="520" as="geometry" />
-        </mxCell>
-        <mxCell id="130" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#F8FAFC;strokeColor=#B8C4D6;strokeWidth=2;" value="" vertex="1">
-          <mxGeometry height="196" width="214" x="546" y="500" as="geometry" />
-        </mxCell>
-        <mxCell id="131" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=14;fontStyle=1;fontColor=#6B7280;" value="Client" vertex="1">
-          <mxGeometry height="22" width="80" x="201" y="497" as="geometry" />
-        </mxCell>
-        <mxCell id="132" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=14;fontStyle=1;fontColor=#6B7280;" value="Server" vertex="1">
-          <mxGeometry height="22" width="80" x="613" y="476" as="geometry" />
-        </mxCell>
-        <mxCell id="133" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=13;fontStyle=1;fontColor=#15803D;" value="삭제 책임: Server" vertex="1">
-          <mxGeometry height="22" width="120" x="560" y="516" as="geometry" />
-        </mxCell>
-        <mxCell id="134" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#A7B4C6;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=18;" value="사용자" vertex="1">
-          <mxGeometry height="42" width="96" x="102" y="547" as="geometry" />
-        </mxCell>
-        <mxCell id="135" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#EAF2FF;strokeColor=#0A84FF;strokeWidth=2;fontColor=#0B1F33;fontStyle=1;fontSize=18;" value="ViewModel" vertex="1">
-          <mxGeometry height="44" width="112" x="286" y="545" as="geometry" />
-        </mxCell>
-        <mxCell id="136" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#A7B4C6;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=18;" value="Toast" vertex="1">
-          <mxGeometry height="42" width="84" x="199" y="638" as="geometry" />
-        </mxCell>
-        <mxCell id="137" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#A7B4C6;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=18;" value="Cloud Functions" vertex="1">
-          <mxGeometry height="44" width="126" x="598" y="545" as="geometry" />
-        </mxCell>
-        <mxCell id="138" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#A7B4C6;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=18;" value="Firestore" vertex="1">
-          <mxGeometry height="42" width="108" x="609" y="638" as="geometry" />
-        </mxCell>
-        <mxCell id="139" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=10;fontColor=#6B7280;" value="삭제 요청" vertex="1">
-          <mxGeometry height="22" width="82" x="188" y="548" as="geometry" />
-        </mxCell>
-        <mxCell id="140" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=10;fontColor=#6B7280;" value="Undo 토스트 표시" vertex="1">
-          <mxGeometry height="22" width="104" x="207" y="595" as="geometry" />
-        </mxCell>
-        <mxCell id="141" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=10;fontColor=#6B7280;" value="Undo 요청" vertex="1">
-          <mxGeometry height="22" width="82" x="286" y="619" as="geometry" />
-        </mxCell>
-        <mxCell id="142" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=10;fontColor=#6B7280;" value="삭제 / Undo 요청" vertex="1">
-          <mxGeometry height="22" width="100" x="430" y="546" as="geometry" />
-        </mxCell>
-        <mxCell id="144" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=10;fontColor=#6B7280;" value="데이터 수정" vertex="1">
-          <mxGeometry height="22" width="148" x="615" y="591" as="geometry" />
-        </mxCell>
-        <mxCell id="145" edge="1" parent="1" source="134" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#5E6AD2;strokeWidth=3;" target="135">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-        <mxCell id="146" edge="1" parent="1" source="135" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0A84FF;strokeWidth=3;entryX=0.866;entryY=0.013;entryDx=0;entryDy=0;entryPerimeter=0;" target="136">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-        <mxCell id="147" edge="1" parent="1" source="136" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#5E6AD2;strokeWidth=3;entryX=0.5;entryY=1;entryDx=0;entryDy=0;exitX=1;exitY=0.25;exitDx=0;exitDy=0;" target="135">
-          <mxGeometry relative="1" as="geometry">
-            <mxPoint x="290.95294117647063" y="658" as="sourcePoint" />
-            <mxPoint x="340.8588235294119" y="616" as="targetPoint" />
+        <mxCell id="du-edge-functions-undo" edge="1" parent="1" source="du-functions" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#16A34A;strokeWidth=3;labelBackgroundColor=#FFFFFF;fontSize=12;" target="du-firestore" value="">
+          <mxGeometry relative="1" x="0.0909" y="9" as="geometry">
+            <mxPoint as="offset" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="148" edge="1" parent="1" source="135" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0A84FF;strokeWidth=3;" target="137">
-          <mxGeometry relative="1" as="geometry" />
+        <mxCell id="du-edge-firestore-request" edge="1" parent="1" source="du-firestore" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#64748B;strokeWidth=3;labelBackgroundColor=#FFFFFF;fontSize=12;exitX=1;exitY=0.25;exitDx=0;exitDy=0;entryX=-0.012;entryY=0.756;entryDx=0;entryDy=0;entryPerimeter=0;" target="du-request-list" value="서버 기준 리스트">
+          <mxGeometry relative="1" x="-0.5683" y="32" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
         </mxCell>
-        <mxCell id="150" edge="1" parent="1" source="137" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0A84FF;strokeWidth=3;" target="138">
-          <mxGeometry relative="1" as="geometry" />
+        <mxCell id="du-edge-firestore-other" edge="1" parent="1" source="du-firestore" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#64748B;strokeWidth=3;labelBackgroundColor=#FFFFFF;fontSize=12;exitX=1;exitY=0.75;exitDx=0;exitDy=0;entryX=0;entryY=0.25;entryDx=0;entryDy=0;" target="du-other-list" value="동일 상태 반영">
+          <mxGeometry relative="1" x="-0.4165" y="-28" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
         </mxCell>
       </root>
     </mxGraphModel>
   </diagram>
-  <diagram id="todo-reminder-flow-page" name="Todo Reminder Flow">
-    <mxGraphModel dx="1768" dy="951" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1200" pageHeight="1200" background="none" math="0" shadow="0">
+  <diagram id="todo-reminder-validation-flow-page" name="Todo Reminder Validation Flow">
+    <mxGraphModel dx="1414" dy="850" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1280" pageHeight="600" background="#ffffff" math="0" shadow="0">
       <root>
         <mxCell id="0" />
         <mxCell id="1" parent="0" />
-        <mxCell id="200" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=18;fontStyle=1;fontColor=#1F2328;" value="개선 전" vertex="1">
-          <mxGeometry height="28" width="120" x="180" y="24" as="geometry" />
-        </mxCell>
-        <mxCell id="201" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=18;fontStyle=1;fontColor=#1F2328;" value="개선 후" vertex="1">
-          <mxGeometry height="28" width="120" x="656" y="24" as="geometry" />
-        </mxCell>
-        <mxCell id="202" parent="1" style="rounded=1;arcSize=20;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#D8E0EA;strokeWidth=2;" value="" vertex="1">
-          <mxGeometry height="390" width="444" x="36" y="60" as="geometry" />
-        </mxCell>
-        <mxCell id="203" parent="1" style="rounded=1;arcSize=20;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#D8E0EA;strokeWidth=2;" value="" vertex="1">
-          <mxGeometry height="740" width="410" x="500" y="60" as="geometry" />
-        </mxCell>
-        <mxCell id="204" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#F8FAFC;strokeColor=#B8C4D6;strokeWidth=2;" value="" vertex="1">
-          <mxGeometry height="330" width="196" x="56" y="96" as="geometry" />
-        </mxCell>
-        <mxCell id="205" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#F8FAFC;strokeColor=#B8C4D6;strokeWidth=2;" value="" vertex="1">
-          <mxGeometry height="180" width="148" x="312" y="116" as="geometry" />
-        </mxCell>
-        <mxCell id="206" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=14;fontStyle=1;fontColor=#6B7280;" value="Client" vertex="1">
-          <mxGeometry height="22" width="80" x="114" y="72" as="geometry" />
-        </mxCell>
-        <mxCell id="207" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=14;fontStyle=1;fontColor=#6B7280;" value="Server" vertex="1">
-          <mxGeometry height="22" width="80" x="346" y="94" as="geometry" />
-        </mxCell>
-        <mxCell id="208" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;fontSize=13;fontStyle=1;fontColor=#C2410C;" value="예약 책임: Client" vertex="1">
-          <mxGeometry height="22" width="110" x="70" y="106" as="geometry" />
-        </mxCell>
-        <mxCell id="209" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#0A84FF;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=15;" value="Todo 생성 / 수정" vertex="1">
-          <mxGeometry height="52" width="140" x="84" y="132" as="geometry" />
-        </mxCell>
-        <mxCell id="210" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#A7B4C6;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=15;" value="사용자 설정&#xa;(시각 / Timezone)" vertex="1">
-          <mxGeometry height="64" width="140" x="84" y="240" as="geometry" />
-        </mxCell>
-        <mxCell id="211" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#EAF2FF;strokeColor=#0A84FF;strokeWidth=2;fontColor=#0B1F33;fontStyle=1;fontSize=15;" value="이벤트 기반 예약" vertex="1">
-          <mxGeometry height="52" width="140" x="84" y="364" as="geometry" />
-        </mxCell>
-        <mxCell id="212" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#A7B4C6;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=14;" value="Cloud Tasks" vertex="1">
-          <mxGeometry height="40" width="100" x="336" y="128" as="geometry" />
-        </mxCell>
-        <mxCell id="213" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#A7B4C6;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=12;" value="알림 발송 처리" vertex="1">
-          <mxGeometry height="40" width="100" x="336" y="238" as="geometry" />
-        </mxCell>
-        <mxCell id="214" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#A7B4C6;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=12;" value="설정 변경 후&#xa;예상 시간과 달라질 수 있음&#xa;최신 Todo 상태 미반영 가능" vertex="1">
-          <mxGeometry height="67" width="164" x="304" y="329" as="geometry" />
-        </mxCell>
-        <mxCell id="218" edge="1" parent="1" source="209" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0A84FF;strokeWidth=3;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" target="210">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-        <mxCell id="219" edge="1" parent="1" source="210" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#5E6AD2;strokeWidth=3;" target="211">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-        <mxCell id="220" edge="1" parent="1" source="211" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0A84FF;strokeWidth=3;edgeStyle=orthogonalEdgeStyle;" target="212">
-          <mxGeometry relative="1" as="geometry">
-            <Array as="points">
-              <mxPoint x="280" y="406" />
-              <mxPoint x="280" y="146" />
-              <mxPoint x="330" y="146" />
-              <mxPoint x="330" y="148" />
-            </Array>
+        <mxCell id="trv-edge-app-state" edge="1" parent="1" source="trv-app" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0A84FF;strokeWidth=3;labelBackgroundColor=#FFFFFF;fontSize=12;" target="trv-server-state" value="Timezone,&lt;div&gt;알림 설정 저장&lt;/div&gt;">
+          <mxGeometry relative="1" x="-0.2" y="17" as="geometry">
+            <mxPoint as="offset" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="221" edge="1" parent="1" source="212" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0A84FF;strokeWidth=3;entryX=0.5;entryY=0;entryDx=0;entryDy=0;exitX=0.5;exitY=1;exitDx=0;exitDy=0;" target="213">
-          <mxGeometry relative="1" as="geometry">
-            <mxPoint x="385.7624590163934" y="182.16" as="sourcePoint" />
-            <mxPoint x="386.114" y="234.99600000000004" as="targetPoint" />
+        <mxCell id="trv-edge-state-batch" edge="1" parent="1" source="trv-server-state" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#64748B;strokeWidth=3;labelBackgroundColor=#FFFFFF;fontSize=12;" target="trv-batch" value="최신 기준 조회">
+          <mxGeometry relative="1" x="-0.0769" y="15" as="geometry">
+            <mxPoint as="offset" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="222" edge="1" parent="1" source="213" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#5E6AD2;strokeWidth=3;entryX=0.5;entryY=0;entryDx=0;entryDy=0;exitX=0.5;exitY=1;exitDx=0;exitDy=0;" target="214">
+        <mxCell id="trv-edge-batch-queue" edge="1" parent="1" source="trv-batch" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#64748B;strokeWidth=3;labelBackgroundColor=#FFFFFF;fontSize=12;exitX=0;exitY=0.75;exitDx=0;exitDy=0;entryX=1;entryY=0.25;entryDx=0;entryDy=0;" target="trv-queue" value="작업 적재">
           <mxGeometry relative="1" as="geometry">
-            <mxPoint x="344" y="346" as="sourcePoint" />
-            <mxPoint x="343" y="466" as="targetPoint" />
+            <mxPoint y="-18" as="offset" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="223" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#F8FAFC;strokeColor=#B8C4D6;strokeWidth=2;" value="" vertex="1">
-          <mxGeometry height="80" width="170" x="520" y="112" as="geometry" />
-        </mxCell>
-        <mxCell id="225" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=14;fontStyle=1;fontColor=#6B7280;" value="Client" vertex="1">
-          <mxGeometry height="22" width="80" x="565" y="90" as="geometry" />
-        </mxCell>
-        <mxCell id="235" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=11;fontColor=#6B7280;" value="설정 기준" vertex="1">
-          <mxGeometry height="20" width="70" x="600" y="272" as="geometry" />
-        </mxCell>
-        <mxCell id="238" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=11;fontColor=#6B7280;" value="발송 시점 재검증" vertex="1">
-          <mxGeometry height="20" width="136" x="690" y="522" as="geometry" />
-        </mxCell>
-        <mxCell id="216" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=11;fontColor=#6B7280;" value="enqueue" vertex="1">
-          <mxGeometry height="20" width="54" x="251" y="403" as="geometry" />
-        </mxCell>
-        <mxCell id="217" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=11;fontColor=#6B7280;" value="예약 당시 데이터 사용" vertex="1">
-          <mxGeometry height="20" width="120" x="299" y="183" as="geometry" />
-        </mxCell>
-        <mxCell id="215" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=11;fontColor=#6B7280;" value="변경 시 예약" vertex="1">
-          <mxGeometry height="20" width="70" x="150" y="316" as="geometry" />
-        </mxCell>
-        <mxCell id="228" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#0A84FF;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=15;" value="사용자 설정&#xa;(시각 / Timezone)" vertex="1">
-          <mxGeometry height="60" width="150" x="530" y="122" as="geometry" />
-        </mxCell>
-        <mxCell id="224" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#F8FAFC;strokeColor=#B8C4D6;strokeWidth=2;" value="" vertex="1">
-          <mxGeometry height="550" width="192" x="705" y="95" as="geometry" />
-        </mxCell>
-        <mxCell id="226" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=14;fontStyle=1;fontColor=#6B7280;" value="Server" vertex="1">
-          <mxGeometry height="22" width="80" x="759" y="71" as="geometry" />
-        </mxCell>
-        <mxCell id="239" edge="1" parent="1" source="228" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#5E6AD2;strokeWidth=3;exitX=0.5;exitY=1;exitDx=0;exitDy=0;edgeStyle=orthogonalEdgeStyle;" target="230">
+        <mxCell id="trv-edge-queue-sender" edge="1" parent="1" source="trv-queue" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0891B2;strokeWidth=3;labelBackgroundColor=#FFFFFF;fontSize=12;" target="trv-sender" value="발송 요청">
           <mxGeometry relative="1" as="geometry">
-            <Array as="points">
-              <mxPoint x="605" y="270" />
-            </Array>
+            <mxPoint y="-16" as="offset" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="227" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;fontSize=13;fontStyle=1;fontColor=#15803D;" value="예약 책임: Server" vertex="1">
-          <mxGeometry height="22" width="110" x="727" y="105" as="geometry" />
+        <mxCell id="trv-edge-sender-fcm" edge="1" parent="1" source="trv-sender" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#16A34A;strokeWidth=3;labelBackgroundColor=#FFFFFF;fontSize=12;exitX=1;exitY=0.25;exitDx=0;exitDy=0;entryX=0;entryY=0.75;entryDx=0;entryDy=0;" target="trv-fcm" value="조건 일치">
+          <mxGeometry relative="1" x="-0.2753" y="19" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
         </mxCell>
-        <mxCell id="229" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#0A84FF;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=15;" value="5분 주기&#xa;Scheduler" vertex="1">
-          <mxGeometry height="64" width="110" x="746" y="133" as="geometry" />
+        <mxCell id="trv-edge-sender-cancel" edge="1" parent="1" source="trv-sender" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#EF4444;strokeWidth=3;labelBackgroundColor=#FFFFFF;fontSize=12;exitX=1;exitY=0.75;exitDx=0;exitDy=0;entryX=0;entryY=0.25;entryDx=0;entryDy=0;" target="trv-cancel" value="조건 불일치">
+          <mxGeometry relative="1" x="-0.2503" y="-23" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
         </mxCell>
-        <mxCell id="230" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#EAF2FF;strokeColor=#0A84FF;strokeWidth=2;fontColor=#0B1F33;fontStyle=1;fontSize=13;" value="리마인더 배치 실행" vertex="1">
-          <mxGeometry height="60" width="110" x="746" y="243" as="geometry" />
+        <mxCell id="trv-app" link="https://github.com/opficdev/SwiftUI_DevLog/blob/main/DevLog/App/Handler/UserTimeZoneSyncHandler.swift" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#EAF2FF;strokeColor=#0A84FF;strokeWidth=2;fontColor=#0B1F33;fontSize=13;align=center;" value="&lt;b&gt;iOS Client&lt;/b&gt;" vertex="1">
+          <mxGeometry height="70" width="200" x="60" y="110" as="geometry" />
         </mxCell>
-        <mxCell id="231" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#A7B4C6;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=14;" value="내일 마감 Todo&#xa;재계산" vertex="1">
-          <mxGeometry height="60" width="110" x="746" y="353" as="geometry" />
+        <mxCell id="trv-server-state" link="https://github.com/opficdev/SwiftUI_DevLog/blob/main/Firebase/functions/src/common/firestorePath.ts" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#64748B;strokeWidth=2;fontColor=#1F2328;fontSize=13;align=center;" value="&lt;b&gt;Firestore 설정·Todo&lt;/b&gt;&lt;br&gt;&lt;span style=&quot;font-weight: normal;&quot;&gt;최신 발송 기준 보관&lt;/span&gt;" vertex="1">
+          <mxGeometry height="70" width="200" x="390" y="110" as="geometry" />
         </mxCell>
-        <mxCell id="232" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#A7B4C6;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=14;" value="Cloud Tasks" vertex="1">
-          <mxGeometry height="60" width="110" x="746" y="463" as="geometry" />
+        <mxCell id="trv-batch" link="https://github.com/opficdev/SwiftUI_DevLog/blob/main/Firebase/functions/src/fcm/schedule.ts" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#64748B;strokeWidth=2;fontColor=#1F2328;fontSize=13;align=center;" value="&lt;b&gt;리마인더 배치&lt;/b&gt;&lt;br&gt;&lt;span style=&quot;font-weight: normal;&quot;&gt;Timezone 기준 대상 재계산&lt;/span&gt;" vertex="1">
+          <mxGeometry height="70" width="200" x="720" y="110" as="geometry" />
         </mxCell>
-        <mxCell id="233" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#A7B4C6;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=12;" value="알림 발송 처리" vertex="1">
-          <mxGeometry height="60" width="110" x="746" y="573" as="geometry" />
+        <mxCell id="trv-queue" link="https://github.com/opficdev/SwiftUI_DevLog/blob/main/Firebase/functions/src/fcm/schedule.ts" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#ECFEFF;strokeColor=#0891B2;strokeWidth=2;fontColor=#164E63;fontSize=13;align=center;" value="&lt;b&gt;Cloud Tasks&lt;/b&gt;&lt;br&gt;&lt;span style=&quot;font-weight: normal;&quot;&gt;Todo 식별자·마감일 기준 보관&lt;/span&gt;" vertex="1">
+          <mxGeometry height="70" width="200" x="60" y="350" as="geometry" />
         </mxCell>
-        <mxCell id="234" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#A7B4C6;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=12;" value="설정 변경 이후에도&#xa;최신 기준으로 스케줄링&#xa;최신 Todo 상태 반영" vertex="1">
-          <mxGeometry height="96" width="119" x="741.5" y="683" as="geometry" />
+        <mxCell id="trv-sender" link="https://github.com/opficdev/SwiftUI_DevLog/blob/main/Firebase/functions/src/fcm/notification.ts" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#DCFCE7;strokeColor=#16A34A;strokeWidth=2;fontColor=#14532D;fontSize=13;align=center;" value="&lt;b&gt;알림 발송 처리&lt;/b&gt;&lt;br&gt;&lt;span style=&quot;font-weight: normal;&quot;&gt;최신 설정·Todo 재검증 후 발송/중단&lt;/span&gt;" vertex="1">
+          <mxGeometry height="70" width="200" x="390" y="350" as="geometry" />
         </mxCell>
-        <mxCell id="237" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=11;fontColor=#6B7280;" value="enqueue" vertex="1">
-          <mxGeometry height="20" width="60" x="744" y="417" as="geometry" />
+        <mxCell id="Xp06P4H-ANORCYlnH8vk-1" connectable="0" parent="1" style="group" value="" vertex="1">
+          <mxGeometry height="240" width="200" x="720" y="260" as="geometry" />
         </mxCell>
-        <mxCell id="240" edge="1" parent="1" source="229" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#5E6AD2;strokeWidth=3;" target="230">
-          <mxGeometry relative="1" as="geometry" />
+        <mxCell id="trv-fcm" link="https://github.com/opficdev/SwiftUI_DevLog/blob/main/Firebase/functions/src/fcm/notification.ts" parent="Xp06P4H-ANORCYlnH8vk-1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#F5F3FF;strokeColor=#7C3AED;strokeWidth=2;fontColor=#1F2328;fontSize=13;align=center;" value="&lt;b&gt;FCM&lt;/b&gt;&lt;br&gt;&lt;span style=&quot;font-weight: normal;&quot;&gt;검증된 푸시 발송&lt;/span&gt;" vertex="1">
+          <mxGeometry height="70" width="200" as="geometry" />
         </mxCell>
-        <mxCell id="241" edge="1" parent="1" source="230" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0A84FF;strokeWidth=3;entryX=0.473;entryY=0.012;entryDx=0;entryDy=0;entryPerimeter=0;" target="231">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-        <mxCell id="242" edge="1" parent="1" source="231" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0A84FF;strokeWidth=3;exitX=0.475;exitY=0.986;exitDx=0;exitDy=0;exitPerimeter=0;" target="232">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-        <mxCell id="243" edge="1" parent="1" source="232" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0A84FF;strokeWidth=3;" target="233">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-        <mxCell id="244" edge="1" parent="1" source="233" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#5E6AD2;strokeWidth=3;entryX=0.5;entryY=0;entryDx=0;entryDy=0;exitX=0.5;exitY=1;exitDx=0;exitDy=0;" target="234">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-        <mxCell id="QxAspJlolYb2ybC7-Ub2-246" edge="1" parent="1" source="203" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;" target="203">
-          <mxGeometry relative="1" as="geometry" />
+        <mxCell id="trv-cancel" parent="Xp06P4H-ANORCYlnH8vk-1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#FEF2F2;strokeColor=#EF4444;strokeWidth=2;fontColor=#7F1D1D;fontSize=13;align=center;" value="&lt;b&gt;발송 중단&lt;/b&gt;&lt;br&gt;&lt;span style=&quot;font-weight: normal;&quot;&gt;조건 불일치 알림 차단&lt;/span&gt;" vertex="1">
+          <mxGeometry height="70" width="200" y="170" as="geometry" />
         </mxCell>
       </root>
     </mxGraphModel>
   </diagram>
   <diagram id="webpage-image-restore-page" name="WebPage Image Restore Flow">
-    <mxGraphModel dx="1885" dy="1015" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="900" pageHeight="1400" background="none" math="0" shadow="0">
+    <mxGraphModel dx="1131" dy="680" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1280" pageHeight="600" background="#ffffff" math="0" shadow="0">
       <root>
         <mxCell id="0" />
         <mxCell id="1" parent="0" />
-        <mxCell id="300" parent="1" style="rounded=1;arcSize=20;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#D8E0EA;strokeWidth=2;" value="" vertex="1">
-          <mxGeometry height="1024" width="450" x="200" y="36" as="geometry" />
-        </mxCell>
-        <mxCell id="301" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=18;fontStyle=1;fontColor=#1F2328;" value="WebPage Image Restore Flow" vertex="1">
-          <mxGeometry height="28" width="300" x="263" y="50" as="geometry" />
-        </mxCell>
-        <mxCell id="302" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#EAF2FF;strokeColor=#0A84FF;strokeWidth=2;fontColor=#0B1F33;fontStyle=1;fontSize=15;" value="웹페이지 데이터 fetch" vertex="1">
-          <mxGeometry height="50" width="230" x="220" y="100" as="geometry" />
-        </mxCell>
-        <mxCell id="303" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#A7B4C6;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=15;" value="Firestore 웹페이지 데이터 조회" vertex="1">
-          <mxGeometry height="50" width="230" x="220" y="200" as="geometry" />
-        </mxCell>
-        <mxCell id="304" parent="1" style="rhombus;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#0A84FF;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=15;" value="&lt;div&gt;&lt;br&gt;&lt;/div&gt;이미지 복구 필요?&lt;div&gt;&lt;span style=&quot;color: rgb(107, 114, 128); font-size: 11px; font-weight: 400; white-space: nowrap;&quot;&gt;imageURL이 실제 로컬 리소스를&lt;/span&gt;&lt;br style=&quot;color: rgb(107, 114, 128); font-size: 11px; font-weight: 400; white-space: nowrap;&quot;&gt;&lt;span style=&quot;color: rgb(107, 114, 128); font-size: 11px; font-weight: 400; white-space: nowrap;&quot;&gt;가리키는지 확인&lt;/span&gt;&lt;/div&gt;" vertex="1">
-          <mxGeometry height="110" width="230" x="220" y="300" as="geometry" />
-        </mxCell>
-        <mxCell id="306" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#A7B4C6;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=15;" value="메타데이터 재수집" vertex="1">
-          <mxGeometry height="50" width="230" x="220" y="460" as="geometry" />
-        </mxCell>
-        <mxCell id="307" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#A7B4C6;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=15;" value="로컬 이미지 캐시 생성" vertex="1">
-          <mxGeometry height="50" width="230" x="220" y="560" as="geometry" />
-        </mxCell>
-        <mxCell id="308" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#A7B4C6;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=15;" value="Application Support /&#xa;webPageImages 저장" vertex="1">
-          <mxGeometry height="50" width="230" x="220" y="660" as="geometry" />
-        </mxCell>
-        <mxCell id="309" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#A7B4C6;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=15;" value="복구된 imageURL로&#xa;Firestore 데이터 갱신" vertex="1">
-          <mxGeometry height="50" width="230" x="220" y="760" as="geometry" />
-        </mxCell>
-        <mxCell id="310" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#A7B4C6;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=15;" value="기존 데이터 반환" vertex="1">
-          <mxGeometry height="52" width="108" x="520" y="329" as="geometry" />
-        </mxCell>
-        <mxCell id="311" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#A7B4C6;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=14;" value="실패 시 썸네일&amp;nbsp;&lt;div&gt;없이 반환&lt;/div&gt;" vertex="1">
-          <mxGeometry height="72" width="108" x="492" y="449" as="geometry" />
-        </mxCell>
-        <mxCell id="312" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#A7B4C6;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=15;" value="복구된 데이터 반환" vertex="1">
-          <mxGeometry height="50" width="230" x="220" y="860" as="geometry" />
-        </mxCell>
-        <mxCell id="313" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#A7B4C6;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=15;" value="UI에 전달" vertex="1">
-          <mxGeometry height="50" width="230" x="220" y="960" as="geometry" />
-        </mxCell>
-        <mxCell id="314" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=12;fontColor=#6B7280;" value="No" vertex="1">
-          <mxGeometry height="20" width="28" x="460" y="361" as="geometry" />
-        </mxCell>
-        <mxCell id="315" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=12;fontColor=#6B7280;" value="Yes" vertex="1">
-          <mxGeometry height="20" width="40" x="330" y="411" as="geometry" />
-        </mxCell>
-        <mxCell id="317" edge="1" parent="1" source="303" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0A84FF;strokeWidth=3;" target="304">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-        <mxCell id="318" edge="1" parent="1" source="304" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0A84FF;strokeWidth=3;" target="306">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-        <mxCell id="319" edge="1" parent="1" source="304" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#5E6AD2;strokeWidth=3;" target="310">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-        <mxCell id="320" edge="1" parent="1" source="306" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0A84FF;strokeWidth=3;" target="307">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-        <mxCell id="321" edge="1" parent="1" source="307" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0A84FF;strokeWidth=3;" target="308">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-        <mxCell id="322" edge="1" parent="1" source="308" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0A84FF;strokeWidth=3;" target="309">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-        <mxCell id="323" edge="1" parent="1" source="309" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0A84FF;strokeWidth=3;" target="312">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-        <mxCell id="325" edge="1" parent="1" source="306" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#5E6AD2;strokeWidth=3;exitX=1;exitY=0.5;exitDx=0;exitDy=0;" target="311">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-        <mxCell id="326" edge="1" parent="1" source="311" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#5E6AD2;strokeWidth=3;edgeStyle=orthogonalEdgeStyle;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" target="313">
+        <mxCell id="web-img-edge-fetch-read" edge="1" parent="1" source="web-img-fetch" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=0;strokeColor=#0A84FF;strokeWidth=3;labelBackgroundColor=#FFFFFF;fontSize=12;fontColor=#334155;" target="web-img-firestore-read" value="저장 데이터 조회">
           <mxGeometry relative="1" as="geometry">
-            <Array as="points">
-              <mxPoint x="550" y="985" />
-            </Array>
+            <mxPoint y="-14" as="offset" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="327" edge="1" parent="1" source="312" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0A84FF;strokeWidth=3;" target="313">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-        <mxCell id="t-uegaWhmTgudXhdjnCE-327" edge="1" parent="1" source="300" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;" target="300">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-        <mxCell id="DXkntij-9fGk1yJ9dKEM-329" edge="1" parent="1" source="302" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0A84FF;strokeWidth=3;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" target="303">
+        <mxCell id="web-img-edge-read-check" edge="1" parent="1" source="web-img-firestore-read" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=0;strokeColor=#64748B;strokeWidth=3;labelBackgroundColor=#FFFFFF;fontSize=12;fontColor=#334155;" target="web-img-cache-check" value="imageURL 확인">
           <mxGeometry relative="1" as="geometry">
-            <mxPoint x="335" y="160" as="sourcePoint" />
-            <mxPoint x="334.77" y="200" as="targetPoint" />
+            <mxPoint y="-14" as="offset" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="yQ3WxlWRvIrxJqyOYGCa-328" edge="1" parent="1" source="310" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#5E6AD2;strokeWidth=3;edgeStyle=orthogonalEdgeStyle;entryX=1;entryY=0.5;entryDx=0;entryDy=0;exitX=0.836;exitY=0.994;exitDx=0;exitDy=0;exitPerimeter=0;" target="313">
-          <mxGeometry relative="1" as="geometry">
-            <Array as="points">
-              <mxPoint x="610" y="620" />
-              <mxPoint x="550" y="620" />
-              <mxPoint x="550" y="985" />
-            </Array>
-            <mxPoint x="610" y="396" as="sourcePoint" />
-            <mxPoint x="510" y="860" as="targetPoint" />
+        <mxCell id="web-img-edge-check-restore" edge="1" parent="1" source="web-img-cache-check" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=0;strokeColor=#0891B2;strokeWidth=3;labelBackgroundColor=#FFFFFF;fontSize=12;fontColor=#0E3B43;exitX=0;exitY=0.75;exitDx=0;exitDy=0;entryX=0.991;entryY=0.008;entryDx=0;entryDy=0;entryPerimeter=0;" target="web-img-restore" value="캐시 유실 감지">
+          <mxGeometry relative="1" x="-0.0139" y="-26" as="geometry">
+            <mxPoint as="offset" />
           </mxGeometry>
+        </mxCell>
+        <mxCell id="web-img-edge-restore-update" edge="1" parent="1" source="web-img-restore" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=0;strokeColor=#16A34A;strokeWidth=3;labelBackgroundColor=#FFFFFF;fontSize=12;fontColor=#14532D;" target="web-img-firestore-update" value="복구된 imageURL">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint y="-14" as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="web-img-edge-update-ui" edge="1" parent="1" source="web-img-firestore-update" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=0;strokeColor=#64748B;strokeWidth=3;labelBackgroundColor=#FFFFFF;fontSize=12;fontColor=#334155;" target="web-img-ui" value="복구 결과 반환">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint y="-14" as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="web-img-fetch" link="https://github.com/opficdev/SwiftUI_DevLog/blob/main/DevLog/Data/Repository/WebPageRepositoryImpl.swift" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#EAF2FF;strokeColor=#0A84FF;strokeWidth=2;fontColor=#0B1F33;fontStyle=1;fontSize=15;" value="&lt;b&gt;웹페이지 fetch&lt;/b&gt;&lt;div&gt;&lt;span style=&quot;font-size:12px;font-weight:400;&quot;&gt;저장된 WebPage 조회&lt;/span&gt;&lt;/div&gt;" vertex="1">
+          <mxGeometry height="70" width="200" x="60" y="110" as="geometry" />
+        </mxCell>
+        <mxCell id="web-img-firestore-read" link="https://github.com/opficdev/SwiftUI_DevLog/blob/main/DevLog/Infra/Service/WebPageService.swift" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#64748B;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=15;" value="&lt;b&gt;Firestore WebPage&lt;/b&gt;&lt;div&gt;&lt;span style=&quot;font-size:12px;font-weight:400;&quot;&gt;imageURL·메타데이터 보관&lt;/span&gt;&lt;/div&gt;" vertex="1">
+          <mxGeometry height="70" width="200" x="405" y="110" as="geometry" />
+        </mxCell>
+        <mxCell id="web-img-cache-check" link="https://github.com/opficdev/SwiftUI_DevLog/blob/main/DevLog/Data/Repository/WebPageRepositoryImpl.swift" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#ECFEFF;strokeColor=#0891B2;strokeWidth=2;fontColor=#0E3B43;fontStyle=1;fontSize=15;" value="&lt;b&gt;로컬 캐시 검증&lt;/b&gt;&lt;div&gt;&lt;span style=&quot;font-size:12px;font-weight:400;&quot;&gt;파일 경로·이미지 데이터 확인&lt;/span&gt;&lt;/div&gt;" vertex="1">
+          <mxGeometry height="70" width="200" x="780" y="110" as="geometry" />
+        </mxCell>
+        <mxCell id="web-img-restore" link="https://github.com/opficdev/SwiftUI_DevLog/blob/main/DevLog/Infra/Service/WebPageMetadataService.swift" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#DCFCE7;strokeColor=#16A34A;strokeWidth=2;fontColor=#14532D;fontStyle=1;fontSize=15;" value="&lt;b&gt;메타데이터 복구&lt;/b&gt;&lt;div&gt;&lt;span style=&quot;font-size:12px;font-weight:400;&quot;&gt;썸네일 재수집·캐시 재생성&lt;/span&gt;&lt;/div&gt;" vertex="1">
+          <mxGeometry height="70" width="200" x="60" y="350" as="geometry" />
+        </mxCell>
+        <mxCell id="web-img-firestore-update" link="https://github.com/opficdev/SwiftUI_DevLog/blob/main/DevLog/Infra/Service/WebPageService.swift" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#64748B;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=15;" value="&lt;b&gt;Firestore 갱신&lt;/b&gt;&lt;div&gt;&lt;span style=&quot;font-size:12px;font-weight:400;&quot;&gt;복구된 imageURL 저장&lt;/span&gt;&lt;/div&gt;" vertex="1">
+          <mxGeometry height="70" width="200" x="405" y="350" as="geometry" />
+        </mxCell>
+        <mxCell id="web-img-ui" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#F5F3FF;strokeColor=#7C3AED;strokeWidth=2;fontColor=#2E1065;fontStyle=1;fontSize=15;" value="&lt;b&gt;웹페이지 리스트 UI&lt;/b&gt;&lt;div&gt;&lt;span style=&quot;font-size:12px;font-weight:400;&quot;&gt;복구 결과 기준 표시&lt;/span&gt;&lt;/div&gt;" vertex="1">
+          <mxGeometry height="70" width="200" x="780" y="350" as="geometry" />
         </mxCell>
       </root>
     </mxGraphModel>

--- a/docs/DevLog.drawio
+++ b/docs/DevLog.drawio
@@ -103,24 +103,12 @@
     </mxGraphModel>
   </diagram>
   <diagram id="delete-flow-page" name="Delete Undo Flow">
-    <mxGraphModel dx="1414" dy="850" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1280" pageHeight="600" background="#ffffff" math="0" shadow="0">
+    <mxGraphModel dx="555" dy="333" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1280" pageHeight="600" background="#ffffff" math="0" shadow="0">
       <root>
         <mxCell id="0" />
         <mxCell id="1" parent="0" />
         <mxCell id="du-request-device" link="https://github.com/opficdev/SwiftUI_DevLog/blob/main/DevLog/Presentation/ViewModel/PushNotificationListViewModel.swift" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#EAF2FF;strokeColor=#0A84FF;strokeWidth=2;fontColor=#0B1F33;fontSize=13;align=center;" value="&lt;b&gt;iOS Client&lt;/b&gt;" vertex="1">
           <mxGeometry height="70" width="200" x="80" y="250" as="geometry" />
-        </mxCell>
-        <mxCell id="du-functions" link="https://github.com/opficdev/SwiftUI_DevLog/blob/main/Firebase/functions/src/notification/deletion.ts" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#DCFCE7;strokeColor=#16A34A;strokeWidth=2;fontColor=#14532D;fontSize=13;align=center;" value="&lt;b&gt;Cloud Functions&lt;/b&gt;&lt;br&gt;&lt;span style=&quot;font-weight: normal;&quot;&gt;삭제·Undo 요청 처리&lt;/span&gt;" vertex="1">
-          <mxGeometry height="70" width="200" x="390" y="250" as="geometry" />
-        </mxCell>
-        <mxCell id="du-firestore" link="https://github.com/opficdev/SwiftUI_DevLog/blob/main/Firebase/functions/src/notification/deletion.ts" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#64748B;strokeWidth=2;fontColor=#1F2328;fontSize=13;align=center;" value="&lt;b&gt;Firestore 알림 문서&lt;/b&gt;&lt;br&gt;&lt;span style=&quot;font-weight: normal;&quot;&gt;삭제 상태 저장·해제&lt;/span&gt;" vertex="1">
-          <mxGeometry height="70" width="200" x="710" y="250" as="geometry" />
-        </mxCell>
-        <mxCell id="du-request-list" link="https://github.com/opficdev/SwiftUI_DevLog/blob/main/DevLog/Presentation/ViewModel/PushNotificationListViewModel.swift" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#F5F3FF;strokeColor=#7C3AED;strokeWidth=2;fontColor=#1F2328;fontSize=13;align=center;" value="&lt;b&gt;요청 기기 리스트&lt;/b&gt;&lt;br&gt;&lt;span style=&quot;font-weight: normal;&quot;&gt;서버 재조회로 동기화&lt;/span&gt;" vertex="1">
-          <mxGeometry height="70" width="200" x="1020" y="150" as="geometry" />
-        </mxCell>
-        <mxCell id="du-other-list" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#F5F3FF;strokeColor=#7C3AED;strokeWidth=2;fontColor=#1F2328;fontSize=13;align=center;" value="&lt;b&gt;다른 기기 리스트&lt;/b&gt;&lt;br&gt;&lt;span style=&quot;font-weight: normal;&quot;&gt;같은 삭제 상태 반영&lt;/span&gt;" vertex="1">
-          <mxGeometry height="70" width="200" x="1020" y="350" as="geometry" />
         </mxCell>
         <mxCell id="du-edge-request-functions" edge="1" parent="1" source="du-request-device" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0A84FF;strokeWidth=3;labelBackgroundColor=#FFFFFF;fontSize=12;" target="du-functions" value="삭제·Undo 요청">
           <mxGeometry relative="1" x="-0.0909" y="15" as="geometry">
@@ -132,7 +120,7 @@
             <mxPoint as="offset" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="du-edge-functions-undo" edge="1" parent="1" source="du-functions" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#16A34A;strokeWidth=3;labelBackgroundColor=#FFFFFF;fontSize=12;" target="du-firestore" value="">
+        <mxCell id="du-edge-functions-undo" edge="1" parent="1" source="du-functions" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#16A34A;strokeWidth=3;labelBackgroundColor=#FFFFFF;fontSize=12;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" target="du-firestore" value="">
           <mxGeometry relative="1" x="0.0909" y="9" as="geometry">
             <mxPoint as="offset" />
           </mxGeometry>
@@ -146,6 +134,18 @@
           <mxGeometry relative="1" x="-0.4165" y="-28" as="geometry">
             <mxPoint as="offset" />
           </mxGeometry>
+        </mxCell>
+        <mxCell id="du-functions" link="https://github.com/opficdev/SwiftUI_DevLog/blob/main/Firebase/functions/src/notification/deletion.ts" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#DCFCE7;strokeColor=#16A34A;strokeWidth=2;fontColor=#14532D;fontSize=13;align=center;" value="&lt;b&gt;Cloud Functions&lt;/b&gt;&lt;br&gt;&lt;span style=&quot;font-weight: normal;&quot;&gt;삭제·Undo 요청 처리&lt;/span&gt;" vertex="1">
+          <mxGeometry height="70" width="200" x="390" y="250" as="geometry" />
+        </mxCell>
+        <mxCell id="du-firestore" link="https://github.com/opficdev/SwiftUI_DevLog/blob/main/Firebase/functions/src/notification/deletion.ts" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#64748B;strokeWidth=2;fontColor=#1F2328;fontSize=13;align=center;" value="&lt;b&gt;Firestore 알림 문서&lt;/b&gt;&lt;br&gt;&lt;span style=&quot;font-weight: normal;&quot;&gt;삭제 상태 저장·해제&lt;/span&gt;" vertex="1">
+          <mxGeometry height="70" width="200" x="710" y="250" as="geometry" />
+        </mxCell>
+        <mxCell id="du-request-list" link="https://github.com/opficdev/SwiftUI_DevLog/blob/main/DevLog/Presentation/ViewModel/PushNotificationListViewModel.swift" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#F5F3FF;strokeColor=#7C3AED;strokeWidth=2;fontColor=#1F2328;fontSize=13;align=center;" value="&lt;b&gt;요청 기기 리스트&lt;/b&gt;&lt;br&gt;&lt;span style=&quot;font-weight: normal;&quot;&gt;서버 재조회로 동기화&lt;/span&gt;" vertex="1">
+          <mxGeometry height="70" width="200" x="1020" y="150" as="geometry" />
+        </mxCell>
+        <mxCell id="du-other-list" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#F5F3FF;strokeColor=#7C3AED;strokeWidth=2;fontColor=#1F2328;fontSize=13;align=center;" value="&lt;b&gt;다른 기기 리스트&lt;/b&gt;&lt;br&gt;&lt;span style=&quot;font-weight: normal;&quot;&gt;같은 삭제 상태 반영&lt;/span&gt;" vertex="1">
+          <mxGeometry height="70" width="200" x="1020" y="350" as="geometry" />
         </mxCell>
       </root>
     </mxGraphModel>


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #449

## 🎯 의도

- 포트폴리오 문서에서 개별 기능 설명보다 아키텍처와 데이터 흐름을 먼저 이해할 수 있도록 구성하기 위함
- 기능 단위 구현 설명만으로는 문제 해결의 맥락이 분산되어 보일 수 있어 각 개선 사례가 어떤 책임 이동과 흐름 변경을 통해 해결되었는지 먼저 드러내고자 함

## 📝 작업 내용

### 📌 요약

- 주요 문제 해결 사례의 설명 순서를 아키텍처와 전체 플로우 중심으로 재구성
- 기능 동작 설명보다 데이터 흐름, 책임 분리, 서버 기준 상태 관리가 먼저 보이도록 문서 구조 조정
- 각 사례의 문제 원인, 해결 과정, 결과를 포트폴리오 문맥에 맞게 간결하게 정리

### 🔍 상세

- Todo 리마인더 흐름에서 Cloud Tasks, 서버 배치, 발송 시점 검증의 역할이 드러나도록 구성
- 푸시알림 삭제 Undo 흐름에서 클라이언트 로컬 상태 의존을 서버 삭제 유예 상태 관리로 옮긴 흐름을 우선 설명
- 웹페이지 썸네일 복구 흐름에서 Firestore에 저장된 이미지 URL과 로컬 캐시 검증, 복구 흐름이 이어지도록 정리
- 결과 섹션은 구현 과정 반복을 줄이고 실제로 해소된 문제와 부가 효과 중심으로 축약

## 📸 영상 / 이미지 (Optional)
