### PR TITLE
[#454] Infra 레이어에서 Domain 레이어 의존성을 제거한다

### DIFF
--- a/Application/DevLogCore/Sources/PushNotificationQuery.swift
+++ b/Application/DevLogCore/Sources/PushNotificationQuery.swift
@@ -1,6 +1,6 @@
 //
 //  PushNotificationQuery.swift
-//  DevLogDomain
+//  DevLogCore
 //
 //  Created by opfic on 2/18/26.
 //

--- a/Application/DevLogCore/Sources/SystemTheme.swift
+++ b/Application/DevLogCore/Sources/SystemTheme.swift
@@ -1,6 +1,6 @@
 //
 //  SystemTheme.swift
-//  DevLogDomain
+//  DevLogCore
 //
 //  Created by opfic on 5/6/25.
 //

--- a/Application/DevLogCore/Sources/TodayDisplayOptions.swift
+++ b/Application/DevLogCore/Sources/TodayDisplayOptions.swift
@@ -1,6 +1,6 @@
 //
 //  TodayDisplayOptions.swift
-//  DevLogDomain
+//  DevLogCore
 //
 //  Created by opfic on 3/6/26.
 //

--- a/Application/DevLogCore/Sources/TodoQuery.swift
+++ b/Application/DevLogCore/Sources/TodoQuery.swift
@@ -1,6 +1,6 @@
 //
 //  TodoQuery.swift
-//  DevLogDomain
+//  DevLogCore
 //
 //  Created by opfic on 2/21/26.
 //
@@ -14,47 +14,17 @@ public struct TodoQuery: Equatable {
         case deletedAt
         case updatedAt
         case dueDate
-
-        public var fieldName: String {
-            switch self {
-            case .createdAt:
-                return "createdAt"
-            case .completedAt:
-                return "completedAt"
-            case .deletedAt:
-                return "deletedAt"
-            case .updatedAt:
-                return "updatedAt"
-            case .dueDate:
-                return "dueDate"
-            }
-        }
     }
 
     public enum SortOrder: Equatable, Hashable {
         case latest
         case oldest
-
-        public var isDescending: Bool {
-            self == .latest
-        }
     }
 
     public enum CompletionFilter: Equatable, Hashable {
         case all
         case incomplete
         case completed
-
-        public var isCompletedValue: Bool? {
-            switch self {
-            case .all:
-                return nil
-            case .incomplete:
-                return false
-            case .completed:
-                return true
-            }
-        }
     }
 
     public enum DueDateFilter: Equatable, Hashable {
@@ -63,7 +33,7 @@ public struct TodoQuery: Equatable {
         case withoutDueDate
     }
 
-    public var category: TodoCategory?
+    public var categoryId: String?
     public var keyword: String?
     public var isPinned: Bool?
     public var completionFilter: CompletionFilter
@@ -77,7 +47,7 @@ public struct TodoQuery: Equatable {
     public var fetchAllPages: Bool
 
     public init(
-        category: TodoCategory? = nil,
+        categoryId: String? = nil,
         keyword: String? = nil,
         isPinned: Bool? = nil,
         completionFilter: CompletionFilter = .all,
@@ -90,7 +60,7 @@ public struct TodoQuery: Equatable {
         pageSize: Int = 20,
         fetchAllPages: Bool = false
     ) {
-        self.category = category
+        self.categoryId = categoryId
         self.keyword = keyword
         self.isPinned = isPinned
         self.completionFilter = completionFilter

--- a/Application/DevLogData/Sources/Common/DataLayerError.swift
+++ b/Application/DevLogData/Sources/Common/DataLayerError.swift
@@ -44,6 +44,10 @@ public enum DataError: Error {
     }
 }
 
+public enum DataLayerError: Error {
+    case notAuthenticated
+}
+
 public extension Error {
     var isSocialLoginCancelled: Bool {
         switch self {

--- a/Application/DevLogData/Sources/Common/DataLayerError.swift
+++ b/Application/DevLogData/Sources/Common/DataLayerError.swift
@@ -46,6 +46,7 @@ public enum DataError: Error {
 
 public enum DataLayerError: Error {
     case notAuthenticated
+    case linkCredentialAlreadyInUse
 }
 
 public extension Error {

--- a/Application/DevLogData/Sources/DTO/TodoCategoryPreferenceResponse.swift
+++ b/Application/DevLogData/Sources/DTO/TodoCategoryPreferenceResponse.swift
@@ -1,0 +1,42 @@
+//
+//  TodoCategoryPreferenceResponse.swift
+//  DevLogData
+//
+//  Created by opfic on 5/16/26.
+//
+
+import Foundation
+
+public struct TodoCategoryPreferenceResponse: Equatable {
+    public enum Category: Equatable {
+        case system(String)
+        case user(UserCategory)
+    }
+
+    public struct UserCategory: Equatable {
+        public let id: String
+        public let name: String
+        public let colorHex: String
+
+        public init(
+            id: String,
+            name: String,
+            colorHex: String
+        ) {
+            self.id = id
+            self.name = name
+            self.colorHex = colorHex
+        }
+    }
+
+    public let category: Category
+    public let isVisible: Bool
+
+    public init(
+        category: Category,
+        isVisible: Bool
+    ) {
+        self.category = category
+        self.isVisible = isVisible
+    }
+}

--- a/Application/DevLogData/Sources/DTO/TodoCursorDTO.swift
+++ b/Application/DevLogData/Sources/DTO/TodoCursorDTO.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import DevLogDomain
 
 public struct TodoCursorDTO {
     public let primarySortDate: Date?

--- a/Application/DevLogData/Sources/Mapper/DataLayerErrorMapping.swift
+++ b/Application/DevLogData/Sources/Mapper/DataLayerErrorMapping.swift
@@ -1,0 +1,18 @@
+//
+//  DataLayerErrorMapping.swift
+//  DevLogData
+//
+//  Created by opfic on 5/16/26.
+//
+
+import DevLogDomain
+
+extension Error {
+    func toDataLayerError() -> Error {
+        if case .notAuthenticated = self as? DataLayerError {
+            return AuthError.notAuthenticated
+        }
+
+        return self
+    }
+}

--- a/Application/DevLogData/Sources/Mapper/ErrorMapping.swift
+++ b/Application/DevLogData/Sources/Mapper/ErrorMapping.swift
@@ -9,10 +9,13 @@ import DevLogDomain
 
 extension Error {
     func toDomain() -> Error {
-        if case .notAuthenticated = self as? DataLayerError {
+        switch self as? DataLayerError {
+        case .notAuthenticated:
             return AuthError.notAuthenticated
+        case .linkCredentialAlreadyInUse:
+            return AuthError.linkCredentialAlreadyInUse
+        case .none:
+            return self
         }
-
-        return self
     }
 }

--- a/Application/DevLogData/Sources/Mapper/ErrorMapping.swift
+++ b/Application/DevLogData/Sources/Mapper/ErrorMapping.swift
@@ -1,5 +1,5 @@
 //
-//  DataLayerErrorMapping.swift
+//  ErrorMapping.swift
 //  DevLogData
 //
 //  Created by opfic on 5/16/26.
@@ -8,7 +8,7 @@
 import DevLogDomain
 
 extension Error {
-    func toDataLayerError() -> Error {
+    func toDomain() -> Error {
         if case .notAuthenticated = self as? DataLayerError {
             return AuthError.notAuthenticated
         }

--- a/Application/DevLogData/Sources/Mapper/TodoCategoryMapping.swift
+++ b/Application/DevLogData/Sources/Mapper/TodoCategoryMapping.swift
@@ -76,17 +76,18 @@ private func mergedTodoCategoryPreferences(
     _ preferences: [TodoCategoryPreference]
 ) -> [TodoCategoryPreference] {
     var mergedPreferences = preferences
-
-    for systemTodoCategory in SystemTodoCategory.allCases {
-        let containsSystemTodoCategory = preferences.contains { preference in
-            guard case .system(let currentSystemTodoCategory) = preference.category else {
-                return false
+    let existingSystemTodoCategories = Set<SystemTodoCategory>(
+        preferences.compactMap { preference in
+            guard case .system(let systemTodoCategory) = preference.category else {
+                return nil
             }
 
-            return currentSystemTodoCategory == systemTodoCategory
+            return systemTodoCategory
         }
+    )
 
-        if containsSystemTodoCategory { continue }
+    for systemTodoCategory in SystemTodoCategory.allCases {
+        if existingSystemTodoCategories.contains(systemTodoCategory) { continue }
 
         mergedPreferences.append(
             TodoCategoryPreference(

--- a/Application/DevLogData/Sources/Mapper/TodoCategoryMapping.swift
+++ b/Application/DevLogData/Sources/Mapper/TodoCategoryMapping.swift
@@ -1,0 +1,100 @@
+//
+//  TodoCategoryMapping.swift
+//  DevLogData
+//
+//  Created by opfic on 5/16/26.
+//
+
+import DevLogDomain
+
+extension TodoCategoryPreferenceResponse {
+    static func fromDomain(_ preference: TodoCategoryPreference) -> Self {
+        switch preference.category {
+        case .system(let systemTodoCategory):
+            return TodoCategoryPreferenceResponse(
+                category: .system(systemTodoCategory.rawValue),
+                isVisible: preference.isVisible
+            )
+        case .user(let userTodoCategory):
+            return TodoCategoryPreferenceResponse(
+                category: .user(
+                    UserCategory(
+                        id: userTodoCategory.id,
+                        name: userTodoCategory.name,
+                        colorHex: userTodoCategory.colorHex
+                    )
+                ),
+                isVisible: preference.isVisible
+            )
+        }
+    }
+
+    func toDomain() -> TodoCategoryPreference? {
+        switch category {
+        case .system(let rawValue):
+            guard let systemTodoCategory = SystemTodoCategory(rawValue: rawValue) else {
+                return nil
+            }
+
+            return TodoCategoryPreference(
+                category: .system(systemTodoCategory),
+                isVisible: isVisible
+            )
+        case .user(let userCategory):
+            return TodoCategoryPreference(
+                category: .user(
+                    UserTodoCategory(
+                        id: userCategory.id,
+                        name: userCategory.name,
+                        colorHex: userCategory.colorHex
+                    )
+                ),
+                isVisible: isVisible
+            )
+        }
+    }
+}
+
+extension Array where Element == TodoCategoryPreferenceResponse {
+    func toDomain() -> [TodoCategoryPreference] {
+        let preferences = compactMap { $0.toDomain() }
+        guard !preferences.isEmpty else {
+            return defaultTodoCategoryPreferences()
+        }
+
+        return mergedTodoCategoryPreferences(preferences)
+    }
+}
+
+private func defaultTodoCategoryPreferences() -> [TodoCategoryPreference] {
+    SystemTodoCategory.allCases.map {
+        TodoCategoryPreference(category: .system($0), isVisible: true)
+    }
+}
+
+private func mergedTodoCategoryPreferences(
+    _ preferences: [TodoCategoryPreference]
+) -> [TodoCategoryPreference] {
+    var mergedPreferences = preferences
+
+    for systemTodoCategory in SystemTodoCategory.allCases {
+        let containsSystemTodoCategory = preferences.contains { preference in
+            guard case .system(let currentSystemTodoCategory) = preference.category else {
+                return false
+            }
+
+            return currentSystemTodoCategory == systemTodoCategory
+        }
+
+        if containsSystemTodoCategory { continue }
+
+        mergedPreferences.append(
+            TodoCategoryPreference(
+                category: .system(systemTodoCategory),
+                isVisible: true
+            )
+        )
+    }
+
+    return mergedPreferences
+}

--- a/Application/DevLogData/Sources/Protocol/PushNotificationService.swift
+++ b/Application/DevLogData/Sources/Protocol/PushNotificationService.swift
@@ -7,7 +7,7 @@
 
 import Combine
 import Foundation
-import DevLogDomain
+import DevLogCore
 
 public protocol PushNotificationService {
     func fetchPushNotificationEnabled() async throws -> Bool

--- a/Application/DevLogData/Sources/Protocol/ThemeStore.swift
+++ b/Application/DevLogData/Sources/Protocol/ThemeStore.swift
@@ -7,7 +7,7 @@
 
 import Combine
 import Foundation
-import DevLogDomain
+import DevLogCore
 
 public protocol ThemeStore {
     func observeTheme() -> AnyPublisher<SystemTheme, Never>

--- a/Application/DevLogData/Sources/Protocol/TodoCategoryService.swift
+++ b/Application/DevLogData/Sources/Protocol/TodoCategoryService.swift
@@ -6,9 +6,8 @@
 //
 
 import Foundation
-import DevLogDomain
 
 public protocol TodoCategoryService {
-    func fetchPreferences() async throws -> [TodoCategoryPreference]
-    func updatePreferences(_ preferences: [TodoCategoryPreference]) async throws
+    func fetchPreferences() async throws -> [TodoCategoryPreferenceResponse]
+    func updatePreferences(_ preferences: [TodoCategoryPreferenceResponse]) async throws
 }

--- a/Application/DevLogData/Sources/Protocol/TodoService.swift
+++ b/Application/DevLogData/Sources/Protocol/TodoService.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import DevLogDomain
+import DevLogCore
 
 public protocol TodoService {
     func fetchTodos(_ query: TodoQuery, cursor: TodoCursorDTO?) async throws -> TodoPageResponse

--- a/Application/DevLogData/Sources/Protocol/WidgetSnapshotPreferenceStore.swift
+++ b/Application/DevLogData/Sources/Protocol/WidgetSnapshotPreferenceStore.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import DevLogCore
 import DevLogDomain
 
 public protocol WidgetSnapshotPreferenceStore {

--- a/Application/DevLogData/Sources/Protocol/WidgetSnapshotUpdater.swift
+++ b/Application/DevLogData/Sources/Protocol/WidgetSnapshotUpdater.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import DevLogCore
 import DevLogDomain
 
 public protocol WidgetSnapshotUpdater {

--- a/Application/DevLogData/Sources/Repository/AuthDataRepositoryImpl.swift
+++ b/Application/DevLogData/Sources/Repository/AuthDataRepositoryImpl.swift
@@ -94,6 +94,6 @@ private extension AuthDataRepositoryImpl {
             }
         }
 
-        return error
+        return error.toDomain()
     }
 }

--- a/Application/DevLogData/Sources/Repository/AuthenticationRepositoryImpl.swift
+++ b/Application/DevLogData/Sources/Repository/AuthenticationRepositoryImpl.swift
@@ -76,8 +76,12 @@ final class AuthenticationRepositoryImpl: AuthenticationRepository {
             case .google:
                 try await googleAuthService.signOut(uid)
             }
-        } catch AuthError.notAuthenticated {
-            try await authService.clearCurrentSession()
+        } catch {
+            if case AuthError.notAuthenticated = error.toDomain() {
+                try await authService.clearCurrentSession()
+            } else {
+                throw error.toDomain()
+            }
         }
 
         widgetSnapshotUpdater.clear()
@@ -106,9 +110,13 @@ final class AuthenticationRepositoryImpl: AuthenticationRepository {
             }
         }
 
-        try await authService.deleteCurrentUser()
-        try await authService.clearCurrentSession()
-        widgetSnapshotUpdater.clear()
+        do {
+            try await authService.deleteCurrentUser()
+            try await authService.clearCurrentSession()
+            widgetSnapshotUpdater.clear()
+        } catch {
+            throw error.toDomain()
+        }
     }
 }
 
@@ -119,6 +127,6 @@ private extension AuthenticationRepositoryImpl {
             return AuthError.emailNotFound
         }
 
-        return error
+        return error.toDomain()
     }
 }

--- a/Application/DevLogData/Sources/Repository/PushNotificationRepositoryImpl.swift
+++ b/Application/DevLogData/Sources/Repository/PushNotificationRepositoryImpl.swift
@@ -23,19 +23,31 @@ final class PushNotificationRepositoryImpl: PushNotificationRepository {
 
     /// 푸시 알림 On/Off 설정
     func fetchPushNotificationEnabled() async throws -> Bool {
-        return try await pushNotificationService.fetchPushNotificationEnabled()
+        do {
+            return try await pushNotificationService.fetchPushNotificationEnabled()
+        } catch {
+            throw error.toDomain()
+        }
     }
 
     /// 푸시 알림 시간 설정
     func fetchPushNotificationTime() async throws -> DateComponents {
-        return try await pushNotificationService.fetchPushNotificationTime()
+        do {
+            return try await pushNotificationService.fetchPushNotificationTime()
+        } catch {
+            throw error.toDomain()
+        }
     }
 
     /// 푸시 알림 설정 업데이트
     func updatePushNotificationSettings(_ settings: PushNotificationSettings) async throws {
-        try await pushNotificationService.updatePushNotificationSettings(
-            isEnabled: settings.isEnabled, components: settings.scheduledTime
-        )
+        do {
+            try await pushNotificationService.updatePushNotificationSettings(
+                isEnabled: settings.isEnabled, components: settings.scheduledTime
+            )
+        } catch {
+            throw error.toDomain()
+        }
     }
 
     /// 푸시 알림 기록 요청
@@ -43,12 +55,16 @@ final class PushNotificationRepositoryImpl: PushNotificationRepository {
         _ query: PushNotificationQuery,
         cursor: PushNotificationCursor?
     ) async throws -> PushNotificationPage {
-        let cursorDTO = cursor.map { PushNotificationCursorDTO.fromDomain($0) }
-        async let responseTask = pushNotificationService.requestNotifications(query, cursor: cursorDTO)
-        async let preferencesTask = todoCategoryService.fetchPreferences()
+        do {
+            let cursorDTO = cursor.map { PushNotificationCursorDTO.fromDomain($0) }
+            async let responseTask = pushNotificationService.requestNotifications(query, cursor: cursorDTO)
+            async let preferencesTask = todoCategoryService.fetchPreferences()
 
-        let (response, preferences) = try await (responseTask, preferencesTask)
-        return try resolvePage(from: response, with: preferences)
+            let (response, preferences) = try await (responseTask, preferencesTask)
+            return try resolvePage(from: response, with: preferences)
+        } catch {
+            throw error.toDomain()
+        }
     }
 
     func observeNotifications(
@@ -58,30 +74,34 @@ final class PushNotificationRepositoryImpl: PushNotificationRepository {
         let subject = PassthroughSubject<PushNotificationPage, Error>()
         var cancellable: AnyCancellable?
 
-        cancellable = try pushNotificationService.observeNotifications(query, limit: limit)
-            .sink(
-                receiveCompletion: { completion in
-                    switch completion {
-                    case .finished:
-                        subject.send(completion: .finished)
-                    case .failure(let error):
-                        subject.send(completion: .failure(error))
-                    }
-                },
-                receiveValue: { [weak self] response in
-                    guard let self else { return }
+        do {
+            cancellable = try pushNotificationService.observeNotifications(query, limit: limit)
+                .sink(
+                    receiveCompletion: { completion in
+                        switch completion {
+                        case .finished:
+                            subject.send(completion: .finished)
+                        case .failure(let error):
+                            subject.send(completion: .failure(error.toDomain()))
+                        }
+                    },
+                    receiveValue: { [weak self] response in
+                        guard let self else { return }
 
-                    Task {
-                        do {
-                            let preferences = try await self.todoCategoryService.fetchPreferences()
-                            let page = try self.resolvePage(from: response, with: preferences)
-                            subject.send(page)
-                        } catch {
-                            subject.send(completion: .failure(error))
+                        Task {
+                            do {
+                                let preferences = try await self.todoCategoryService.fetchPreferences()
+                                let page = try self.resolvePage(from: response, with: preferences)
+                                subject.send(page)
+                            } catch {
+                                subject.send(completion: .failure(error.toDomain()))
+                            }
                         }
                     }
-                }
-            )
+                )
+        } catch {
+            throw error.toDomain()
+        }
 
         return subject
             .handleEvents(receiveCancel: { cancellable?.cancel() })
@@ -89,22 +109,39 @@ final class PushNotificationRepositoryImpl: PushNotificationRepository {
     }
 
     func observeUnreadPushCount() throws -> AnyPublisher<Int, Error> {
-        try pushNotificationService.observeUnreadPushCount()
-            .eraseToAnyPublisher()
+        do {
+            return try pushNotificationService.observeUnreadPushCount()
+                .mapError { $0.toDomain() }
+                .eraseToAnyPublisher()
+        } catch {
+            throw error.toDomain()
+        }
     }
 
     // 푸시 알림 기록 삭제
     func deleteNotification(_ notificationID: String) async throws {
-        try await pushNotificationService.deleteNotification(notificationID)
+        do {
+            try await pushNotificationService.deleteNotification(notificationID)
+        } catch {
+            throw error.toDomain()
+        }
     }
 
     func undoDeleteNotification(_ notificationID: String) async throws {
-        try await pushNotificationService.undoDeleteNotification(notificationID)
+        do {
+            try await pushNotificationService.undoDeleteNotification(notificationID)
+        } catch {
+            throw error.toDomain()
+        }
     }
 
     // 푸시 알림 읽음/안읽음 토글
     func toggleNotificationRead(_ todoId: String) async throws {
-        try await pushNotificationService.toggleNotificationRead(todoId)
+        do {
+            try await pushNotificationService.toggleNotificationRead(todoId)
+        } catch {
+            throw error.toDomain()
+        }
     }
 }
 

--- a/Application/DevLogData/Sources/Repository/PushNotificationRepositoryImpl.swift
+++ b/Application/DevLogData/Sources/Repository/PushNotificationRepositoryImpl.swift
@@ -61,8 +61,8 @@ final class PushNotificationRepositoryImpl: PushNotificationRepository {
             async let responseTask = pushNotificationService.requestNotifications(query, cursor: cursorDTO)
             async let preferencesTask = todoCategoryService.fetchPreferences()
 
-            let (response, preferences) = try await (responseTask, preferencesTask)
-            return try resolvePage(from: response, with: preferences)
+            let (response, preferenceResponses) = try await (responseTask, preferencesTask)
+            return try resolvePage(from: response, with: preferenceResponses.toDomain())
         } catch {
             throw error.toDomain()
         }
@@ -91,7 +91,7 @@ final class PushNotificationRepositoryImpl: PushNotificationRepository {
 
                         Task {
                             do {
-                                let preferences = try await self.todoCategoryService.fetchPreferences()
+                                let preferences = try await self.todoCategoryService.fetchPreferences().toDomain()
                                 let page = try self.resolvePage(from: response, with: preferences)
                                 subject.send(page)
                             } catch {

--- a/Application/DevLogData/Sources/Repository/PushNotificationRepositoryImpl.swift
+++ b/Application/DevLogData/Sources/Repository/PushNotificationRepositoryImpl.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import Combine
+import DevLogCore
 import DevLogDomain
 
 final class PushNotificationRepositoryImpl: PushNotificationRepository {

--- a/Application/DevLogData/Sources/Repository/TodoCategoryRepositoryImpl.swift
+++ b/Application/DevLogData/Sources/Repository/TodoCategoryRepositoryImpl.swift
@@ -16,7 +16,7 @@ final class TodoCategoryRepositoryImpl: TodoCategoryRepository {
 
     func fetchPreferences() async throws -> [TodoCategoryPreference] {
         do {
-            return try await todoCategoryService.fetchPreferences()
+            return try await todoCategoryService.fetchPreferences().toDomain()
         } catch {
             throw error.toDomain()
         }
@@ -24,7 +24,9 @@ final class TodoCategoryRepositoryImpl: TodoCategoryRepository {
 
     func updatePreferences(_ preferences: [TodoCategoryPreference]) async throws {
         do {
-            try await todoCategoryService.updatePreferences(preferences)
+            try await todoCategoryService.updatePreferences(
+                preferences.map(TodoCategoryPreferenceResponse.fromDomain)
+            )
         } catch {
             throw error.toDomain()
         }

--- a/Application/DevLogData/Sources/Repository/TodoCategoryRepositoryImpl.swift
+++ b/Application/DevLogData/Sources/Repository/TodoCategoryRepositoryImpl.swift
@@ -15,10 +15,18 @@ final class TodoCategoryRepositoryImpl: TodoCategoryRepository {
     }
 
     func fetchPreferences() async throws -> [TodoCategoryPreference] {
-        try await todoCategoryService.fetchPreferences()
+        do {
+            return try await todoCategoryService.fetchPreferences()
+        } catch {
+            throw error.toDomain()
+        }
     }
 
     func updatePreferences(_ preferences: [TodoCategoryPreference]) async throws {
-        try await todoCategoryService.updatePreferences(preferences)
+        do {
+            try await todoCategoryService.updatePreferences(preferences)
+        } catch {
+            throw error.toDomain()
+        }
     }
 }

--- a/Application/DevLogData/Sources/Repository/TodoRepositoryImpl.swift
+++ b/Application/DevLogData/Sources/Repository/TodoRepositoryImpl.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import DevLogCore
 import DevLogDomain
 
 final class TodoRepositoryImpl: TodoRepository {
@@ -22,82 +23,107 @@ final class TodoRepositoryImpl: TodoRepository {
 
     func fetchTodos(_ query: TodoQuery, cursor: TodoCursor?) async throws -> TodoPage {
         let responseCursor = cursor.map { TodoCursorDTO.fromDomain($0) }
-        async let response = todoService.fetchTodos(query, cursor: responseCursor)
-        async let preferences = todoCategoryService.fetchPreferences()
 
-        let (todoResponse, todoPreferences) = try await (response, preferences)
-        let userTodoCategories: [UserTodoCategory] = todoPreferences.compactMap { preference in
-            guard case .user(let category) = preference.category else {
-                return nil
+        do {
+            async let response = todoService.fetchTodos(query, cursor: responseCursor)
+            async let preferences = todoCategoryService.fetchPreferences()
+
+            let (todoResponse, todoPreferences) = try await (response, preferences)
+            let userTodoCategories: [UserTodoCategory] = todoPreferences.compactMap { preference in
+                guard case .user(let category) = preference.category else {
+                    return nil
+                }
+
+                return category
             }
 
-            return category
-        }
+            let resolvedTodoResponses = try todoResponse.items.map {
+                try resolve($0, userTodoCategories: userTodoCategories)
+            }
 
-        let resolvedTodoResponses = try todoResponse.items.map {
-            try resolve($0, userTodoCategories: userTodoCategories)
+            return try TodoPageResponse(
+                items: resolvedTodoResponses,
+                nextCursor: todoResponse.nextCursor
+            ).toDomain()
+        } catch {
+            throw error.toDataLayerError()
         }
-
-        return try TodoPageResponse(
-            items: resolvedTodoResponses,
-            nextCursor: todoResponse.nextCursor
-        ).toDomain()
     }
 
     func fetchTodo(_ todoId: String) async throws -> Todo {
-        async let response = todoService.fetchTodo(todoId: todoId)
-        async let preferences = todoCategoryService.fetchPreferences()
+        do {
+            async let response = todoService.fetchTodo(todoId: todoId)
+            async let preferences = todoCategoryService.fetchPreferences()
 
-        let (todoResponse, todoPreferences) = try await (response, preferences)
-        let userTodoCategories: [UserTodoCategory] = todoPreferences.compactMap { preference in
-            guard case .user(let category) = preference.category else {
-                return nil
+            let (todoResponse, todoPreferences) = try await (response, preferences)
+            let userTodoCategories: [UserTodoCategory] = todoPreferences.compactMap { preference in
+                guard case .user(let category) = preference.category else {
+                    return nil
+                }
+
+                return category
             }
 
-            return category
+            return try resolve(todoResponse, userTodoCategories: userTodoCategories).toDomain()
+        } catch {
+            throw error.toDataLayerError()
         }
-
-        return try resolve(todoResponse, userTodoCategories: userTodoCategories).toDomain()
     }
 
     func fetchReferences(_ numbers: [Int]) async throws -> [Int: TodoReference] {
-        async let responseTask = todoService.fetchReferences(numbers)
-        async let preferencesTask = todoCategoryService.fetchPreferences()
+        do {
+            async let responseTask = todoService.fetchReferences(numbers)
+            async let preferencesTask = todoCategoryService.fetchPreferences()
 
-        let (responses, preferences) = try await (responseTask, preferencesTask)
-        let userTodoCategories: [UserTodoCategory] = preferences.compactMap { preference in
-            guard case .user(let category) = preference.category else {
-                return nil
+            let (responses, preferences) = try await (responseTask, preferencesTask)
+            let userTodoCategories: [UserTodoCategory] = preferences.compactMap { preference in
+                guard case .user(let category) = preference.category else {
+                    return nil
+                }
+
+                return category
             }
 
-            return category
-        }
+            return try responses.reduce(into: [Int: TodoReference]()) { partialResult, pair in
+                let response = try resolve(pair.value, userTodoCategories: userTodoCategories)
+                guard case let .decoded(category) = response.category else {
+                    throw DataError.invalidData("TodoReferenceResponse.category must be resolved before use")
+                }
 
-        return try responses.reduce(into: [Int: TodoReference]()) { partialResult, pair in
-            let response = try resolve(pair.value, userTodoCategories: userTodoCategories)
-            guard case let .decoded(category) = response.category else {
-                throw DataError.invalidData("TodoReferenceResponse.category must be resolved before use")
+                partialResult[pair.key] = TodoReference(
+                    id: response.id,
+                    title: response.title,
+                    category: category
+                )
             }
-
-            partialResult[pair.key] = TodoReference(
-                id: response.id,
-                title: response.title,
-                category: category
-            )
+        } catch {
+            throw error.toDataLayerError()
         }
     }
     
     func upsertTodo(_ todo: Todo) async throws {
         let request = TodoRequest.fromDomain(todo)
-        try await todoService.upsertTodo(request: request)
+        do {
+            try await todoService.upsertTodo(request: request)
+        } catch {
+            throw error.toDataLayerError()
+        }
     }
     
     func deleteTodo(_ todoId: String) async throws {
-        try await todoService.deleteTodo(todoId: todoId)
+        do {
+            try await todoService.deleteTodo(todoId: todoId)
+        } catch {
+            throw error.toDataLayerError()
+        }
     }
 
     func undoDeleteTodo(_ todoId: String) async throws {
-        try await todoService.undoDeleteTodo(todoId: todoId)
+        do {
+            try await todoService.undoDeleteTodo(todoId: todoId)
+        } catch {
+            throw error.toDataLayerError()
+        }
     }
 }
 
@@ -147,23 +173,23 @@ private extension TodoRepositoryImpl {
         _ response: TodoReferenceResponse,
         userTodoCategories: [UserTodoCategory]
     ) throws -> TodoReferenceResponse {
-        let categoryID: String
+        let categoryId: String
         switch response.category {
         case .raw(let value):
-            categoryID = value
+            categoryId = value
         case .decoded:
             return response
         }
 
         let category: TodoCategory
-        if let systemTodoCategory = SystemTodoCategory(rawValue: categoryID) {
+        if let systemTodoCategory = SystemTodoCategory(rawValue: categoryId) {
             category = .system(systemTodoCategory)
         } else if let userTodoCategory = userTodoCategories.first(where: {
-            $0.id == categoryID
+            $0.id == categoryId
         }) {
             category = .user(userTodoCategory)
         } else {
-            throw DataError.invalidData("TodoReferenceResponse.category is invalid: \(categoryID)")
+            throw DataError.invalidData("TodoReferenceResponse.category is invalid: \(categoryId)")
         }
 
         return TodoReferenceResponse(

--- a/Application/DevLogData/Sources/Repository/TodoRepositoryImpl.swift
+++ b/Application/DevLogData/Sources/Repository/TodoRepositoryImpl.swift
@@ -46,7 +46,7 @@ final class TodoRepositoryImpl: TodoRepository {
                 nextCursor: todoResponse.nextCursor
             ).toDomain()
         } catch {
-            throw error.toDataLayerError()
+            throw error.toDomain()
         }
     }
 
@@ -66,7 +66,7 @@ final class TodoRepositoryImpl: TodoRepository {
 
             return try resolve(todoResponse, userTodoCategories: userTodoCategories).toDomain()
         } catch {
-            throw error.toDataLayerError()
+            throw error.toDomain()
         }
     }
 
@@ -97,7 +97,7 @@ final class TodoRepositoryImpl: TodoRepository {
                 )
             }
         } catch {
-            throw error.toDataLayerError()
+            throw error.toDomain()
         }
     }
     
@@ -106,7 +106,7 @@ final class TodoRepositoryImpl: TodoRepository {
         do {
             try await todoService.upsertTodo(request: request)
         } catch {
-            throw error.toDataLayerError()
+            throw error.toDomain()
         }
     }
     
@@ -114,7 +114,7 @@ final class TodoRepositoryImpl: TodoRepository {
         do {
             try await todoService.deleteTodo(todoId: todoId)
         } catch {
-            throw error.toDataLayerError()
+            throw error.toDomain()
         }
     }
 
@@ -122,7 +122,7 @@ final class TodoRepositoryImpl: TodoRepository {
         do {
             try await todoService.undoDeleteTodo(todoId: todoId)
         } catch {
-            throw error.toDataLayerError()
+            throw error.toDomain()
         }
     }
 }

--- a/Application/DevLogData/Sources/Repository/TodoRepositoryImpl.swift
+++ b/Application/DevLogData/Sources/Repository/TodoRepositoryImpl.swift
@@ -28,8 +28,8 @@ final class TodoRepositoryImpl: TodoRepository {
             async let response = todoService.fetchTodos(query, cursor: responseCursor)
             async let preferences = todoCategoryService.fetchPreferences()
 
-            let (todoResponse, todoPreferences) = try await (response, preferences)
-            let userTodoCategories: [UserTodoCategory] = todoPreferences.compactMap { preference in
+            let (todoResponse, todoPreferenceResponses) = try await (response, preferences)
+            let userTodoCategories: [UserTodoCategory] = todoPreferenceResponses.toDomain().compactMap { preference in
                 guard case .user(let category) = preference.category else {
                     return nil
                 }
@@ -55,8 +55,8 @@ final class TodoRepositoryImpl: TodoRepository {
             async let response = todoService.fetchTodo(todoId: todoId)
             async let preferences = todoCategoryService.fetchPreferences()
 
-            let (todoResponse, todoPreferences) = try await (response, preferences)
-            let userTodoCategories: [UserTodoCategory] = todoPreferences.compactMap { preference in
+            let (todoResponse, todoPreferenceResponses) = try await (response, preferences)
+            let userTodoCategories: [UserTodoCategory] = todoPreferenceResponses.toDomain().compactMap { preference in
                 guard case .user(let category) = preference.category else {
                     return nil
                 }
@@ -75,8 +75,8 @@ final class TodoRepositoryImpl: TodoRepository {
             async let responseTask = todoService.fetchReferences(numbers)
             async let preferencesTask = todoCategoryService.fetchPreferences()
 
-            let (responses, preferences) = try await (responseTask, preferencesTask)
-            let userTodoCategories: [UserTodoCategory] = preferences.compactMap { preference in
+            let (responses, preferenceResponses) = try await (responseTask, preferencesTask)
+            let userTodoCategories: [UserTodoCategory] = preferenceResponses.toDomain().compactMap { preference in
                 guard case .user(let category) = preference.category else {
                     return nil
                 }

--- a/Application/DevLogData/Sources/Repository/UserDataRepositoryImpl.swift
+++ b/Application/DevLogData/Sources/Repository/UserDataRepositoryImpl.swift
@@ -15,12 +15,20 @@ final class UserDataRepositoryImpl: UserDataRepository {
     }
 
     func fetch() async throws -> UserProfile {
-        let response = try await userService.fetchUserProfile()
+        do {
+            let response = try await userService.fetchUserProfile()
 
-        return response.toDomain()
+            return response.toDomain()
+        } catch {
+            throw error.toDomain()
+        }
     }
 
     func upsertStatusMessage(_ message: String) async throws {
-        try await userService.upsertStatusMessage(message)
+        do {
+            try await userService.upsertStatusMessage(message)
+        } catch {
+            throw error.toDomain()
+        }
     }
 }

--- a/Application/DevLogData/Sources/Repository/UserPreferencesRepositoryImpl.swift
+++ b/Application/DevLogData/Sources/Repository/UserPreferencesRepositoryImpl.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import Combine
+import DevLogCore
 import DevLogDomain
 
 final class UserPreferencesRepositoryImpl: UserPreferencesRepository {

--- a/Application/DevLogData/Sources/Repository/WebPageRepositoryImpl.swift
+++ b/Application/DevLogData/Sources/Repository/WebPageRepositoryImpl.swift
@@ -22,46 +22,62 @@ final class WebPageRepositoryImpl: WebPageRepository {
     }
 
     func fetch(_ query: String) async throws -> [WebPage] {
-        let responses = try await webPageService.fetchWebPages(query)
-        var pages: [WebPage] = []
-        pages.reserveCapacity(responses.count)
+        do {
+            let responses = try await webPageService.fetchWebPages(query)
+            var pages: [WebPage] = []
+            pages.reserveCapacity(responses.count)
 
-        for response in responses {
-            if await needsImageRestore(response) {
-                if let restored = try? await restoreWebPage(response) {
-                    pages.append(restored)
-                } else if let page = try? responseWithoutImage(response).toDomain() {
+            for response in responses {
+                if await needsImageRestore(response) {
+                    if let restored = try? await restoreWebPage(response) {
+                        pages.append(restored)
+                    } else if let page = try? responseWithoutImage(response).toDomain() {
+                        pages.append(page)
+                    }
+                    continue
+                }
+                if let page = try? response.toDomain() {
                     pages.append(page)
                 }
-                continue
             }
-            if let page = try? response.toDomain() {
-                pages.append(page)
-            }
-        }
 
-        return pages
+            return pages
+        } catch {
+            throw error.toDataLayerError()
+        }
     }
 
     func upsert(_ urlString: String) async throws {
-        let metadata = try await metadataService.fetchMetadata(from: urlString)
-        let request = WebPageRequest(
-            title: metadata.title,
-            url: urlString,
-            displayURL: metadata.displayURL,
-            imageURL: metadata.imageURL,
-            isDeleted: false
-        )
-        try await webPageService.upsertWebPage(request)
+        do {
+            let metadata = try await metadataService.fetchMetadata(from: urlString)
+            let request = WebPageRequest(
+                title: metadata.title,
+                url: urlString,
+                displayURL: metadata.displayURL,
+                imageURL: metadata.imageURL,
+                isDeleted: false
+            )
+            try await webPageService.upsertWebPage(request)
+        } catch {
+            throw error.toDataLayerError()
+        }
     }
 
     func delete(_ urlString: String) async throws {
-        try await webPageService.deleteWebPage(urlString)
-        await metadataService.removeCachedImage(for: urlString)
+        do {
+            try await webPageService.deleteWebPage(urlString)
+            await metadataService.removeCachedImage(for: urlString)
+        } catch {
+            throw error.toDataLayerError()
+        }
     }
 
     func undoDelete(_ urlString: String) async throws {
-        try await webPageService.undoDeleteWebPage(urlString)
+        do {
+            try await webPageService.undoDeleteWebPage(urlString)
+        } catch {
+            throw error.toDataLayerError()
+        }
     }
 }
 

--- a/Application/DevLogData/Sources/Repository/WebPageRepositoryImpl.swift
+++ b/Application/DevLogData/Sources/Repository/WebPageRepositoryImpl.swift
@@ -43,7 +43,7 @@ final class WebPageRepositoryImpl: WebPageRepository {
 
             return pages
         } catch {
-            throw error.toDataLayerError()
+            throw error.toDomain()
         }
     }
 
@@ -59,7 +59,7 @@ final class WebPageRepositoryImpl: WebPageRepository {
             )
             try await webPageService.upsertWebPage(request)
         } catch {
-            throw error.toDataLayerError()
+            throw error.toDomain()
         }
     }
 
@@ -68,7 +68,7 @@ final class WebPageRepositoryImpl: WebPageRepository {
             try await webPageService.deleteWebPage(urlString)
             await metadataService.removeCachedImage(for: urlString)
         } catch {
-            throw error.toDataLayerError()
+            throw error.toDomain()
         }
     }
 
@@ -76,7 +76,7 @@ final class WebPageRepositoryImpl: WebPageRepository {
         do {
             try await webPageService.undoDeleteWebPage(urlString)
         } catch {
-            throw error.toDataLayerError()
+            throw error.toDomain()
         }
     }
 }

--- a/Application/DevLogDomain/Sources/Protocol/PushNotificationRepository.swift
+++ b/Application/DevLogDomain/Sources/Protocol/PushNotificationRepository.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import Combine
+import DevLogCore
 
 public protocol PushNotificationRepository {
     func fetchPushNotificationEnabled() async throws -> Bool

--- a/Application/DevLogDomain/Sources/Protocol/TodoRepository.swift
+++ b/Application/DevLogDomain/Sources/Protocol/TodoRepository.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import DevLogCore
 
 public protocol TodoRepository {
     func fetchTodos(_ query: TodoQuery, cursor: TodoCursor?) async throws -> TodoPage

--- a/Application/DevLogDomain/Sources/Protocol/UserPreferencesRepository.swift
+++ b/Application/DevLogDomain/Sources/Protocol/UserPreferencesRepository.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import Combine
+import DevLogCore
 
 public protocol UserPreferencesRepository {
     func observeSystemTheme() -> AnyPublisher<SystemTheme, Never>

--- a/Application/DevLogDomain/Sources/UseCase/PushNotification/Fetch/FetchPushNotificationsUseCase.swift
+++ b/Application/DevLogDomain/Sources/UseCase/PushNotification/Fetch/FetchPushNotificationsUseCase.swift
@@ -6,6 +6,7 @@
 //
 
 import Combine
+import DevLogCore
 
 public protocol FetchPushNotificationsUseCase {
     func execute(

--- a/Application/DevLogDomain/Sources/UseCase/PushNotification/Fetch/FetchPushNotificationsUseCaseImpl.swift
+++ b/Application/DevLogDomain/Sources/UseCase/PushNotification/Fetch/FetchPushNotificationsUseCaseImpl.swift
@@ -6,6 +6,7 @@
 //
 
 import Combine
+import DevLogCore
 
 public final class FetchPushNotificationsUseCaseImpl: FetchPushNotificationsUseCase {
     private let repository: PushNotificationRepository

--- a/Application/DevLogDomain/Sources/UseCase/Todo/Fetch/FetchTodosUseCase.swift
+++ b/Application/DevLogDomain/Sources/UseCase/Todo/Fetch/FetchTodosUseCase.swift
@@ -5,6 +5,8 @@
 //  Created by opfic on 3/3/26.
 //
 
+import DevLogCore
+
 public protocol FetchTodosUseCase {
     func execute(_ query: TodoQuery, cursor: TodoCursor?) async throws -> TodoPage
 }

--- a/Application/DevLogDomain/Sources/UseCase/Todo/Fetch/FetchTodosUseCaseImpl.swift
+++ b/Application/DevLogDomain/Sources/UseCase/Todo/Fetch/FetchTodosUseCaseImpl.swift
@@ -5,6 +5,8 @@
 //  Created by opfic on 3/3/26.
 //
 
+import DevLogCore
+
 public final class FetchTodosUseCaseImpl: FetchTodosUseCase {
     private let repository: TodoRepository
 

--- a/Application/DevLogDomain/Sources/UseCase/UserPreferences/PushNotification/FetchPushNotificationQueryUseCase.swift
+++ b/Application/DevLogDomain/Sources/UseCase/UserPreferences/PushNotification/FetchPushNotificationQueryUseCase.swift
@@ -5,6 +5,8 @@
 //  Created by 최윤진 on 2/25/26.
 //
 
+import DevLogCore
+
 public protocol FetchPushNotificationQueryUseCase {
     func execute() -> PushNotificationQuery
 }

--- a/Application/DevLogDomain/Sources/UseCase/UserPreferences/PushNotification/FetchPushNotificationQueryUseCaseImpl.swift
+++ b/Application/DevLogDomain/Sources/UseCase/UserPreferences/PushNotification/FetchPushNotificationQueryUseCaseImpl.swift
@@ -5,6 +5,8 @@
 //  Created by 최윤진 on 2/25/26.
 //
 
+import DevLogCore
+
 public final class FetchPushNotificationQueryUseCaseImpl: FetchPushNotificationQueryUseCase {
     private let repository: UserPreferencesRepository
 

--- a/Application/DevLogDomain/Sources/UseCase/UserPreferences/PushNotification/UpdatePushNotificationQueryUseCase.swift
+++ b/Application/DevLogDomain/Sources/UseCase/UserPreferences/PushNotification/UpdatePushNotificationQueryUseCase.swift
@@ -5,6 +5,8 @@
 //  Created by 최윤진 on 2/25/26.
 //
 
+import DevLogCore
+
 public protocol UpdatePushNotificationQueryUseCase {
     func execute(_ query: PushNotificationQuery)
 }

--- a/Application/DevLogDomain/Sources/UseCase/UserPreferences/PushNotification/UpdatePushNotificationQueryUseCaseImpl.swift
+++ b/Application/DevLogDomain/Sources/UseCase/UserPreferences/PushNotification/UpdatePushNotificationQueryUseCaseImpl.swift
@@ -5,6 +5,8 @@
 //  Created by 최윤진 on 2/25/26.
 //
 
+import DevLogCore
+
 public final class UpdatePushNotificationQueryUseCaseImpl: UpdatePushNotificationQueryUseCase {
     private let repository: UserPreferencesRepository
 

--- a/Application/DevLogDomain/Sources/UseCase/UserPreferences/Theme/ObserveSystemThemeUseCase.swift
+++ b/Application/DevLogDomain/Sources/UseCase/UserPreferences/Theme/ObserveSystemThemeUseCase.swift
@@ -6,6 +6,7 @@
 //
 
 import Combine
+import DevLogCore
 
 public protocol ObserveSystemThemeUseCase {
     func observe() -> AnyPublisher<SystemTheme, Never>

--- a/Application/DevLogDomain/Sources/UseCase/UserPreferences/Theme/ObserveSystemThemeUseCaseImpl.swift
+++ b/Application/DevLogDomain/Sources/UseCase/UserPreferences/Theme/ObserveSystemThemeUseCaseImpl.swift
@@ -6,6 +6,7 @@
 //
 
 import Combine
+import DevLogCore
 
 public final class ObserveSystemThemeUseCaseImpl: ObserveSystemThemeUseCase {
     private let repository: UserPreferencesRepository

--- a/Application/DevLogDomain/Sources/UseCase/UserPreferences/Theme/UpdateSystemThemeUseCase.swift
+++ b/Application/DevLogDomain/Sources/UseCase/UserPreferences/Theme/UpdateSystemThemeUseCase.swift
@@ -5,6 +5,8 @@
 //  Created by 최윤진 on 2/25/26.
 //
 
+import DevLogCore
+
 public protocol UpdateSystemThemeUseCase {
     func execute(_ theme: SystemTheme)
 }

--- a/Application/DevLogDomain/Sources/UseCase/UserPreferences/Theme/UpdateSystemThemeUseCaseImpl.swift
+++ b/Application/DevLogDomain/Sources/UseCase/UserPreferences/Theme/UpdateSystemThemeUseCaseImpl.swift
@@ -5,6 +5,8 @@
 //  Created by 최윤진 on 2/25/26.
 //
 
+import DevLogCore
+
 public final class UpdateSystemThemeUseCaseImpl: UpdateSystemThemeUseCase {
     private let repository: UserPreferencesRepository
 

--- a/Application/DevLogDomain/Sources/UseCase/UserPreferences/Today/FetchTodayDisplayOptionsUseCase.swift
+++ b/Application/DevLogDomain/Sources/UseCase/UserPreferences/Today/FetchTodayDisplayOptionsUseCase.swift
@@ -5,6 +5,8 @@
 //  Created by opfic on 3/6/26.
 //
 
+import DevLogCore
+
 public protocol FetchTodayDisplayOptionsUseCase {
     func execute() -> TodayDisplayOptions
 }

--- a/Application/DevLogDomain/Sources/UseCase/UserPreferences/Today/FetchTodayDisplayOptionsUseCaseImpl.swift
+++ b/Application/DevLogDomain/Sources/UseCase/UserPreferences/Today/FetchTodayDisplayOptionsUseCaseImpl.swift
@@ -5,6 +5,8 @@
 //  Created by opfic on 3/6/26.
 //
 
+import DevLogCore
+
 public final class FetchTodayDisplayOptionsUseCaseImpl: FetchTodayDisplayOptionsUseCase {
     private let repository: UserPreferencesRepository
 

--- a/Application/DevLogDomain/Sources/UseCase/UserPreferences/Today/UpdateTodayDisplayOptionsUseCase.swift
+++ b/Application/DevLogDomain/Sources/UseCase/UserPreferences/Today/UpdateTodayDisplayOptionsUseCase.swift
@@ -5,6 +5,8 @@
 //  Created by opfic on 3/6/26.
 //
 
+import DevLogCore
+
 public protocol UpdateTodayDisplayOptionsUseCase {
     func execute(_ options: TodayDisplayOptions)
 }

--- a/Application/DevLogDomain/Sources/UseCase/UserPreferences/Today/UpdateTodayDisplayOptionsUseCaseImpl.swift
+++ b/Application/DevLogDomain/Sources/UseCase/UserPreferences/Today/UpdateTodayDisplayOptionsUseCaseImpl.swift
@@ -5,6 +5,8 @@
 //  Created by opfic on 3/6/26.
 //
 
+import DevLogCore
+
 public final class UpdateTodayDisplayOptionsUseCaseImpl: UpdateTodayDisplayOptionsUseCase {
     private let repository: UserPreferencesRepository
 

--- a/Application/DevLogInfra/DevLogInfra.xcodeproj/project.pbxproj
+++ b/Application/DevLogInfra/DevLogInfra.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		21F6F37746C943D1A019963F /* DevLogDomain.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8C4421AE6B9E4E419E73297F /* DevLogDomain.framework */; };
 		65623F19F34A9A75BC72EE36 /* FirebaseFirestore in Frameworks */ = {isa = PBXBuildFile; productRef = CE8F32B22E13743B3FF3B66B /* FirebaseFirestore */; };
 		B11111111111111111111111 /* DevLogCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B55555555555555555555555 /* DevLogCore.framework */; };
 		E747320CAD03A579976E87F8 /* FirebaseFunctions in Frameworks */ = {isa = PBXBuildFile; productRef = 172AF9DE3BC54E9E0B4EFD19 /* FirebaseFunctions */; };
@@ -43,26 +42,12 @@
 			remoteGlobalIDString = 9E9FD7B09D0D7EAB8B828A5E;
 			remoteInfo = Subproject;
 		};
-		3941472A0F8E4DA796217D2B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = A748C00357094C72BA72DC72 /* DevLogDomain.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 3F08F6B94839E9021FCFC466;
-			remoteInfo = Subproject;
-		};
 		92ED4507B81AC42C599EE7EE /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = DC20615F7FBF2DEEB480D826 /* DevLogData.xcodeproj */;
 			proxyType = 2;
 			remoteGlobalIDString = 4AB6E00A38C37CDBF82B57FD;
 			remoteInfo = Subproject;
-		};
-		DD5CC520521F4F86A8EC6225 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = A748C00357094C72BA72DC72 /* DevLogDomain.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 7D1E74925088998D68BBFBBB;
-			remoteInfo = DevLogDomain;
 		};
 		66FBFAC873BD4CEDA5984DD4 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -77,7 +62,6 @@
 		592C8B7B099933759AB316A5 /* DevLogInfra.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DevLogInfra.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		AD628A91CC6D40B29D89DEA3 /* DevLogInfraTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DevLogInfraTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		7CC9FAB56498FA5BAEAC59A6 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		A748C00357094C72BA72DC72 /* DevLogDomain.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = DevLogDomain.xcodeproj; path = ../DevLogDomain/DevLogDomain.xcodeproj; sourceTree = "<group>"; };
 		B44444444444444444444444 /* DevLogCore.xcodeproj */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "wrapper.pb-project"; name = DevLogCore.xcodeproj; path = ../DevLogCore/DevLogCore.xcodeproj; sourceTree = "<group>"; };
 		DC20615F7FBF2DEEB480D826 /* DevLogData.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = DevLogData.xcodeproj; path = ../DevLogData/DevLogData.xcodeproj; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -116,7 +100,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				F75AA9259C6636CF733C4D82 /* Foundation.framework in Frameworks */,
-				21F6F37746C943D1A019963F /* DevLogDomain.framework in Frameworks */,
 				5F7A14F2C5294547884212E1 /* FirebaseCore in Frameworks */,
 				FB5186BC5A89B7DADAB8A82A /* FirebaseAuth in Frameworks */,
 				65623F19F34A9A75BC72EE36 /* FirebaseFirestore in Frameworks */,
@@ -145,7 +128,6 @@
 			children = (
 				592C8B7B099933759AB316A5 /* DevLogInfra.framework */,
 				AD628A91CC6D40B29D89DEA3 /* DevLogInfraTests.xctest */,
-				8C4421AE6B9E4E419E73297F /* DevLogDomain.framework */,
 				A4F874032FD57C0BBCC41C64 /* DevLogData.framework */,
 				B55555555555555555555555 /* DevLogCore.framework */,
 			);
@@ -183,7 +165,6 @@
 			isa = PBXGroup;
 			children = (
 				DC20615F7FBF2DEEB480D826 /* DevLogData.xcodeproj */,
-				A748C00357094C72BA72DC72 /* DevLogDomain.xcodeproj */,
 				B44444444444444444444444 /* DevLogCore.xcodeproj */,
 			);
 			name = Projects;
@@ -223,7 +204,6 @@
 			);
 			dependencies = (
 				1F4AAA000000000000000001 /* PBXTargetDependency */,
-				342FB70B2E884012B67F8B38 /* PBXTargetDependency */,
 				B62EE119F71162DAB0F9D034 /* PBXTargetDependency */,
 				B88888888888888888888888 /* PBXTargetDependency */,
 			);
@@ -307,10 +287,6 @@
 				},
 				{
 					ProductGroup = 0488BFD2A2F470EEE29679F1 /* Products */;
-					ProjectRef = A748C00357094C72BA72DC72 /* DevLogDomain.xcodeproj */;
-				},
-				{
-					ProductGroup = 0488BFD2A2F470EEE29679F1 /* Products */;
 					ProjectRef = B44444444444444444444444 /* DevLogCore.xcodeproj */;
 				},
 			);
@@ -323,13 +299,6 @@
 /* End PBXProject section */
 
 /* Begin PBXReferenceProxy section */
-		8C4421AE6B9E4E419E73297F /* DevLogDomain.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = DevLogDomain.framework;
-			remoteRef = 3941472A0F8E4DA796217D2B /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
 		A4F874032FD57C0BBCC41C64 /* DevLogData.framework */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.framework;
@@ -388,11 +357,6 @@
 		1F4AAA000000000000000004 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			productRef = 1F4AAA000000000000000003 /* plugin:SwiftLintBuildToolPlugin */;
-		};
-		342FB70B2E884012B67F8B38 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = DevLogDomain;
-			targetProxy = DD5CC520521F4F86A8EC6225 /* PBXContainerItemProxy */;
 		};
 		B62EE119F71162DAB0F9D034 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/Application/DevLogInfra/Sources/Service/AuthServiceImpl.swift
+++ b/Application/DevLogInfra/Sources/Service/AuthServiceImpl.swift
@@ -11,7 +11,6 @@ import FirebaseFirestore
 import FirebaseMessaging
 import DevLogCore
 import DevLogData
-import DevLogDomain
 
 final class AuthServiceImpl: AuthService {
     private let store = Firestore.firestore()
@@ -106,7 +105,7 @@ final class AuthServiceImpl: AuthService {
 
         guard let currentUser = Auth.auth().currentUser else {
             logger.warning("No current user to delete")
-            throw AuthError.notAuthenticated
+            throw DataLayerError.notAuthenticated
         }
 
         do {

--- a/Application/DevLogInfra/Sources/Service/PushNotificationServiceImpl.swift
+++ b/Application/DevLogInfra/Sources/Service/PushNotificationServiceImpl.swift
@@ -10,7 +10,6 @@ import Combine
 import FirebaseFirestore
 import FirebaseFunctions
 import DevLogCore
-import DevLogDomain
 import DevLogData
 
 final class PushNotificationServiceImpl: PushNotificationService {

--- a/Application/DevLogInfra/Sources/Service/PushNotificationServiceImpl.swift
+++ b/Application/DevLogInfra/Sources/Service/PushNotificationServiceImpl.swift
@@ -29,7 +29,7 @@ final class PushNotificationServiceImpl: PushNotificationService {
         
         guard let uid = Auth.auth().currentUser?.uid else {
             logger.error("User not authenticated")
-            throw AuthError.notAuthenticated
+            throw DataLayerError.notAuthenticated
         }
 
         do {
@@ -55,7 +55,7 @@ final class PushNotificationServiceImpl: PushNotificationService {
 
         guard let uid = Auth.auth().currentUser?.uid else {
             logger.error("User not authenticated")
-            throw AuthError.notAuthenticated
+            throw DataLayerError.notAuthenticated
         }
 
         do {
@@ -83,7 +83,7 @@ final class PushNotificationServiceImpl: PushNotificationService {
         
         guard let uid = Auth.auth().currentUser?.uid else {
             logger.error("User not authenticated")
-            throw AuthError.notAuthenticated
+            throw DataLayerError.notAuthenticated
         }
 
         do {
@@ -113,7 +113,7 @@ final class PushNotificationServiceImpl: PushNotificationService {
         cursor: PushNotificationCursorDTO?
     ) async throws -> PushNotificationPageResponse {
         do {
-            guard let uid = Auth.auth().currentUser?.uid else { throw AuthError.notAuthenticated }
+            guard let uid = Auth.auth().currentUser?.uid else { throw DataLayerError.notAuthenticated }
 
             var firestoreQuery = makeQuery(uid: uid, query: notificationQuery)
 
@@ -153,7 +153,7 @@ final class PushNotificationServiceImpl: PushNotificationService {
         _ query: PushNotificationQuery,
         limit: Int
     ) throws -> AnyPublisher<PushNotificationPageResponse, Error> {
-        guard let uid = Auth.auth().currentUser?.uid else { throw AuthError.notAuthenticated }
+        guard let uid = Auth.auth().currentUser?.uid else { throw DataLayerError.notAuthenticated }
 
         let subject = PassthroughSubject<PushNotificationPageResponse, Error>()
         let pageLimit = max(query.pageSize, limit)
@@ -183,7 +183,7 @@ final class PushNotificationServiceImpl: PushNotificationService {
     }
 
     func observeUnreadPushCount() throws -> AnyPublisher<Int, Error> {
-        guard let uid = Auth.auth().currentUser?.uid else { throw AuthError.notAuthenticated }
+        guard let uid = Auth.auth().currentUser?.uid else { throw DataLayerError.notAuthenticated }
 
         let subject = PassthroughSubject<Int, Error>()
         let listener = store.collection(FirestorePath.notifications(uid))
@@ -208,7 +208,7 @@ final class PushNotificationServiceImpl: PushNotificationService {
     /// 푸시 알림 기록 삭제
     func deleteNotification(_ notificationID: String) async throws {
         do {
-            guard Auth.auth().currentUser?.uid != nil else { throw AuthError.notAuthenticated }
+            guard Auth.auth().currentUser?.uid != nil else { throw DataLayerError.notAuthenticated }
 
             let function = functions.httpsCallable(FunctionName.requestPushNotificationDeletion)
             _ = try await function.call(["notificationId": notificationID])
@@ -220,7 +220,7 @@ final class PushNotificationServiceImpl: PushNotificationService {
 
     func undoDeleteNotification(_ notificationID: String) async throws {
         do {
-            guard Auth.auth().currentUser?.uid != nil else { throw AuthError.notAuthenticated }
+            guard Auth.auth().currentUser?.uid != nil else { throw DataLayerError.notAuthenticated }
 
             let function = functions.httpsCallable(FunctionName.undoPushNotificationDeletion)
             _ = try await function.call(["notificationId": notificationID])
@@ -237,7 +237,7 @@ final class PushNotificationServiceImpl: PushNotificationService {
         do {
             guard let uid = Auth.auth().currentUser?.uid else {
                 logger.error("User not authenticated")
-                throw AuthError.notAuthenticated
+                throw DataLayerError.notAuthenticated
             }
 
             let collection = store.collection(FirestorePath.notifications(uid))

--- a/Application/DevLogInfra/Sources/Service/SocialLogin/AppleAuthenticationServiceImpl.swift
+++ b/Application/DevLogInfra/Sources/Service/SocialLogin/AppleAuthenticationServiceImpl.swift
@@ -14,7 +14,6 @@ import FirebaseMessaging
 import Foundation
 import DevLogCore
 import DevLogData
-import DevLogDomain
 
 final class AppleAuthenticationServiceImpl: AuthenticationService {
     private enum FunctionName: String {
@@ -161,7 +160,7 @@ final class AppleAuthenticationServiceImpl: AuthenticationService {
         } catch {
             logger.error("Failed to link Apple account", error: error)
             if error.isFirebaseCredentialAlreadyInUse {
-                throw AuthError.linkCredentialAlreadyInUse
+                throw DataLayerError.linkCredentialAlreadyInUse
             }
             throw error
         }

--- a/Application/DevLogInfra/Sources/Service/SocialLogin/GithubAuthenticationServiceImpl.swift
+++ b/Application/DevLogInfra/Sources/Service/SocialLogin/GithubAuthenticationServiceImpl.swift
@@ -14,7 +14,6 @@ import FirebaseMessaging
 import Nexa
 import DevLogCore
 import DevLogData
-import DevLogDomain
 
 final class GithubAuthenticationServiceImpl: NSObject, AuthenticationService {
     private enum FunctionName: String {
@@ -145,7 +144,7 @@ final class GithubAuthenticationServiceImpl: NSObject, AuthenticationService {
         } catch {
             logger.error("Failed to link GitHub account", error: error)
             if error.isFirebaseCredentialAlreadyInUse {
-                throw AuthError.linkCredentialAlreadyInUse
+                throw DataLayerError.linkCredentialAlreadyInUse
             }
             throw error
         }

--- a/Application/DevLogInfra/Sources/Service/SocialLogin/GoogleAuthenticationServiceImpl.swift
+++ b/Application/DevLogInfra/Sources/Service/SocialLogin/GoogleAuthenticationServiceImpl.swift
@@ -12,7 +12,6 @@ import Foundation
 import GoogleSignIn
 import DevLogCore
 import DevLogData
-import DevLogDomain
 
 final class GoogleAuthenticationServiceImpl: AuthenticationService {
     private let store = Firestore.firestore()
@@ -125,7 +124,7 @@ final class GoogleAuthenticationServiceImpl: AuthenticationService {
         } catch {
             logger.error("Failed to link Google account", error: error)
             if error.isFirebaseCredentialAlreadyInUse {
-                throw AuthError.linkCredentialAlreadyInUse
+                throw DataLayerError.linkCredentialAlreadyInUse
             }
             throw error
         }

--- a/Application/DevLogInfra/Sources/Service/TodoCategoryServiceImpl.swift
+++ b/Application/DevLogInfra/Sources/Service/TodoCategoryServiceImpl.swift
@@ -33,7 +33,7 @@ final class TodoCategoryServiceImpl: TodoCategoryService {
     func fetchPreferences() async throws -> [TodoCategoryPreference] {
         guard let uid = Auth.auth().currentUser?.uid else {
             logger.error("User not authenticated")
-            throw AuthError.notAuthenticated
+            throw DataLayerError.notAuthenticated
         }
 
         logger.info("Fetching todo category preferences")
@@ -70,7 +70,7 @@ final class TodoCategoryServiceImpl: TodoCategoryService {
     func updatePreferences(_ preferences: [TodoCategoryPreference]) async throws {
         guard let uid = Auth.auth().currentUser?.uid else {
             logger.error("User not authenticated")
-            throw AuthError.notAuthenticated
+            throw DataLayerError.notAuthenticated
         }
 
         logger.info("Updating todo category preferences")

--- a/Application/DevLogInfra/Sources/Service/TodoCategoryServiceImpl.swift
+++ b/Application/DevLogInfra/Sources/Service/TodoCategoryServiceImpl.swift
@@ -8,7 +8,6 @@
 import FirebaseAuth
 import FirebaseFirestore
 import DevLogCore
-import DevLogDomain
 import DevLogData
 
 final class TodoCategoryServiceImpl: TodoCategoryService {
@@ -30,7 +29,7 @@ final class TodoCategoryServiceImpl: TodoCategoryService {
     private let store = Firestore.firestore()
     private let logger = Logger(category: "TodoCategoryServiceImpl")
 
-    func fetchPreferences() async throws -> [TodoCategoryPreference] {
+    func fetchPreferences() async throws -> [TodoCategoryPreferenceResponse] {
         guard let uid = Auth.auth().currentUser?.uid else {
             logger.error("User not authenticated")
             throw DataLayerError.notAuthenticated
@@ -45,29 +44,24 @@ final class TodoCategoryServiceImpl: TodoCategoryService {
 
             guard let items = snapshot.data()?[Field.items.rawValue] as? [[String: Any]] else {
                 logger.info("Todo category preferences not found, using defaults")
-                return SystemTodoCategory.allCases.map {
-                    TodoCategoryPreference(category: .system($0), isVisible: true)
-                }
+                return []
             }
 
             let preferences = items.compactMap { makePreference($0) }
             if preferences.isEmpty {
                 logger.info("Todo category preferences empty, using defaults")
-                return SystemTodoCategory.allCases.map {
-                    TodoCategoryPreference(category: .system($0), isVisible: true)
-                }
+                return []
             }
 
-            let mergedPreferences = mergedPreferences(preferences)
             logger.info("Successfully fetched todo category preferences")
-            return mergedPreferences
+            return preferences
         } catch {
             logger.error("Failed to fetch todo category preferences", error: error)
             throw error
         }
     }
 
-    func updatePreferences(_ preferences: [TodoCategoryPreference]) async throws {
+    func updatePreferences(_ preferences: [TodoCategoryPreferenceResponse]) async throws {
         guard let uid = Auth.auth().currentUser?.uid else {
             logger.error("User not authenticated")
             throw DataLayerError.notAuthenticated
@@ -91,34 +85,7 @@ final class TodoCategoryServiceImpl: TodoCategoryService {
 }
 
 private extension TodoCategoryServiceImpl {
-    func mergedPreferences(
-        _ preferences: [TodoCategoryPreference]
-    ) -> [TodoCategoryPreference] {
-        var mergedPreferences = preferences
-
-        for systemTodoCategory in SystemTodoCategory.allCases {
-            let containsSystemTodoCategory = preferences.contains { preference in
-                guard case .system(let currentSystemTodoCategory) = preference.category else {
-                    return false
-                }
-
-                return currentSystemTodoCategory == systemTodoCategory
-            }
-
-            if containsSystemTodoCategory { continue }
-
-            mergedPreferences.append(
-                TodoCategoryPreference(
-                    category: .system(systemTodoCategory),
-                    isVisible: true
-                )
-            )
-        }
-
-        return mergedPreferences
-    }
-
-    func makePreference(_ items: [String: Any]) -> TodoCategoryPreference? {
+    func makePreference(_ items: [String: Any]) -> TodoCategoryPreferenceResponse? {
         guard
             let kindString = items[Field.kind.rawValue] as? String,
             let kind = Kind(rawValue: kindString),
@@ -129,15 +96,12 @@ private extension TodoCategoryServiceImpl {
 
         switch kind {
         case .system:
-            guard
-                let systemCategoryString = items[Field.systemCategory.rawValue] as? String,
-                let systemTodoCategory = SystemTodoCategory(rawValue: systemCategoryString)
-            else {
+            guard let systemCategoryString = items[Field.systemCategory.rawValue] as? String else {
                 return nil
             }
 
-            return TodoCategoryPreference(
-                category: .system(systemTodoCategory),
+            return TodoCategoryPreferenceResponse(
+                category: .system(systemCategoryString),
                 isVisible: isVisible
             )
         case .user:
@@ -149,9 +113,9 @@ private extension TodoCategoryServiceImpl {
                 return nil
             }
 
-            return TodoCategoryPreference(
+            return TodoCategoryPreferenceResponse(
                 category: .user(
-                    UserTodoCategory(
+                    TodoCategoryPreferenceResponse.UserCategory(
                         id: id,
                         name: name,
                         colorHex: colorHex
@@ -162,20 +126,20 @@ private extension TodoCategoryServiceImpl {
         }
     }
 
-    func toDictionary(_ preference: TodoCategoryPreference) -> [String: Any] {
+    func toDictionary(_ preference: TodoCategoryPreferenceResponse) -> [String: Any] {
         switch preference.category {
-        case .system(let systemTodoCategory):
+        case .system(let rawValue):
             return [
                 Field.kind.rawValue: Kind.system.rawValue,
-                Field.systemCategory.rawValue: systemTodoCategory.rawValue,
+                Field.systemCategory.rawValue: rawValue,
                 Field.isVisible.rawValue: preference.isVisible
             ]
-        case .user(let userTodoCategory):
+        case .user(let userCategory):
             return [
                 Field.kind.rawValue: Kind.user.rawValue,
-                Field.id.rawValue: userTodoCategory.id,
-                Field.name.rawValue: userTodoCategory.name,
-                Field.colorHex.rawValue: userTodoCategory.colorHex,
+                Field.id.rawValue: userCategory.id,
+                Field.name.rawValue: userCategory.name,
+                Field.colorHex.rawValue: userCategory.colorHex,
                 Field.isVisible.rawValue: preference.isVisible
             ]
         }

--- a/Application/DevLogInfra/Sources/Service/TodoServiceImpl.swift
+++ b/Application/DevLogInfra/Sources/Service/TodoServiceImpl.swift
@@ -9,7 +9,6 @@ import FirebaseAuth
 import FirebaseFirestore
 import FirebaseFunctions
 import DevLogCore
-import DevLogDomain
 import DevLogData
 
 final class TodoServiceImpl: TodoService {
@@ -28,16 +27,18 @@ final class TodoServiceImpl: TodoService {
         _ query: TodoQuery,
         cursor: TodoCursorDTO?
     ) async throws -> TodoPageResponse {
-        guard let uid = Auth.auth().currentUser?.uid else { throw AuthError.notAuthenticated }
+        guard let uid = Auth.auth().currentUser?.uid else { throw DataLayerError.notAuthenticated }
 
         let trimmedKeyword = query.keyword?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         let logComponents: [String?] = [
             "sortTarget=\(query.sortTarget.fieldName)",
             "sortOrder=\(query.sortOrder == .latest ? "latest" : "oldest")",
             query.keyword != nil ? "keywordLength=\(trimmedKeyword.count)" : nil,
-            query.category != nil ? "category=\(query.category!.storageValue)" : nil,
+            query.categoryId != nil ? "category=\(query.categoryId!)" : nil,
             query.isPinned != nil ? "pinned=\(query.isPinned!)" : nil,
-            query.completionFilter.isCompletedValue != nil ? "completed=\(query.completionFilter.isCompletedValue!)" : nil,
+            query.completionFilter.isCompletedValue != nil
+                ? "completed=\(query.completionFilter.isCompletedValue!)"
+                : nil,
             query.dueDateFilter != .all ? "dueDateFilter=\(query.dueDateFilter)" : nil,
             query.sortDateFrom != nil ? "sortDateFrom=\(query.sortDateFrom!)" : nil,
             query.sortDateTo != nil ? "sortDateTo=\(query.sortDateTo!)" : nil,
@@ -50,10 +51,10 @@ final class TodoServiceImpl: TodoService {
 
         var firestoreQuery = makeQuery(uid: uid, query: query)
 
-        if let category = query.category {
+        if let categoryId = query.categoryId {
             firestoreQuery = firestoreQuery.whereField(
                 TodoFieldKey.category.rawValue,
-                isEqualTo: category.storageValue
+                isEqualTo: categoryId
             )
         }
 
@@ -99,7 +100,10 @@ final class TodoServiceImpl: TodoService {
                 while true {
                     var pageQuery = firestoreQuery
                     if let pageCursor {
-                        guard let cursorValues = cursorValues(for: query, cursor: pageCursor) else {
+                        guard let cursorValues = cursorValues(
+                            for: query,
+                            cursor: pageCursor
+                        ) else {
                             logger.error("Failed to build cursor values for paginated todo fetch.")
                             break
                         }
@@ -165,7 +169,7 @@ final class TodoServiceImpl: TodoService {
     // swiftlint:enable function_body_length
 
     func upsertTodo(request: TodoRequest) async throws {
-        guard let uid = Auth.auth().currentUser?.uid else { throw AuthError.notAuthenticated }
+        guard let uid = Auth.auth().currentUser?.uid else { throw DataLayerError.notAuthenticated }
 
         logger.info("Upserting todo")
         
@@ -199,7 +203,7 @@ final class TodoServiceImpl: TodoService {
     }
     
     func deleteTodo(todoId: String) async throws {
-        guard Auth.auth().currentUser?.uid != nil else { throw AuthError.notAuthenticated }
+        guard Auth.auth().currentUser?.uid != nil else { throw DataLayerError.notAuthenticated }
 
         logger.info("Requesting todo deletion")
         
@@ -215,7 +219,7 @@ final class TodoServiceImpl: TodoService {
     }
 
     func undoDeleteTodo(todoId: String) async throws {
-        guard Auth.auth().currentUser?.uid != nil else { throw AuthError.notAuthenticated }
+        guard Auth.auth().currentUser?.uid != nil else { throw DataLayerError.notAuthenticated }
 
         logger.info("Undoing todo deletion")
 
@@ -231,7 +235,7 @@ final class TodoServiceImpl: TodoService {
     }
 
     func fetchTodo(todoId: String) async throws -> TodoResponse {
-        guard let uid = Auth.auth().currentUser?.uid else { throw AuthError.notAuthenticated }
+        guard let uid = Auth.auth().currentUser?.uid else { throw DataLayerError.notAuthenticated }
 
         logger.info("Fetching todo")
 
@@ -254,7 +258,7 @@ final class TodoServiceImpl: TodoService {
     }
 
     func fetchReferences(_ numbers: [Int]) async throws -> [Int: TodoReferenceResponse] {
-        guard let uid = Auth.auth().currentUser?.uid else { throw AuthError.notAuthenticated }
+        guard let uid = Auth.auth().currentUser?.uid else { throw DataLayerError.notAuthenticated }
 
         let uniqueNumbers = Array(Set(numbers)).sorted()
         if uniqueNumbers.isEmpty { return [:] }
@@ -524,5 +528,41 @@ private extension TodoServiceImpl {
     enum CounterFieldKey: String {
         case nextNumber
         case updatedAt
+    }
+}
+
+private extension TodoQuery.SortTarget {
+    var fieldName: String {
+        switch self {
+        case .createdAt:
+            return "createdAt"
+        case .completedAt:
+            return "completedAt"
+        case .deletedAt:
+            return "deletedAt"
+        case .updatedAt:
+            return "updatedAt"
+        case .dueDate:
+            return "dueDate"
+        }
+    }
+}
+
+private extension TodoQuery.SortOrder {
+    var isDescending: Bool {
+        self == .latest
+    }
+}
+
+private extension TodoQuery.CompletionFilter {
+    var isCompletedValue: Bool? {
+        switch self {
+        case .all:
+            return nil
+        case .incomplete:
+            return false
+        case .completed:
+            return true
+        }
     }
 }

--- a/Application/DevLogInfra/Sources/Service/UserServiceImpl.swift
+++ b/Application/DevLogInfra/Sources/Service/UserServiceImpl.swift
@@ -9,7 +9,6 @@ import FirebaseAuth
 import FirebaseFirestore
 import DevLogCore
 import DevLogData
-import DevLogDomain
 
 final class UserServiceImpl: UserService {
     private let store = Firestore.firestore()
@@ -21,7 +20,7 @@ final class UserServiceImpl: UserService {
         
         guard let user = Auth.auth().currentUser else {
             logger.error("User not authenticated")
-            throw AuthError.notAuthenticated
+            throw DataLayerError.notAuthenticated
         }
 
         do {
@@ -115,7 +114,7 @@ final class UserServiceImpl: UserService {
         
         guard let uid = Auth.auth().currentUser?.uid else {
             logger.error("User not authenticated")
-            throw AuthError.notAuthenticated
+            throw DataLayerError.notAuthenticated
         }
 
         do {
@@ -153,7 +152,7 @@ final class UserServiceImpl: UserService {
         
         guard let uid = Auth.auth().currentUser?.uid else {
             logger.error("User not authenticated")
-            throw AuthError.notAuthenticated
+            throw DataLayerError.notAuthenticated
         }
 
         do {

--- a/Application/DevLogInfra/Sources/Service/WebPageServiceImpl.swift
+++ b/Application/DevLogInfra/Sources/Service/WebPageServiceImpl.swift
@@ -10,7 +10,6 @@ import FirebaseFirestore
 import FirebaseFunctions
 import DevLogCore
 import DevLogData
-import DevLogDomain
 
 final class WebPageServiceImpl: WebPageService {
     private enum FunctionName: String {
@@ -29,7 +28,7 @@ final class WebPageServiceImpl: WebPageService {
         
         guard let uid = Auth.auth().currentUser?.uid else {
             logger.error("User not authenticated")
-            throw AuthError.notAuthenticated
+            throw DataLayerError.notAuthenticated
         }
 
         do {
@@ -62,7 +61,7 @@ final class WebPageServiceImpl: WebPageService {
         
         guard let uid = Auth.auth().currentUser?.uid else {
             logger.error("User not authenticated")
-            throw AuthError.notAuthenticated
+            throw DataLayerError.notAuthenticated
         }
 
         do {
@@ -82,7 +81,7 @@ final class WebPageServiceImpl: WebPageService {
 
         guard Auth.auth().currentUser?.uid != nil else {
             logger.error("User not authenticated")
-            throw AuthError.notAuthenticated
+            throw DataLayerError.notAuthenticated
         }
 
         do {
@@ -100,7 +99,7 @@ final class WebPageServiceImpl: WebPageService {
 
         guard Auth.auth().currentUser?.uid != nil else {
             logger.error("User not authenticated")
-            throw AuthError.notAuthenticated
+            throw DataLayerError.notAuthenticated
         }
 
         do {

--- a/Application/DevLogPersistence/Sources/Persistence/ThemeStoreImpl.swift
+++ b/Application/DevLogPersistence/Sources/Persistence/ThemeStoreImpl.swift
@@ -8,7 +8,6 @@
 import Combine
 import DevLogDomain
 import DevLogData
-import DevLogWidgetCore
 
 final class ThemeStoreImpl: ThemeStore {
     private let subject = CurrentValueSubject<SystemTheme, Never>(.automatic)

--- a/Application/DevLogPersistence/Sources/Persistence/ThemeStoreImpl.swift
+++ b/Application/DevLogPersistence/Sources/Persistence/ThemeStoreImpl.swift
@@ -6,7 +6,7 @@
 //
 
 import Combine
-import DevLogDomain
+import DevLogCore
 import DevLogData
 
 final class ThemeStoreImpl: ThemeStore {

--- a/Application/DevLogPersistence/Sources/Persistence/UserDefaultsStoreImpl.swift
+++ b/Application/DevLogPersistence/Sources/Persistence/UserDefaultsStoreImpl.swift
@@ -6,9 +6,7 @@
 //
 
 import Foundation
-import DevLogDomain
 import DevLogData
-import DevLogWidgetCore
 
 final class UserDefaultsStoreImpl: UserDefaultsStore {
     private let userDefaults: UserDefaults

--- a/Application/DevLogPersistence/Sources/Persistence/WebPageImageStoreImpl.swift
+++ b/Application/DevLogPersistence/Sources/Persistence/WebPageImageStoreImpl.swift
@@ -7,9 +7,7 @@
 
 import CryptoKit
 import Foundation
-import DevLogDomain
 import DevLogData
-import DevLogWidgetCore
 
 actor WebPageImageStoreImpl: WebPageImageStore {
     func cachedImageURL(for url: URL) async throws -> URL {

--- a/Application/DevLogPersistence/Sources/Persistence/WidgetSnapshotPreferenceStoreImpl.swift
+++ b/Application/DevLogPersistence/Sources/Persistence/WidgetSnapshotPreferenceStoreImpl.swift
@@ -6,8 +6,9 @@
 //
 
 import Foundation
-import DevLogDomain
+import DevLogCore
 import DevLogData
+import DevLogDomain
 
 final class WidgetSnapshotPreferenceStoreImpl: WidgetSnapshotPreferenceStore {
     private enum Key: String, CaseIterable {

--- a/Application/DevLogPersistence/Sources/Persistence/WidgetSnapshotPreferenceStoreImpl.swift
+++ b/Application/DevLogPersistence/Sources/Persistence/WidgetSnapshotPreferenceStoreImpl.swift
@@ -8,7 +8,6 @@
 import Foundation
 import DevLogDomain
 import DevLogData
-import DevLogWidgetCore
 
 final class WidgetSnapshotPreferenceStoreImpl: WidgetSnapshotPreferenceStore {
     private enum Key: String, CaseIterable {

--- a/Application/DevLogPersistence/Tests/Persistence/WidgetSnapshotUpdaterTests.swift
+++ b/Application/DevLogPersistence/Tests/Persistence/WidgetSnapshotUpdaterTests.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import DevLogCore
 import DevLogDomain
 import Testing
 @testable import DevLogPersistence

--- a/Application/DevLogPresentation/Sources/Home/TodoEditorView.swift
+++ b/Application/DevLogPresentation/Sources/Home/TodoEditorView.swift
@@ -215,9 +215,9 @@ private struct TodoEditorInfoSheetView: View {
                         String(localized: "todo_category"),
                         selection: Binding(
                             get: { viewModel.state.category.id },
-                            set: { categoryID in
+                            set: { categoryId in
                                 guard let item = viewModel.state.categories.first(where: {
-                                    $0.id == categoryID
+                                    $0.id == categoryId
                                 }) else {
                                     return
                                 }

--- a/Application/DevLogPresentation/Sources/Setting/ThemeView.swift
+++ b/Application/DevLogPresentation/Sources/Setting/ThemeView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import DevLogCore
 import DevLogDomain
 
 struct ThemeView: View {

--- a/Application/DevLogPresentation/Sources/Today/TodayView.swift
+++ b/Application/DevLogPresentation/Sources/Today/TodayView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import DevLogCore
 import DevLogDomain
 
 struct TodayView: View {

--- a/Application/DevLogPresentation/Sources/ViewModel/HomeViewModel.swift
+++ b/Application/DevLogPresentation/Sources/ViewModel/HomeViewModel.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import Combine
+import DevLogCore
 import DevLogDomain
 
 @Observable

--- a/Application/DevLogPresentation/Sources/ViewModel/ProfileViewModel.swift
+++ b/Application/DevLogPresentation/Sources/ViewModel/ProfileViewModel.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import Combine
+import DevLogCore
 import DevLogDomain
 
 @Observable

--- a/Application/DevLogPresentation/Sources/ViewModel/PushNotificationListViewModel.swift
+++ b/Application/DevLogPresentation/Sources/ViewModel/PushNotificationListViewModel.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import Combine
+import DevLogCore
 import DevLogDomain
 
 @Observable

--- a/Application/DevLogPresentation/Sources/ViewModel/RootViewModel.swift
+++ b/Application/DevLogPresentation/Sources/ViewModel/RootViewModel.swift
@@ -8,6 +8,7 @@
 import Foundation
 import Combine
 import UserNotifications
+import DevLogCore
 import DevLogDomain
 
 @Observable

--- a/Application/DevLogPresentation/Sources/ViewModel/SearchViewModel.swift
+++ b/Application/DevLogPresentation/Sources/ViewModel/SearchViewModel.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import OrderedCollections
+import DevLogCore
 import DevLogDomain
 
 @Observable

--- a/Application/DevLogPresentation/Sources/ViewModel/SettingViewModel.swift
+++ b/Application/DevLogPresentation/Sources/ViewModel/SettingViewModel.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import Combine
+import DevLogCore
 import DevLogDomain
 
 @Observable

--- a/Application/DevLogPresentation/Sources/ViewModel/TodayViewModel.swift
+++ b/Application/DevLogPresentation/Sources/ViewModel/TodayViewModel.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import DevLogCore
 import DevLogDomain
 
 @Observable

--- a/Application/DevLogPresentation/Sources/ViewModel/TodoListViewModel.swift
+++ b/Application/DevLogPresentation/Sources/ViewModel/TodoListViewModel.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import DevLogCore
 import DevLogDomain
 
 @Observable
@@ -109,7 +110,7 @@ final class TodoListViewModel: Store {
         self.undoDeleteTodoUseCase = undoDeleteTodoUseCase
         self.category = category
         self.state = State(
-            query: TodoQuery(category: category)
+            query: TodoQuery(categoryId: category.storageValue)
         )
     }
 
@@ -192,7 +193,7 @@ final class TodoListViewModel: Store {
                             self.endLoading(.immediate)
                         }
                     }
-                    let query = TodoQuery(category: category, keyword: keyword)
+                    let query = TodoQuery(categoryId: category.storageValue, keyword: keyword)
                     let page = try await fetchTodosUseCase.execute(query, cursor: nil)
                     if Task.isCancelled { return }
                     send(.fetchSearchResults(page.items.compactMap { TodoListItem(from: $0) }))
@@ -308,7 +309,7 @@ private extension TodoListViewModel {
             self.nextCursor = nil
             return [.fetch]
         case .resetFilters:
-            state.query = TodoQuery(category: category)
+            state.query = TodoQuery(categoryId: category.storageValue)
             self.nextCursor = nil
             return [.fetch]
         case .setIsSearching(let value):

--- a/Application/DevLogPresentation/Tests/PushNotification/DeletePushNotificationTests.swift
+++ b/Application/DevLogPresentation/Tests/PushNotification/DeletePushNotificationTests.swift
@@ -7,6 +7,7 @@
 
 import Testing
 import Foundation
+import DevLogCore
 import DevLogDomain
 @testable import DevLogPresentation
 

--- a/Application/DevLogPresentation/Tests/Support/TestSupport.swift
+++ b/Application/DevLogPresentation/Tests/Support/TestSupport.swift
@@ -8,6 +8,7 @@
 import Testing
 import Foundation
 import Combine
+import DevLogCore
 import DevLogDomain
 @testable import DevLogPresentation
 

--- a/Widget/DevLogWidgetCore/Sources/Today/TodayWidgetSnapshotFactory.swift
+++ b/Widget/DevLogWidgetCore/Sources/Today/TodayWidgetSnapshotFactory.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import DevLogCore
 import DevLogDomain
 import DevLogData
 

--- a/Widget/DevLogWidgetCore/Tests/Sync/WidgetSyncEventHandlerTests.swift
+++ b/Widget/DevLogWidgetCore/Tests/Sync/WidgetSyncEventHandlerTests.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import Testing
+import DevLogCore
 import DevLogData
 import DevLogDomain
 @testable import DevLogWidgetCore

--- a/Widget/DevLogWidgetCore/Tests/Today/TodayWidgetSnapshotFactoryTests.swift
+++ b/Widget/DevLogWidgetCore/Tests/Today/TodayWidgetSnapshotFactoryTests.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import Testing
+import DevLogCore
 import DevLogDomain
 @testable import DevLogWidgetCore
 


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #454

## 🎯 의도

Infra, Persistence, WidgetCore에서 Domain 레이어에 직접 의존하던 구조를 정리하고 레이어 간 참조 방향을 명확히 하기 위함

## 📝 작업 내용

### 📌 요약

- 공통 계약 모델을 Core로 이동
- Infra 레이어의 Domain 직접 의존성 제거
- Data 레이어에서 DTO와 Domain 모델 간 매핑 책임 정리
- Data / Domain 경계의 에러 매핑 구조 정리
- DevLogInfra 프로젝트에서 불필요한 DevLogDomain 링크 제거

### 🔍 상세

- `TodoQuery`, `PushNotificationQuery`, `SystemTheme`, `TodayDisplayOptions`를 Core 모델로 이동
- Infra 서비스가 Domain 모델 대신 Core / Data 모델을 사용하도록 수정
- `TodoCategoryPreferenceResponse`를 추가하여 TodoCategory 저장 응답을 Data 모델로 분리
- Todo, PushNotification, WebPage, User, TodoCategory Repository에서 DTO와 Domain 변환 흐름 정리
- Data 레이어 에러를 Domain 에러로 변환하는 `toDomain()` 매핑 추가
- Auth 관련 Infra 에러를 Data 레이어 경계에서 처리하도록 정리
- `DevLogInfra.xcodeproj`에서 `DevLogDomain.framework` link, target dependency, project reference 제거
- Presentation / WidgetCore / Persistence에서 Core 모델 import 반영

## 📸 영상 / 이미지 (Optional)
