### PR TITLE
[#470] Xcode 프로젝트 편집 중 크래시가 발생하는 현상을 해결한다

### DIFF
--- a/Application/DevLogApp/DevLogApp.xcodeproj/project.pbxproj
+++ b/Application/DevLogApp/DevLogApp.xcodeproj/project.pbxproj
@@ -7,20 +7,20 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		020DFF50F37E47DF86BC155D /* DevLogData.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = B1B97007E09855108A99428B /* DevLogData.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		0B50A22827B641AEBCC033D4 /* DevLogWidgetCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = EBFCE939492CAE5AB44E6B81 /* DevLogWidgetCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		1589C1EF4029ECBF15A842F0 /* DevLogWidgetCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EBFCE939492CAE5AB44E6B81 /* DevLogWidgetCore.framework */; };
 		160E41BDADA3136CD58BE0B4 /* DevLogData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B1B97007E09855108A99428B /* DevLogData.framework */; };
 		186E9AB4F0A79C50FE853607 /* DevLogDomain.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA49949C677DDE083F7DE29E /* DevLogDomain.framework */; };
 		18D57A125ACCF0F6B11A7101 /* GoogleSignIn in Frameworks */ = {isa = PBXBuildFile; productRef = F972F1E8E0F5156FE9651020 /* GoogleSignIn */; };
+		1E452BFF04594187A06AED58 /* DevLogDomain.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = DA49949C677DDE083F7DE29E /* DevLogDomain.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		26C3DC51F23F9C590FDB282D /* DevLogPresentation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 67918B544432C45E63273D84 /* DevLogPresentation.framework */; };
-		020DFF50F37E47DF86BC155D /* DevLogData.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = B1B97007E09855108A99428B /* DevLogData.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		393544DD58D941B69760727E /* DevLogPresentation.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 67918B544432C45E63273D84 /* DevLogPresentation.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		618B54224ACD6B35D9A8F841 /* DevLogWidgetCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EBFCE939492CAE5AB44E6B81 /* DevLogWidgetCore.framework */; };
 		7188DA2B6DFD13F7FF73069E /* DevLogInfra.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A6AEE3AFC586C92F1643282 /* DevLogInfra.framework */; };
 		79134AD67952720CCC5069EA /* DevLogPersistence.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6FFA0A819CB16649AC35CCE6 /* DevLogPersistence.framework */; };
-		0B50A22827B641AEBCC033D4 /* DevLogWidgetCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = EBFCE939492CAE5AB44E6B81 /* DevLogWidgetCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		1E452BFF04594187A06AED58 /* DevLogDomain.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = DA49949C677DDE083F7DE29E /* DevLogDomain.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		393544DD58D941B69760727E /* DevLogPresentation.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 67918B544432C45E63273D84 /* DevLogPresentation.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		AB11B22C33D44E55F6677889 /* DevLogCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AE11B22C33D44E55F6677889 /* DevLogCore.framework */; };
 		A54A1843C2074FD4A651238F /* DevLogWidgetCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = EBFCE939492CAE5AB44E6B81 /* DevLogWidgetCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		AB11B22C33D44E55F6677889 /* DevLogCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AE11B22C33D44E55F6677889 /* DevLogCore.framework */; };
 		B38B9C91AECB49BA9C7CB8DC /* DevLogPersistence.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 6FFA0A819CB16649AC35CCE6 /* DevLogPersistence.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		B9409E4F83EB4B0A9049D245 /* DevLogInfra.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9A6AEE3AFC586C92F1643282 /* DevLogInfra.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		DA205F52B7C54C2C99671D50 /* DevLogCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = AE11B22C33D44E55F6677889 /* DevLogCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -89,17 +89,17 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		DF3416492E45F67C00F9312B /* DevLogAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DevLogAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		DFD3A9702F8E89DD001DA7CD /* DevLogWidgetExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = DevLogWidgetExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
-		DFD3A9712F8E89DD001DA7CD /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
-		DFD3A9732F8E89DD001DA7CD /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
-		DFD48B002DC4D6E2005905C5 /* DevLog.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DevLog.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		67918B544432C45E63273D84 /* DevLogPresentation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DevLogPresentation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6FFA0A819CB16649AC35CCE6 /* DevLogPersistence.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DevLogPersistence.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9A6AEE3AFC586C92F1643282 /* DevLogInfra.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DevLogInfra.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		AE11B22C33D44E55F6677889 /* DevLogCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DevLogCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B1B97007E09855108A99428B /* DevLogData.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DevLogData.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DA49949C677DDE083F7DE29E /* DevLogDomain.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DevLogDomain.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		DF3416492E45F67C00F9312B /* DevLogAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DevLogAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		DFD3A9702F8E89DD001DA7CD /* DevLogWidgetExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = DevLogWidgetExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		DFD3A9712F8E89DD001DA7CD /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
+		DFD3A9732F8E89DD001DA7CD /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
+		DFD48B002DC4D6E2005905C5 /* DevLog.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DevLog.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		EBFCE939492CAE5AB44E6B81 /* DevLogWidgetCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DevLogWidgetCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -124,8 +124,6 @@
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		DF34164A2E45F67C00F9312B /* Tests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-			);
 			path = Tests;
 			sourceTree = "<group>";
 		};
@@ -397,11 +395,11 @@
 		};
 		DF66A07D2EA52E9F0098E643 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			productRef = DF66A07C2EA52E9F0098E643 /* plugin:SwiftLintBuildToolPlugin */;
+			productRef = DF66A07C2EA52E9F0098E643 /* SwiftLintBuildToolPlugin */;
 		};
 		DF66A07E2EA52E9F0098E643 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			productRef = DF66A07C2EA52E9F0098E643 /* plugin:SwiftLintBuildToolPlugin */;
+			productRef = DF66A07C2EA52E9F0098E643 /* SwiftLintBuildToolPlugin */;
 		};
 		DFD3A97E2F8E89DF001DA7CD /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -819,7 +817,7 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		DF66A07C2EA52E9F0098E643 /* plugin:SwiftLintBuildToolPlugin */ = {
+		DF66A07C2EA52E9F0098E643 /* SwiftLintBuildToolPlugin */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = DF66A07B2EA52E970098E643 /* XCRemoteSwiftPackageReference "SwiftLint" */;
 			productName = "plugin:SwiftLintBuildToolPlugin";

--- a/Application/DevLogApp/DevLogApp.xcodeproj/project.pbxproj
+++ b/Application/DevLogApp/DevLogApp.xcodeproj/project.pbxproj
@@ -30,97 +30,6 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		0F460A6F0F9B74AE847DFD16 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = CA2F877790969610EE38BD93 /* DevLogInfra.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = CB9B628AE2E0684C1FCF8840;
-			remoteInfo = DevLogInfra;
-		};
-		17E732C4E37D1ADD4E46D669 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = DC0CB81C9BF2596ADCE8FB90 /* DevLogPresentation.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = A85D2D7D1D6DAAFBF86C9C34;
-			remoteInfo = DevLogPresentation;
-		};
-		3BC2BDF8DAF15E7E6FF53443 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 76E37401D4B2CBB105E63892 /* DevLogDomain.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 3F08F6B94839E9021FCFC466;
-			remoteInfo = Subproject;
-		};
-		3EECE4329ECCA26C0A19337E /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 8EEA1D8B1005FDC147585C76 /* DevLogPersistence.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 0C205A501EF8E79FA9A73C4B;
-			remoteInfo = DevLogPersistence;
-		};
-		5AD2E0B85930A1F24ED8888E /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = E6378CBE9A1D81625216CF86 /* DevLogData.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 4AB6E00A38C37CDBF82B57FD;
-			remoteInfo = Subproject;
-		};
-		687F85C6DCE6D569D448B141 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 264087B765CCEA97AB4C0B79 /* DevLogWidgetCore.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 6AF1B307A7E7CC03AA2BABB1;
-			remoteInfo = Subproject;
-		};
-		8D6BFCB260B27974560B42C6 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 264087B765CCEA97AB4C0B79 /* DevLogWidgetCore.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 687DD42230CC25053ABB5FB8;
-			remoteInfo = DevLogWidgetCore;
-		};
-		933EF563698CBBA322E4A1FF /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 8EEA1D8B1005FDC147585C76 /* DevLogPersistence.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 86E8AA2A43914F444BF5A6C2;
-			remoteInfo = Subproject;
-		};
-		A974AB39F1B9AEC8C3519A47 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = CA2F877790969610EE38BD93 /* DevLogInfra.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 592C8B7B099933759AB316A5;
-			remoteInfo = Subproject;
-		};
-		AC11B22C33D44E55F6677889 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = AA11B22C33D44E55F6677889 /* DevLogCore.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 5755BDB768C11CE0FDEA4828;
-			remoteInfo = DevLogCore;
-		};
-		AD11B22C33D44E55F6677889 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = AA11B22C33D44E55F6677889 /* DevLogCore.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 9E9FD7B09D0D7EAB8B828A5E;
-			remoteInfo = Subproject;
-		};
-		D113DE9A0832A6EB30D402FD /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = DC0CB81C9BF2596ADCE8FB90 /* DevLogPresentation.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 5E7473315771B5D3030C5003;
-			remoteInfo = Subproject;
-		};
-		D47319B34F77243F170E2A1A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 264087B765CCEA97AB4C0B79 /* DevLogWidgetCore.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 687DD42230CC25053ABB5FB8;
-			remoteInfo = DevLogWidgetCore;
-		};
 		DF34164B2E45F67C00F9312B /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = DFD48AF82DC4D6E2005905C5 /* Project object */;
@@ -134,20 +43,6 @@
 			proxyType = 1;
 			remoteGlobalIDString = DFD3A96F2F8E89DD001DA7CD;
 			remoteInfo = DevLogWidgetExtension;
-		};
-		E95D839477AC9648EDD0F85F /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = E6378CBE9A1D81625216CF86 /* DevLogData.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = D9D76C33D8B4790694BD3488;
-			remoteInfo = DevLogData;
-		};
-		EA9B82690DAF18F719BA42AC /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 76E37401D4B2CBB105E63892 /* DevLogDomain.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 7D1E74925088998D68BBFBBB;
-			remoteInfo = DevLogDomain;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -194,18 +89,18 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		264087B765CCEA97AB4C0B79 /* DevLogWidgetCore.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = DevLogWidgetCore.xcodeproj; path = ../../Widget/DevLogWidgetCore/DevLogWidgetCore.xcodeproj; sourceTree = "<group>"; };
-		76E37401D4B2CBB105E63892 /* DevLogDomain.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = DevLogDomain.xcodeproj; path = ../DevLogDomain/DevLogDomain.xcodeproj; sourceTree = "<group>"; };
-		8EEA1D8B1005FDC147585C76 /* DevLogPersistence.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = DevLogPersistence.xcodeproj; path = ../DevLogPersistence/DevLogPersistence.xcodeproj; sourceTree = "<group>"; };
-		AA11B22C33D44E55F6677889 /* DevLogCore.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = DevLogCore.xcodeproj; path = ../DevLogCore/DevLogCore.xcodeproj; sourceTree = "<group>"; };
-		CA2F877790969610EE38BD93 /* DevLogInfra.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = DevLogInfra.xcodeproj; path = ../DevLogInfra/DevLogInfra.xcodeproj; sourceTree = "<group>"; };
-		DC0CB81C9BF2596ADCE8FB90 /* DevLogPresentation.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = DevLogPresentation.xcodeproj; path = ../DevLogPresentation/DevLogPresentation.xcodeproj; sourceTree = "<group>"; };
 		DF3416492E45F67C00F9312B /* DevLogAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DevLogAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		DFD3A9702F8E89DD001DA7CD /* DevLogWidgetExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = DevLogWidgetExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		DFD3A9712F8E89DD001DA7CD /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
 		DFD3A9732F8E89DD001DA7CD /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
 		DFD48B002DC4D6E2005905C5 /* DevLog.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DevLog.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		E6378CBE9A1D81625216CF86 /* DevLogData.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = DevLogData.xcodeproj; path = ../DevLogData/DevLogData.xcodeproj; sourceTree = "<group>"; };
+		67918B544432C45E63273D84 /* DevLogPresentation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DevLogPresentation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		6FFA0A819CB16649AC35CCE6 /* DevLogPersistence.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DevLogPersistence.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		9A6AEE3AFC586C92F1643282 /* DevLogInfra.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DevLogInfra.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		AE11B22C33D44E55F6677889 /* DevLogCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DevLogCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		B1B97007E09855108A99428B /* DevLogData.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DevLogData.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		DA49949C677DDE083F7DE29E /* DevLogDomain.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DevLogDomain.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		EBFCE939492CAE5AB44E6B81 /* DevLogWidgetCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DevLogWidgetCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -305,20 +200,6 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		4F3D8CEC7F23C3BFF6B9E27B /* Projects */ = {
-			isa = PBXGroup;
-			children = (
-				AA11B22C33D44E55F6677889 /* DevLogCore.xcodeproj */,
-				76E37401D4B2CBB105E63892 /* DevLogDomain.xcodeproj */,
-				E6378CBE9A1D81625216CF86 /* DevLogData.xcodeproj */,
-				CA2F877790969610EE38BD93 /* DevLogInfra.xcodeproj */,
-				8EEA1D8B1005FDC147585C76 /* DevLogPersistence.xcodeproj */,
-				DC0CB81C9BF2596ADCE8FB90 /* DevLogPresentation.xcodeproj */,
-				264087B765CCEA97AB4C0B79 /* DevLogWidgetCore.xcodeproj */,
-			);
-			name = Projects;
-			sourceTree = "<group>";
-		};
 		DFD48AF72DC4D6E2005905C5 = {
 			isa = PBXGroup;
 			children = (
@@ -326,7 +207,6 @@
 				DF34164A2E45F67C00F9312B /* Tests */,
 				DFD3A9752F8E89DD001DA7CD /* ../../Widget/DevLogWidgetExtension */,
 				DFE28EB62DCCF26300B28FE5 /* Frameworks */,
-				4F3D8CEC7F23C3BFF6B9E27B /* Projects */,
 				4B47FFC0E73415A65560089A /* Products */,
 			);
 			sourceTree = "<group>";
@@ -377,7 +257,6 @@
 			buildRules = (
 			);
 			dependencies = (
-				F7528B3FE01EAD33E2A02C63 /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				DFD3A9752F8E89DD001DA7CD /* ../../Widget/DevLogWidgetExtension */,
@@ -402,13 +281,6 @@
 			dependencies = (
 				DF66A07D2EA52E9F0098E643 /* PBXTargetDependency */,
 				DFD3A97E2F8E89DF001DA7CD /* PBXTargetDependency */,
-				AF11B22C33D44E55F6677889 /* PBXTargetDependency */,
-				50D25760371BEF13D9781476 /* PBXTargetDependency */,
-				56CC02CD824E370E0BF33D2E /* PBXTargetDependency */,
-				CD56EF21C39E985CEDBB9165 /* PBXTargetDependency */,
-				F00B1378BDC6B8D7CCD24AB0 /* PBXTargetDependency */,
-				A2A3C286B46BB965A8D4C047 /* PBXTargetDependency */,
-				D8C9622EAD15756212C69E6A /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				DF8AB7982E938B0B00E50BBF /* Sources */,
@@ -460,36 +332,6 @@
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 4B47FFC0E73415A65560089A /* Products */;
 			projectDirPath = "";
-			projectReferences = (
-				{
-					ProductGroup = 4B47FFC0E73415A65560089A /* Products */;
-					ProjectRef = AA11B22C33D44E55F6677889 /* DevLogCore.xcodeproj */;
-				},
-				{
-					ProductGroup = 4B47FFC0E73415A65560089A /* Products */;
-					ProjectRef = E6378CBE9A1D81625216CF86 /* DevLogData.xcodeproj */;
-				},
-				{
-					ProductGroup = 4B47FFC0E73415A65560089A /* Products */;
-					ProjectRef = 76E37401D4B2CBB105E63892 /* DevLogDomain.xcodeproj */;
-				},
-				{
-					ProductGroup = 4B47FFC0E73415A65560089A /* Products */;
-					ProjectRef = CA2F877790969610EE38BD93 /* DevLogInfra.xcodeproj */;
-				},
-				{
-					ProductGroup = 4B47FFC0E73415A65560089A /* Products */;
-					ProjectRef = DC0CB81C9BF2596ADCE8FB90 /* DevLogPresentation.xcodeproj */;
-				},
-				{
-					ProductGroup = 4B47FFC0E73415A65560089A /* Products */;
-					ProjectRef = 8EEA1D8B1005FDC147585C76 /* DevLogPersistence.xcodeproj */;
-				},
-				{
-					ProductGroup = 4B47FFC0E73415A65560089A /* Products */;
-					ProjectRef = 264087B765CCEA97AB4C0B79 /* DevLogWidgetCore.xcodeproj */;
-				},
-			);
 			projectRoot = "";
 			targets = (
 				DF3416442E45F67C00F9312B /* DevLogAppTests */,
@@ -498,58 +340,6 @@
 			);
 		};
 /* End PBXProject section */
-
-/* Begin PBXReferenceProxy section */
-		67918B544432C45E63273D84 /* DevLogPresentation.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = DevLogPresentation.framework;
-			remoteRef = D113DE9A0832A6EB30D402FD /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		6FFA0A819CB16649AC35CCE6 /* DevLogPersistence.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = DevLogPersistence.framework;
-			remoteRef = 933EF563698CBBA322E4A1FF /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		9A6AEE3AFC586C92F1643282 /* DevLogInfra.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = DevLogInfra.framework;
-			remoteRef = A974AB39F1B9AEC8C3519A47 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		AE11B22C33D44E55F6677889 /* DevLogCore.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = DevLogCore.framework;
-			remoteRef = AD11B22C33D44E55F6677889 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		B1B97007E09855108A99428B /* DevLogData.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = DevLogData.framework;
-			remoteRef = 5AD2E0B85930A1F24ED8888E /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		DA49949C677DDE083F7DE29E /* DevLogDomain.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = DevLogDomain.framework;
-			remoteRef = 3BC2BDF8DAF15E7E6FF53443 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		EBFCE939492CAE5AB44E6B81 /* DevLogWidgetCore.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = DevLogWidgetCore.framework;
-			remoteRef = 687F85C6DCE6D569D448B141 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-/* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
 		DF3416482E45F67C00F9312B /* Resources */ = {
@@ -600,36 +390,6 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		50D25760371BEF13D9781476 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = DevLogDomain;
-			targetProxy = EA9B82690DAF18F719BA42AC /* PBXContainerItemProxy */;
-		};
-		56CC02CD824E370E0BF33D2E /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = DevLogInfra;
-			targetProxy = 0F460A6F0F9B74AE847DFD16 /* PBXContainerItemProxy */;
-		};
-		A2A3C286B46BB965A8D4C047 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = DevLogWidgetCore;
-			targetProxy = D47319B34F77243F170E2A1A /* PBXContainerItemProxy */;
-		};
-		AF11B22C33D44E55F6677889 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = DevLogCore;
-			targetProxy = AC11B22C33D44E55F6677889 /* PBXContainerItemProxy */;
-		};
-		CD56EF21C39E985CEDBB9165 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = DevLogPersistence;
-			targetProxy = 3EECE4329ECCA26C0A19337E /* PBXContainerItemProxy */;
-		};
-		D8C9622EAD15756212C69E6A /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = DevLogData;
-			targetProxy = E95D839477AC9648EDD0F85F /* PBXContainerItemProxy */;
-		};
 		DF34164C2E45F67C00F9312B /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = DFD48AFF2DC4D6E2005905C5 /* DevLog */;
@@ -647,16 +407,6 @@
 			isa = PBXTargetDependency;
 			target = DFD3A96F2F8E89DD001DA7CD /* DevLogWidgetExtension */;
 			targetProxy = DFD3A97D2F8E89DF001DA7CD /* PBXContainerItemProxy */;
-		};
-		F00B1378BDC6B8D7CCD24AB0 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = DevLogPresentation;
-			targetProxy = 17E732C4E37D1ADD4E46D669 /* PBXContainerItemProxy */;
-		};
-		F7528B3FE01EAD33E2A02C63 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = DevLogWidgetCore;
-			targetProxy = 8D6BFCB260B27974560B42C6 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 

--- a/Application/DevLogCore/DevLogCore.xcodeproj/project.pbxproj
+++ b/Application/DevLogCore/DevLogCore.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 77;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -18,7 +18,7 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
-		DA0865721A6D430B66025E67 /* Exceptions for "Sources" folder in "DevLogCore" target */ = {
+		DA0865721A6D430B66025E67 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				.swiftlint.yml,
@@ -28,14 +28,7 @@
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		DA0865721A6D430B66025E66 /* Sources */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-				DA0865721A6D430B66025E67 /* Exceptions for "Sources" folder in "DevLogCore" target */,
-			);
-			path = Sources;
-			sourceTree = "<group>";
-		};
+		DA0865721A6D430B66025E66 /* Sources */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (DA0865721A6D430B66025E67 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = Sources; sourceTree = "<group>"; };
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -138,11 +131,9 @@
 				Base,
 			);
 			mainGroup = C0DE4BE90CB1A6B4CEDFCA61;
-			minimizedProjectReferenceProxies = 0;
 			packageReferences = (
 				C0DEAA000000000000000002 /* XCRemoteSwiftPackageReference "SwiftLint" */,
 			);
-			preferredProjectObjectVersion = 77;
 			productRefGroup = B66C037F848BDEE68DAC8902 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -175,28 +166,9 @@
 /* Begin PBXTargetDependency section */
 		C0DEAA000000000000000001 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			productRef = C0DEAA000000000000000003 /* plugin:SwiftLintBuildToolPlugin */;
+			productRef = C0DEAA000000000000000003 /* SwiftLintBuildToolPlugin */;
 		};
 /* End PBXTargetDependency section */
-
-/* Begin XCRemoteSwiftPackageReference section */
-		C0DEAA000000000000000002 /* XCRemoteSwiftPackageReference "SwiftLint" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/realm/SwiftLint";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.62.1;
-			};
-		};
-/* End XCRemoteSwiftPackageReference section */
-
-/* Begin XCSwiftPackageProductDependency section */
-		C0DEAA000000000000000003 /* plugin:SwiftLintBuildToolPlugin */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = C0DEAA000000000000000002 /* XCRemoteSwiftPackageReference "SwiftLint" */;
-			productName = "plugin:SwiftLintBuildToolPlugin";
-		};
-/* End XCSwiftPackageProductDependency section */
 
 /* Begin XCBuildConfiguration section */
 		0095EA3D0E3FC18B545418BE /* Debug */ = {
@@ -211,7 +183,11 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.opfic.DevLog.DevLogCore;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -289,7 +265,11 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.opfic.DevLog.DevLogCore;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -385,6 +365,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		C0DEAA000000000000000002 /* XCRemoteSwiftPackageReference "SwiftLint" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/realm/SwiftLint";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.62.1;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		C0DEAA000000000000000003 /* SwiftLintBuildToolPlugin */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C0DEAA000000000000000002 /* XCRemoteSwiftPackageReference "SwiftLint" */;
+			productName = "plugin:SwiftLintBuildToolPlugin";
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 3CF16EA616D3B65329E78465 /* Project object */;
 }

--- a/Application/DevLogData/DevLogData.xcodeproj/project.pbxproj
+++ b/Application/DevLogData/DevLogData.xcodeproj/project.pbxproj
@@ -14,55 +14,6 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		0AB04633AFB4B3F0B9AC60DC /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 63198F8EBCD1DCBB407926F8 /* DevLogCore.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 5755BDB768C11CE0FDEA4828;
-			remoteInfo = DevLogCore;
-		};
-		1981B85192DAF367924DB34F /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = F7FCB65CAFCBF2BF1791B45B /* DevLogDomain.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 7D1E74925088998D68BBFBBB;
-			remoteInfo = DevLogDomain;
-		};
-		1AEE6078E99E8794FC5D9C1A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = F7FCB65CAFCBF2BF1791B45B /* DevLogDomain.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 7D1E74925088998D68BBFBBB;
-			remoteInfo = DevLogDomain;
-		};
-		2DF60F9020F11CA533852162 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 63198F8EBCD1DCBB407926F8 /* DevLogCore.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 9E9FD7B09D0D7EAB8B828A5E;
-			remoteInfo = Subproject;
-		};
-		345F8284E22699C65B7FF89B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = F7FCB65CAFCBF2BF1791B45B /* DevLogDomain.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 7D1E74925088998D68BBFBBB;
-			remoteInfo = DevLogDomain;
-		};
-		6E927734EC01B34C7A7B01C2 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = F7FCB65CAFCBF2BF1791B45B /* DevLogDomain.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 3F08F6B94839E9021FCFC466;
-			remoteInfo = Subproject;
-		};
-		C7F303494B4D15C44C82AF32 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = F7FCB65CAFCBF2BF1791B45B /* DevLogDomain.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 7D1E74925088998D68BBFBBB;
-			remoteInfo = DevLogDomain;
-		};
 		47BD70322E2E4BCB864A30D6 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = CC7EBB5B45CD6E34221B84D0 /* Project object */;
@@ -75,9 +26,9 @@
 /* Begin PBXFileReference section */
 		4AB6E00A38C37CDBF82B57FD /* DevLogData.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = DevLogData.framework; path = DevLogData.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F0A3B72D714B42CDB4E3E905 /* DevLogDataTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DevLogDataTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		63198F8EBCD1DCBB407926F8 /* DevLogCore.xcodeproj */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "wrapper.pb-project"; name = DevLogCore.xcodeproj; path = ../DevLogCore/DevLogCore.xcodeproj; sourceTree = "<group>"; };
 		DD765636013B36A3BCCCF8B7 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		F7FCB65CAFCBF2BF1791B45B /* DevLogDomain.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = DevLogDomain.xcodeproj; path = ../DevLogDomain/DevLogDomain.xcodeproj; sourceTree = "<group>"; };
+		2039D0A2EB1ADD163DFC253D /* DevLogDomain.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DevLogDomain.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		3AECA90DBE02246762CB1ED1 /* DevLogCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DevLogCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -149,15 +100,6 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		42F9CB6B105B33619467DE78 /* Projects */ = {
-			isa = PBXGroup;
-			children = (
-				F7FCB65CAFCBF2BF1791B45B /* DevLogDomain.xcodeproj */,
-				63198F8EBCD1DCBB407926F8 /* DevLogCore.xcodeproj */,
-			);
-			name = Projects;
-			sourceTree = "<group>";
-		};
 		5A15B28E791BA16F53BAF94E /* Sources */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
@@ -180,7 +122,6 @@
 				5A15B28E791BA16F53BAF94E /* Sources */,
 				5A15B28E791BA16F53BAF950 /* Tests */,
 				3957A84DA44597517DA50BD3 /* Frameworks */,
-				42F9CB6B105B33619467DE78 /* Projects */,
 				27CDFCFF9F1093391B8566A1 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -211,8 +152,6 @@
 			);
 			dependencies = (
 				DA7AAA000000000000000001 /* PBXTargetDependency */,
-				C2D9D7E526019AEF507D8EFD /* PBXTargetDependency */,
-				EAD8C47A731CEFD89B8D06EF /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				5A15B28E791BA16F53BAF94E /* Sources */,
@@ -275,16 +214,6 @@
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 27CDFCFF9F1093391B8566A1 /* Products */;
 			projectDirPath = "";
-			projectReferences = (
-				{
-					ProductGroup = 27CDFCFF9F1093391B8566A1 /* Products */;
-					ProjectRef = F7FCB65CAFCBF2BF1791B45B /* DevLogDomain.xcodeproj */;
-				},
-				{
-					ProductGroup = 27CDFCFF9F1093391B8566A1 /* Products */;
-					ProjectRef = 63198F8EBCD1DCBB407926F8 /* DevLogCore.xcodeproj */;
-				},
-			);
 			projectRoot = "";
 			targets = (
 				D9D76C33D8B4790694BD3488 /* DevLogData */,
@@ -293,22 +222,6 @@
 		};
 /* End PBXProject section */
 
-/* Begin PBXReferenceProxy section */
-		2039D0A2EB1ADD163DFC253D /* DevLogDomain.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = DevLogDomain.framework;
-			remoteRef = 6E927734EC01B34C7A7B01C2 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		3AECA90DBE02246762CB1ED1 /* DevLogCore.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = DevLogCore.framework;
-			remoteRef = 2DF60F9020F11CA533852162 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-/* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
 		73B3ACF5A02F5A91A7C72F92 /* Resources */ = {
@@ -352,16 +265,6 @@
 		DA7AAA000000000000000004 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			productRef = DA7AAA000000000000000003 /* plugin:SwiftLintBuildToolPlugin */;
-		};
-		C2D9D7E526019AEF507D8EFD /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = DevLogDomain;
-			targetProxy = 1981B85192DAF367924DB34F /* PBXContainerItemProxy */;
-		};
-		EAD8C47A731CEFD89B8D06EF /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = DevLogCore;
-			targetProxy = 0AB04633AFB4B3F0B9AC60DC /* PBXContainerItemProxy */;
 		};
 		59B3918E35454521A69DAA14 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/Application/DevLogData/DevLogData.xcodeproj/project.pbxproj
+++ b/Application/DevLogData/DevLogData.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 77;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -24,22 +24,22 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		4AB6E00A38C37CDBF82B57FD /* DevLogData.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = DevLogData.framework; path = DevLogData.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		F0A3B72D714B42CDB4E3E905 /* DevLogDataTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DevLogDataTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		DD765636013B36A3BCCCF8B7 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		2039D0A2EB1ADD163DFC253D /* DevLogDomain.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DevLogDomain.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3AECA90DBE02246762CB1ED1 /* DevLogCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DevLogCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		4AB6E00A38C37CDBF82B57FD /* DevLogData.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DevLogData.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		DD765636013B36A3BCCCF8B7 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		F0A3B72D714B42CDB4E3E905 /* DevLogDataTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DevLogDataTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
-		5A15B28E791BA16F53BAF94F /* Exceptions for "Sources" folder in "DevLogData" target */ = {
+		5A15B28E791BA16F53BAF94F /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				.swiftlint.yml,
 			);
 			target = D9D76C33D8B4790694BD3488 /* DevLogData */;
 		};
-		5A15B28E791BA16F53BAF951 /* Exceptions for "Tests" folder in "DevLogDataTests" target */ = {
+		5A15B28E791BA16F53BAF951 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				.swiftlint.yml,
@@ -49,14 +49,8 @@
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		5A15B28E791BA16F53BAF950 /* Tests */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-				5A15B28E791BA16F53BAF951 /* Exceptions for "Tests" folder in "DevLogDataTests" target */,
-			);
-			path = Tests;
-			sourceTree = "<group>";
-		};
+		5A15B28E791BA16F53BAF94E /* Sources */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (5A15B28E791BA16F53BAF94F /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = Sources; sourceTree = "<group>"; };
+		5A15B28E791BA16F53BAF950 /* Tests */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (5A15B28E791BA16F53BAF951 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = Tests; sourceTree = "<group>"; };
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -100,14 +94,6 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		5A15B28E791BA16F53BAF94E /* Sources */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-				5A15B28E791BA16F53BAF94F /* Exceptions for "Sources" folder in "DevLogData" target */,
-			);
-			path = Sources;
-			sourceTree = "<group>";
-		};
 		8800BDCE685EF17A4BCB28C8 /* iOS */ = {
 			isa = PBXGroup;
 			children = (
@@ -139,28 +125,6 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
-		D9D76C33D8B4790694BD3488 /* DevLogData */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 64EB1E90241FDB4FE019B42A /* Build configuration list for PBXNativeTarget "DevLogData" */;
-			buildPhases = (
-				FEB154AC88AD6EBCF8E8763D /* Headers */,
-				2674AC03A9187931B580AAEE /* Sources */,
-				DC3B63D4A3808A9CE20EE7CD /* Frameworks */,
-				73B3ACF5A02F5A91A7C72F92 /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				DA7AAA000000000000000001 /* PBXTargetDependency */,
-			);
-			fileSystemSynchronizedGroups = (
-				5A15B28E791BA16F53BAF94E /* Sources */,
-			);
-			name = DevLogData;
-			productName = DevLogData;
-			productReference = 4AB6E00A38C37CDBF82B57FD /* DevLogData.framework */;
-			productType = "com.apple.product-type.framework";
-		};
 		8D39D659A2924AA7AE52714A /* DevLogDataTests */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 8EDB2AA4ACB9422EB4F5522A /* Build configuration list for PBXNativeTarget "DevLogDataTests" */;
@@ -182,6 +146,28 @@
 			productName = DevLogDataTests;
 			productReference = F0A3B72D714B42CDB4E3E905 /* DevLogDataTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		D9D76C33D8B4790694BD3488 /* DevLogData */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 64EB1E90241FDB4FE019B42A /* Build configuration list for PBXNativeTarget "DevLogData" */;
+			buildPhases = (
+				FEB154AC88AD6EBCF8E8763D /* Headers */,
+				2674AC03A9187931B580AAEE /* Sources */,
+				DC3B63D4A3808A9CE20EE7CD /* Frameworks */,
+				73B3ACF5A02F5A91A7C72F92 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				DA7AAA000000000000000001 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				5A15B28E791BA16F53BAF94E /* Sources */,
+			);
+			name = DevLogData;
+			productName = DevLogData;
+			productReference = 4AB6E00A38C37CDBF82B57FD /* DevLogData.framework */;
+			productType = "com.apple.product-type.framework";
 		};
 /* End PBXNativeTarget section */
 
@@ -207,11 +193,9 @@
 				Base,
 			);
 			mainGroup = FEAA5F036FEFF5A2BF2FD218;
-			minimizedProjectReferenceProxies = 0;
 			packageReferences = (
 				DA7AAA000000000000000002 /* XCRemoteSwiftPackageReference "SwiftLint" */,
 			);
-			preferredProjectObjectVersion = 77;
 			productRefGroup = 27CDFCFF9F1093391B8566A1 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -222,16 +206,15 @@
 		};
 /* End PBXProject section */
 
-
 /* Begin PBXResourcesBuildPhase section */
-		73B3ACF5A02F5A91A7C72F92 /* Resources */ = {
+		32B3E443D8A04E5AAA101FCA /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		32B3E443D8A04E5AAA101FCA /* Resources */ = {
+		73B3ACF5A02F5A91A7C72F92 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -258,41 +241,41 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		DA7AAA000000000000000001 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			productRef = DA7AAA000000000000000003 /* plugin:SwiftLintBuildToolPlugin */;
-		};
-		DA7AAA000000000000000004 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			productRef = DA7AAA000000000000000003 /* plugin:SwiftLintBuildToolPlugin */;
-		};
 		59B3918E35454521A69DAA14 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = D9D76C33D8B4790694BD3488 /* DevLogData */;
 			targetProxy = 47BD70322E2E4BCB864A30D6 /* PBXContainerItemProxy */;
 		};
+		DA7AAA000000000000000001 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			productRef = DA7AAA000000000000000003 /* SwiftLintBuildToolPlugin */;
+		};
+		DA7AAA000000000000000004 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			productRef = DA7AAA000000000000000003 /* SwiftLintBuildToolPlugin */;
+		};
 /* End PBXTargetDependency section */
 
-/* Begin XCRemoteSwiftPackageReference section */
-		DA7AAA000000000000000002 /* XCRemoteSwiftPackageReference "SwiftLint" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/realm/SwiftLint";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.62.1;
-			};
-		};
-/* End XCRemoteSwiftPackageReference section */
-
-/* Begin XCSwiftPackageProductDependency section */
-		DA7AAA000000000000000003 /* plugin:SwiftLintBuildToolPlugin */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = DA7AAA000000000000000002 /* XCRemoteSwiftPackageReference "SwiftLint" */;
-			productName = "plugin:SwiftLintBuildToolPlugin";
-		};
-/* End XCSwiftPackageProductDependency section */
-
 /* Begin XCBuildConfiguration section */
+		05D167FC8BE0483DAA2BBD7D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.opfic.DevLog.DevLogDataTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = DevLogData;
+			};
+			name = Debug;
+		};
 		1E63E77475382EF159DBD932 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -305,7 +288,11 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.opfic.DevLog.DevLogData;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -444,7 +431,11 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.opfic.DevLog.DevLogData;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -457,27 +448,16 @@
 			};
 			name = Release;
 		};
-		05D167FC8BE0483DAA2BBD7D /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.opfic.DevLog.DevLogDataTests;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_TARGET_NAME = DevLogData;
-			};
-			name = Debug;
-		};
 		FB689A1988E54A218A8365C7 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.opfic.DevLog.DevLogDataTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -518,6 +498,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		DA7AAA000000000000000002 /* XCRemoteSwiftPackageReference "SwiftLint" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/realm/SwiftLint";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.62.1;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		DA7AAA000000000000000003 /* SwiftLintBuildToolPlugin */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = DA7AAA000000000000000002 /* XCRemoteSwiftPackageReference "SwiftLint" */;
+			productName = "plugin:SwiftLintBuildToolPlugin";
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = CC7EBB5B45CD6E34221B84D0 /* Project object */;
 }

--- a/Application/DevLogDomain/DevLogDomain.xcodeproj/project.pbxproj
+++ b/Application/DevLogDomain/DevLogDomain.xcodeproj/project.pbxproj
@@ -3,13 +3,13 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 77;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4FC02B8BD98D4A888C4B9DAA /* DevLogDomain.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3F08F6B94839E9021FCFC466 /* DevLogDomain.framework */; };
 		5044FDD5ED149194C21F45DD /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CCF9FBE3E5B1E3AF0A65F342 /* Foundation.framework */; };
 		7179FD5B4EBF8C744819A8DE /* DevLogCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1A255290C54315FBBFEE3D5C /* DevLogCore.framework */; };
-		4FC02B8BD98D4A888C4B9DAA /* DevLogDomain.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3F08F6B94839E9021FCFC466 /* DevLogDomain.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -23,22 +23,21 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		1A255290C54315FBBFEE3D5C /* DevLogCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DevLogCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3F08F6B94839E9021FCFC466 /* DevLogDomain.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DevLogDomain.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8FA48D71FB864FBFB25626BE /* DevLogDomainTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DevLogDomainTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		CCF9FBE3E5B1E3AF0A65F342 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		1A255290C54315FBBFEE3D5C /* DevLogCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DevLogCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		DF4F66BF2FB6F8F900ED4BA9 /* DevLogCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DevLogCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
-		534E4B81FFFA3D0023139ACF /* Exceptions for "Sources" folder in "DevLogDomain" target */ = {
+		534E4B81FFFA3D0023139ACF /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				.swiftlint.yml,
 			);
 			target = 7D1E74925088998D68BBFBBB /* DevLogDomain */;
 		};
-		534E4B81FFFA3D0023139AD1 /* Exceptions for "Tests" folder in "DevLogDomainTests" target */ = {
+		534E4B81FFFA3D0023139AD1 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				.swiftlint.yml,
@@ -48,14 +47,8 @@
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		534E4B81FFFA3D0023139AD0 /* Tests */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-				534E4B81FFFA3D0023139AD1 /* Exceptions for "Tests" folder in "DevLogDomainTests" target */,
-			);
-			path = Tests;
-			sourceTree = "<group>";
-		};
+		534E4B81FFFA3D0023139ACE /* Sources */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (534E4B81FFFA3D0023139ACF /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = Sources; sourceTree = "<group>"; };
+		534E4B81FFFA3D0023139AD0 /* Tests */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (534E4B81FFFA3D0023139AD1 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = Tests; sourceTree = "<group>"; };
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -87,14 +80,6 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		534E4B81FFFA3D0023139ACE /* Sources */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-				534E4B81FFFA3D0023139ACF /* Exceptions for "Sources" folder in "DevLogDomain" target */,
-			);
-			path = Sources;
-			sourceTree = "<group>";
-		};
 		63B68BC59AF32C52B6CBF85B = {
 			isa = PBXGroup;
 			children = (
@@ -119,14 +104,6 @@
 				3F08F6B94839E9021FCFC466 /* DevLogDomain.framework */,
 				8FA48D71FB864FBFB25626BE /* DevLogDomainTests.xctest */,
 				1A255290C54315FBBFEE3D5C /* DevLogCore.framework */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		DF4F66BB2FB6F8F800ED4BA9 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				DF4F66BF2FB6F8F900ED4BA9 /* DevLogCore.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -225,7 +202,6 @@
 		};
 /* End PBXProject section */
 
-
 /* Begin PBXResourcesBuildPhase section */
 		0A4716162D54F03993DEF290 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
@@ -244,14 +220,14 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		1B05160EC8564CFF74EEA733 /* Sources */ = {
+		0D62B34AFC764A4CBA1F117E /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		0D62B34AFC764A4CBA1F117E /* Sources */ = {
+		1B05160EC8564CFF74EEA733 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -263,11 +239,11 @@
 /* Begin PBXTargetDependency section */
 		D011AA000000000000000001 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			productRef = D011AA000000000000000003 /* plugin:SwiftLintBuildToolPlugin */;
+			productRef = D011AA000000000000000003 /* SwiftLintBuildToolPlugin */;
 		};
 		D011AA000000000000000004 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			productRef = D011AA000000000000000003 /* plugin:SwiftLintBuildToolPlugin */;
+			productRef = D011AA000000000000000003 /* SwiftLintBuildToolPlugin */;
 		};
 		F8E77F4F6B984FA18618FEAF /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -275,25 +251,6 @@
 			targetProxy = 0B3A8BCEA8F240E7A0287892 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
-
-/* Begin XCRemoteSwiftPackageReference section */
-		D011AA000000000000000002 /* XCRemoteSwiftPackageReference "SwiftLint" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/realm/SwiftLint";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.62.1;
-			};
-		};
-/* End XCRemoteSwiftPackageReference section */
-
-/* Begin XCSwiftPackageProductDependency section */
-		D011AA000000000000000003 /* plugin:SwiftLintBuildToolPlugin */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = D011AA000000000000000002 /* XCRemoteSwiftPackageReference "SwiftLint" */;
-			productName = "plugin:SwiftLintBuildToolPlugin";
-		};
-/* End XCSwiftPackageProductDependency section */
 
 /* Begin XCBuildConfiguration section */
 		3A4C7479653B809907982EE0 /* Debug */ = {
@@ -354,6 +311,25 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		86C9C00D3F064DB3BBCA4D13 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.opfic.DevLog.DevLogDomainTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = DevLogDomain;
 			};
 			name = Debug;
 		};
@@ -422,7 +398,11 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.opfic.DevLog.DevLogDomain;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -433,6 +413,25 @@
 				VERSION_INFO_PREFIX = "";
 			};
 			name = Debug;
+		};
+		DD016DD24E1D491080C4E490 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.opfic.DevLog.DevLogDomainTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = DevLogDomain;
+			};
+			name = Release;
 		};
 		F0EB74E2AA0977D6CB2E3A56 /* Release */ = {
 			isa = XCBuildConfiguration;
@@ -446,7 +445,11 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.opfic.DevLog.DevLogDomain;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -456,36 +459,6 @@
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-		86C9C00D3F064DB3BBCA4D13 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.opfic.DevLog.DevLogDomainTests;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_TARGET_NAME = DevLogDomain;
-			};
-			name = Debug;
-		};
-		DD016DD24E1D491080C4E490 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.opfic.DevLog.DevLogDomainTests;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_TARGET_NAME = DevLogDomain;
 			};
 			name = Release;
 		};
@@ -501,15 +474,6 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		A1CC6382BF27FF25C0A22374 /* Build configuration list for PBXNativeTarget "DevLogDomain" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				F0EB74E2AA0977D6CB2E3A56 /* Release */,
-				CE7099C63D3B75B186422932 /* Debug */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
 		A09236D14D844CFD80483854 /* Build configuration list for PBXNativeTarget "DevLogDomainTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -519,7 +483,35 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		A1CC6382BF27FF25C0A22374 /* Build configuration list for PBXNativeTarget "DevLogDomain" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F0EB74E2AA0977D6CB2E3A56 /* Release */,
+				CE7099C63D3B75B186422932 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		D011AA000000000000000002 /* XCRemoteSwiftPackageReference "SwiftLint" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/realm/SwiftLint";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.62.1;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		D011AA000000000000000003 /* SwiftLintBuildToolPlugin */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = D011AA000000000000000002 /* XCRemoteSwiftPackageReference "SwiftLint" */;
+			productName = "plugin:SwiftLintBuildToolPlugin";
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 3D911168F99784261C777CF5 /* Project object */;
 }

--- a/Application/DevLogDomain/DevLogDomain.xcodeproj/project.pbxproj
+++ b/Application/DevLogDomain/DevLogDomain.xcodeproj/project.pbxproj
@@ -13,20 +13,6 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		382F8B0169E4B5594A5A0CB5 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 984FA2FF512E3A17EC214CAD /* DevLogCore.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 9E9FD7B09D0D7EAB8B828A5E;
-			remoteInfo = Subproject;
-		};
-		3FA49F27369B1E23BB63D104 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 984FA2FF512E3A17EC214CAD /* DevLogCore.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 5755BDB768C11CE0FDEA4828;
-			remoteInfo = DevLogCore;
-		};
 		0B3A8BCEA8F240E7A0287892 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 3D911168F99784261C777CF5 /* Project object */;
@@ -34,20 +20,14 @@
 			remoteGlobalIDString = 7D1E74925088998D68BBFBBB;
 			remoteInfo = DevLogDomain;
 		};
-		DF4F66BE2FB6F8F900ED4BA9 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 984FA2FF512E3A17EC214CAD /* DevLogCore.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 9E9FD7B09D0D7EAB8B828A5E;
-			remoteInfo = DevLogCore;
-		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		3F08F6B94839E9021FCFC466 /* DevLogDomain.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DevLogDomain.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8FA48D71FB864FBFB25626BE /* DevLogDomainTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DevLogDomainTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		984FA2FF512E3A17EC214CAD /* DevLogCore.xcodeproj */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "wrapper.pb-project"; name = DevLogCore.xcodeproj; path = ../DevLogCore/DevLogCore.xcodeproj; sourceTree = "<group>"; };
 		CCF9FBE3E5B1E3AF0A65F342 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		1A255290C54315FBBFEE3D5C /* DevLogCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DevLogCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		DF4F66BF2FB6F8F900ED4BA9 /* DevLogCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DevLogCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -121,17 +101,8 @@
 				534E4B81FFFA3D0023139ACE /* Sources */,
 				534E4B81FFFA3D0023139AD0 /* Tests */,
 				40116A7CE17130969F51069D /* Frameworks */,
-				88BF7FD280466FBA9905EAF1 /* Projects */,
 				B4BFBC14E31354BAE25BA2A4 /* Products */,
 			);
-			sourceTree = "<group>";
-		};
-		88BF7FD280466FBA9905EAF1 /* Projects */ = {
-			isa = PBXGroup;
-			children = (
-				984FA2FF512E3A17EC214CAD /* DevLogCore.xcodeproj */,
-			);
-			name = Projects;
 			sourceTree = "<group>";
 		};
 		8FA83A83534627957C480771 /* iOS */ = {
@@ -186,7 +157,6 @@
 			);
 			dependencies = (
 				D011AA000000000000000001 /* PBXTargetDependency */,
-				C87AAAC2357E4D2820F6470A /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				534E4B81FFFA3D0023139ACE /* Sources */,
@@ -247,12 +217,6 @@
 			);
 			productRefGroup = B4BFBC14E31354BAE25BA2A4 /* Products */;
 			projectDirPath = "";
-			projectReferences = (
-				{
-					ProductGroup = DF4F66BB2FB6F8F800ED4BA9 /* Products */;
-					ProjectRef = 984FA2FF512E3A17EC214CAD /* DevLogCore.xcodeproj */;
-				},
-			);
 			projectRoot = "";
 			targets = (
 				7D1E74925088998D68BBFBBB /* DevLogDomain */,
@@ -261,22 +225,6 @@
 		};
 /* End PBXProject section */
 
-/* Begin PBXReferenceProxy section */
-		1A255290C54315FBBFEE3D5C /* DevLogCore.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = DevLogCore.framework;
-			remoteRef = 382F8B0169E4B5594A5A0CB5 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		DF4F66BF2FB6F8F900ED4BA9 /* DevLogCore.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = DevLogCore.framework;
-			remoteRef = DF4F66BE2FB6F8F900ED4BA9 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-/* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
 		0A4716162D54F03993DEF290 /* Resources */ = {
@@ -320,11 +268,6 @@
 		D011AA000000000000000004 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			productRef = D011AA000000000000000003 /* plugin:SwiftLintBuildToolPlugin */;
-		};
-		C87AAAC2357E4D2820F6470A /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = DevLogCore;
-			targetProxy = 3FA49F27369B1E23BB63D104 /* PBXContainerItemProxy */;
 		};
 		F8E77F4F6B984FA18618FEAF /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/Application/DevLogInfra/DevLogInfra.xcodeproj/project.pbxproj
+++ b/Application/DevLogInfra/DevLogInfra.xcodeproj/project.pbxproj
@@ -3,19 +3,19 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 77;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3CE81EA6CD7444739AC73633 /* DevLogInfra.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 592C8B7B099933759AB316A5 /* DevLogInfra.framework */; };
+		5F7A14F2C5294547884212E1 /* FirebaseCore in Frameworks */ = {isa = PBXBuildFile; productRef = 06ADD17826F44543B09286DA /* FirebaseCore */; };
 		65623F19F34A9A75BC72EE36 /* FirebaseFirestore in Frameworks */ = {isa = PBXBuildFile; productRef = CE8F32B22E13743B3FF3B66B /* FirebaseFirestore */; };
 		B11111111111111111111111 /* DevLogCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B55555555555555555555555 /* DevLogCore.framework */; };
+		E06504AD71E9A40ACCA85ABB /* DevLogDomain.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 05A93F27C7172C85CD7252AA /* DevLogDomain.framework */; };
 		E747320CAD03A579976E87F8 /* FirebaseFunctions in Frameworks */ = {isa = PBXBuildFile; productRef = 172AF9DE3BC54E9E0B4EFD19 /* FirebaseFunctions */; };
 		EE62AAD289D9CED31CC9E05D /* GoogleSignIn in Frameworks */ = {isa = PBXBuildFile; productRef = 7333E70E9D312E56D4A364A6 /* GoogleSignIn */; };
 		F085DED20E80F63AE071D8BA /* DevLogData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A4F874032FD57C0BBCC41C64 /* DevLogData.framework */; };
-		E06504AD71E9A40ACCA85ABB /* DevLogDomain.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 05A93F27C7172C85CD7252AA /* DevLogDomain.framework */; };
 		F75AA9259C6636CF733C4D82 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7CC9FAB56498FA5BAEAC59A6 /* Foundation.framework */; };
-		3CE81EA6CD7444739AC73633 /* DevLogInfra.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 592C8B7B099933759AB316A5 /* DevLogInfra.framework */; };
-		5F7A14F2C5294547884212E1 /* FirebaseCore in Frameworks */ = {isa = PBXBuildFile; productRef = 06ADD17826F44543B09286DA /* FirebaseCore */; };
 		FB5186BC5A89B7DADAB8A82A /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 2AC59F98E5A6BFA339C3E5BD /* FirebaseAuth */; };
 		FB8043FF7043AFDA0E3F705B /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 94394E2197878DD50AF67628 /* FirebaseMessaging */; };
 		FEBF252AD70A910C914D3D22 /* Nexa in Frameworks */ = {isa = PBXBuildFile; productRef = EE91BC971B2F1FFEEDA3A3B8 /* Nexa */; };
@@ -32,23 +32,23 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		05A93F27C7172C85CD7252AA /* DevLogDomain.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DevLogDomain.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		592C8B7B099933759AB316A5 /* DevLogInfra.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DevLogInfra.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		AD628A91CC6D40B29D89DEA3 /* DevLogInfraTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DevLogInfraTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		7CC9FAB56498FA5BAEAC59A6 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		A4F874032FD57C0BBCC41C64 /* DevLogData.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DevLogData.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		05A93F27C7172C85CD7252AA /* DevLogDomain.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DevLogDomain.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		AD628A91CC6D40B29D89DEA3 /* DevLogInfraTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DevLogInfraTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B55555555555555555555555 /* DevLogCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DevLogCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
-		959D79D1263CC74E32B40D79 /* Exceptions for "Sources" folder in "DevLogInfra" target */ = {
+		959D79D1263CC74E32B40D79 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				.swiftlint.yml,
 			);
 			target = CB9B628AE2E0684C1FCF8840 /* DevLogInfra */;
 		};
-		959D79D1263CC74E32B40D7B /* Exceptions for "Tests" folder in "DevLogInfraTests" target */ = {
+		959D79D1263CC74E32B40D7B /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				.swiftlint.yml,
@@ -58,17 +58,19 @@
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		959D79D1263CC74E32B40D7A /* Tests */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-				959D79D1263CC74E32B40D7B /* Exceptions for "Tests" folder in "DevLogInfraTests" target */,
-			);
-			path = Tests;
-			sourceTree = "<group>";
-		};
+		959D79D1263CC74E32B40D78 /* Sources */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (959D79D1263CC74E32B40D79 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = Sources; sourceTree = "<group>"; };
+		959D79D1263CC74E32B40D7A /* Tests */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (959D79D1263CC74E32B40D7B /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = Tests; sourceTree = "<group>"; };
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		AA4F133C2BE849A5A33F3499 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3CE81EA6CD7444739AC73633 /* DevLogInfra.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		D357D4FEA7FE7E547ABC10EF /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -84,14 +86,6 @@
 				F085DED20E80F63AE071D8BA /* DevLogData.framework in Frameworks */,
 				E06504AD71E9A40ACCA85ABB /* DevLogDomain.framework in Frameworks */,
 				B11111111111111111111111 /* DevLogCore.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		AA4F133C2BE849A5A33F3499 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				3CE81EA6CD7444739AC73633 /* DevLogInfra.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -128,14 +122,6 @@
 			name = iOS;
 			sourceTree = "<group>";
 		};
-		959D79D1263CC74E32B40D78 /* Sources */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-				959D79D1263CC74E32B40D79 /* Exceptions for "Sources" folder in "DevLogInfra" target */,
-			);
-			path = Sources;
-			sourceTree = "<group>";
-		};
 		FBD6499620DAC9E2F9216AD5 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -157,6 +143,28 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		38643C4F96B2449E85275475 /* DevLogInfraTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 66178A1F2D3D41EF921A2B31 /* Build configuration list for PBXNativeTarget "DevLogInfraTests" */;
+			buildPhases = (
+				70CD76339E5E4F7AA090CCB9 /* Sources */,
+				AA4F133C2BE849A5A33F3499 /* Frameworks */,
+				D5817DC8BA6F4C22B1F4D94B /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				1F4AAA000000000000000004 /* PBXTargetDependency */,
+				DD23C8A4110847EABDCAA271 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				959D79D1263CC74E32B40D7A /* Tests */,
+			);
+			name = DevLogInfraTests;
+			productName = DevLogInfraTests;
+			productReference = AD628A91CC6D40B29D89DEA3 /* DevLogInfraTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		CB9B628AE2E0684C1FCF8840 /* DevLogInfra */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 84235CDC6916AB01B475D550 /* Build configuration list for PBXNativeTarget "DevLogInfra" */;
@@ -188,28 +196,6 @@
 			productReference = 592C8B7B099933759AB316A5 /* DevLogInfra.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		38643C4F96B2449E85275475 /* DevLogInfraTests */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 66178A1F2D3D41EF921A2B31 /* Build configuration list for PBXNativeTarget "DevLogInfraTests" */;
-			buildPhases = (
-				70CD76339E5E4F7AA090CCB9 /* Sources */,
-				AA4F133C2BE849A5A33F3499 /* Frameworks */,
-				D5817DC8BA6F4C22B1F4D94B /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				1F4AAA000000000000000004 /* PBXTargetDependency */,
-				DD23C8A4110847EABDCAA271 /* PBXTargetDependency */,
-			);
-			fileSystemSynchronizedGroups = (
-				959D79D1263CC74E32B40D7A /* Tests */,
-			);
-			name = DevLogInfraTests;
-			productName = DevLogInfraTests;
-			productReference = AD628A91CC6D40B29D89DEA3 /* DevLogInfraTests.xctest */;
-			productType = "com.apple.product-type.bundle.unit-test";
-		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -234,14 +220,12 @@
 				Base,
 			);
 			mainGroup = 78591B5535D993B16F897C7C;
-			minimizedProjectReferenceProxies = 0;
 			packageReferences = (
 				6A88F5113FA6A29A059E7035 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 				7472E8F03A98CCC38B5332F2 /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */,
 				13CD939395C6B0EEB80B46F6 /* XCRemoteSwiftPackageReference "Nexa" */,
 				1F4AAA000000000000000002 /* XCRemoteSwiftPackageReference "SwiftLint" */,
 			);
-			preferredProjectObjectVersion = 77;
 			productRefGroup = 0488BFD2A2F470EEE29679F1 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -251,7 +235,6 @@
 			);
 		};
 /* End PBXProject section */
-
 
 /* Begin PBXResourcesBuildPhase section */
 		24A3D66AD03AA277EDDA0CC7 /* Resources */ = {
@@ -271,14 +254,14 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		FBFB77DC8BC559975D45BE7E /* Sources */ = {
+		70CD76339E5E4F7AA090CCB9 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		70CD76339E5E4F7AA090CCB9 /* Sources */ = {
+		FBFB77DC8BC559975D45BE7E /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -290,11 +273,11 @@
 /* Begin PBXTargetDependency section */
 		1F4AAA000000000000000001 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			productRef = 1F4AAA000000000000000003 /* plugin:SwiftLintBuildToolPlugin */;
+			productRef = 1F4AAA000000000000000003 /* SwiftLintBuildToolPlugin */;
 		};
 		1F4AAA000000000000000004 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			productRef = 1F4AAA000000000000000003 /* plugin:SwiftLintBuildToolPlugin */;
+			productRef = 1F4AAA000000000000000003 /* SwiftLintBuildToolPlugin */;
 		};
 		DD23C8A4110847EABDCAA271 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -304,6 +287,25 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		744098DF376F4E6B9A2736E4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.opfic.DevLog.DevLogInfraTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = DevLogInfra;
+			};
+			name = Release;
+		};
 		7569DA679CECDD9F8128BF95 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -316,7 +318,11 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.opfic.DevLog.DevLogInfra;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -328,6 +334,25 @@
 				VERSION_INFO_PREFIX = "";
 			};
 			name = Release;
+		};
+		7F06F2F8F58E4D2AA5A0891E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.opfic.DevLog.DevLogInfraTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = DevLogInfra;
+			};
+			name = Debug;
 		};
 		B1D42568726630BF33AC1CB9 /* Release */ = {
 			isa = XCBuildConfiguration;
@@ -395,7 +420,11 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.opfic.DevLog.DevLogInfra;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -468,39 +497,18 @@
 			};
 			name = Debug;
 		};
-		7F06F2F8F58E4D2AA5A0891E /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.opfic.DevLog.DevLogInfraTests;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_TARGET_NAME = DevLogInfra;
-			};
-			name = Debug;
-		};
-		744098DF376F4E6B9A2736E4 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.opfic.DevLog.DevLogInfraTests;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_TARGET_NAME = DevLogInfra;
-			};
-			name = Release;
-		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		66178A1F2D3D41EF921A2B31 /* Build configuration list for PBXNativeTarget "DevLogInfraTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				744098DF376F4E6B9A2736E4 /* Release */,
+				7F06F2F8F58E4D2AA5A0891E /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		84235CDC6916AB01B475D550 /* Build configuration list for PBXNativeTarget "DevLogInfra" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -519,15 +527,6 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		66178A1F2D3D41EF921A2B31 /* Build configuration list for PBXNativeTarget "DevLogInfraTests" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				744098DF376F4E6B9A2736E4 /* Release */,
-				7F06F2F8F58E4D2AA5A0891E /* Debug */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
@@ -537,6 +536,14 @@
 			requirement = {
 				kind = upToNextMajorVersion;
 				minimumVersion = 1.1.0;
+			};
+		};
+		1F4AAA000000000000000002 /* XCRemoteSwiftPackageReference "SwiftLint" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/realm/SwiftLint";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.62.1;
 			};
 		};
 		6A88F5113FA6A29A059E7035 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
@@ -555,31 +562,23 @@
 				minimumVersion = 9.0.0;
 			};
 		};
-		1F4AAA000000000000000002 /* XCRemoteSwiftPackageReference "SwiftLint" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/realm/SwiftLint";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.62.1;
-			};
-		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		1F4AAA000000000000000003 /* plugin:SwiftLintBuildToolPlugin */ = {
+		06ADD17826F44543B09286DA /* FirebaseCore */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 1F4AAA000000000000000002 /* XCRemoteSwiftPackageReference "SwiftLint" */;
-			productName = "plugin:SwiftLintBuildToolPlugin";
+			package = 6A88F5113FA6A29A059E7035 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseCore;
 		};
 		172AF9DE3BC54E9E0B4EFD19 /* FirebaseFunctions */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 6A88F5113FA6A29A059E7035 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
 			productName = FirebaseFunctions;
 		};
-		06ADD17826F44543B09286DA /* FirebaseCore */ = {
+		1F4AAA000000000000000003 /* SwiftLintBuildToolPlugin */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 6A88F5113FA6A29A059E7035 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
-			productName = FirebaseCore;
+			package = 1F4AAA000000000000000002 /* XCRemoteSwiftPackageReference "SwiftLint" */;
+			productName = "plugin:SwiftLintBuildToolPlugin";
 		};
 		2AC59F98E5A6BFA339C3E5BD /* FirebaseAuth */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Application/DevLogInfra/DevLogInfra.xcodeproj/project.pbxproj
+++ b/Application/DevLogInfra/DevLogInfra.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		E747320CAD03A579976E87F8 /* FirebaseFunctions in Frameworks */ = {isa = PBXBuildFile; productRef = 172AF9DE3BC54E9E0B4EFD19 /* FirebaseFunctions */; };
 		EE62AAD289D9CED31CC9E05D /* GoogleSignIn in Frameworks */ = {isa = PBXBuildFile; productRef = 7333E70E9D312E56D4A364A6 /* GoogleSignIn */; };
 		F085DED20E80F63AE071D8BA /* DevLogData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A4F874032FD57C0BBCC41C64 /* DevLogData.framework */; };
+		E06504AD71E9A40ACCA85ABB /* DevLogDomain.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 05A93F27C7172C85CD7252AA /* DevLogDomain.framework */; };
 		F75AA9259C6636CF733C4D82 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7CC9FAB56498FA5BAEAC59A6 /* Foundation.framework */; };
 		3CE81EA6CD7444739AC73633 /* DevLogInfra.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 592C8B7B099933759AB316A5 /* DevLogInfra.framework */; };
 		5F7A14F2C5294547884212E1 /* FirebaseCore in Frameworks */ = {isa = PBXBuildFile; productRef = 06ADD17826F44543B09286DA /* FirebaseCore */; };
@@ -21,34 +22,6 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		242875057F793AB5E271751C /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = DC20615F7FBF2DEEB480D826 /* DevLogData.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = D9D76C33D8B4790694BD3488;
-			remoteInfo = DevLogData;
-		};
-		B66666666666666666666666 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = B44444444444444444444444 /* DevLogCore.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 5755BDB768C11CE0FDEA4828;
-			remoteInfo = DevLogCore;
-		};
-		B77777777777777777777777 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = B44444444444444444444444 /* DevLogCore.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 9E9FD7B09D0D7EAB8B828A5E;
-			remoteInfo = Subproject;
-		};
-		92ED4507B81AC42C599EE7EE /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = DC20615F7FBF2DEEB480D826 /* DevLogData.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 4AB6E00A38C37CDBF82B57FD;
-			remoteInfo = Subproject;
-		};
 		66FBFAC873BD4CEDA5984DD4 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = FF22261AB99602DAB8E9B323 /* Project object */;
@@ -62,8 +35,9 @@
 		592C8B7B099933759AB316A5 /* DevLogInfra.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DevLogInfra.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		AD628A91CC6D40B29D89DEA3 /* DevLogInfraTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DevLogInfraTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		7CC9FAB56498FA5BAEAC59A6 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		B44444444444444444444444 /* DevLogCore.xcodeproj */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "wrapper.pb-project"; name = DevLogCore.xcodeproj; path = ../DevLogCore/DevLogCore.xcodeproj; sourceTree = "<group>"; };
-		DC20615F7FBF2DEEB480D826 /* DevLogData.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = DevLogData.xcodeproj; path = ../DevLogData/DevLogData.xcodeproj; sourceTree = "<group>"; };
+		A4F874032FD57C0BBCC41C64 /* DevLogData.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DevLogData.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		05A93F27C7172C85CD7252AA /* DevLogDomain.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DevLogDomain.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		B55555555555555555555555 /* DevLogCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DevLogCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -108,6 +82,7 @@
 				EE62AAD289D9CED31CC9E05D /* GoogleSignIn in Frameworks */,
 				FEBF252AD70A910C914D3D22 /* Nexa in Frameworks */,
 				F085DED20E80F63AE071D8BA /* DevLogData.framework in Frameworks */,
+				E06504AD71E9A40ACCA85ABB /* DevLogDomain.framework in Frameworks */,
 				B11111111111111111111111 /* DevLogCore.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -129,6 +104,7 @@
 				592C8B7B099933759AB316A5 /* DevLogInfra.framework */,
 				AD628A91CC6D40B29D89DEA3 /* DevLogInfraTests.xctest */,
 				A4F874032FD57C0BBCC41C64 /* DevLogData.framework */,
+				05A93F27C7172C85CD7252AA /* DevLogDomain.framework */,
 				B55555555555555555555555 /* DevLogCore.framework */,
 			);
 			name = Products;
@@ -140,7 +116,6 @@
 				959D79D1263CC74E32B40D78 /* Sources */,
 				959D79D1263CC74E32B40D7A /* Tests */,
 				FBD6499620DAC9E2F9216AD5 /* Frameworks */,
-				D47699189A73B8C6972C611A /* Projects */,
 				0488BFD2A2F470EEE29679F1 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -159,15 +134,6 @@
 				959D79D1263CC74E32B40D79 /* Exceptions for "Sources" folder in "DevLogInfra" target */,
 			);
 			path = Sources;
-			sourceTree = "<group>";
-		};
-		D47699189A73B8C6972C611A /* Projects */ = {
-			isa = PBXGroup;
-			children = (
-				DC20615F7FBF2DEEB480D826 /* DevLogData.xcodeproj */,
-				B44444444444444444444444 /* DevLogCore.xcodeproj */,
-			);
-			name = Projects;
 			sourceTree = "<group>";
 		};
 		FBD6499620DAC9E2F9216AD5 /* Frameworks */ = {
@@ -204,8 +170,6 @@
 			);
 			dependencies = (
 				1F4AAA000000000000000001 /* PBXTargetDependency */,
-				B62EE119F71162DAB0F9D034 /* PBXTargetDependency */,
-				B88888888888888888888888 /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				959D79D1263CC74E32B40D78 /* Sources */,
@@ -280,16 +244,6 @@
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 0488BFD2A2F470EEE29679F1 /* Products */;
 			projectDirPath = "";
-			projectReferences = (
-				{
-					ProductGroup = 0488BFD2A2F470EEE29679F1 /* Products */;
-					ProjectRef = DC20615F7FBF2DEEB480D826 /* DevLogData.xcodeproj */;
-				},
-				{
-					ProductGroup = 0488BFD2A2F470EEE29679F1 /* Products */;
-					ProjectRef = B44444444444444444444444 /* DevLogCore.xcodeproj */;
-				},
-			);
 			projectRoot = "";
 			targets = (
 				CB9B628AE2E0684C1FCF8840 /* DevLogInfra */,
@@ -298,22 +252,6 @@
 		};
 /* End PBXProject section */
 
-/* Begin PBXReferenceProxy section */
-		A4F874032FD57C0BBCC41C64 /* DevLogData.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = DevLogData.framework;
-			remoteRef = 92ED4507B81AC42C599EE7EE /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		B55555555555555555555555 /* DevLogCore.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = DevLogCore.framework;
-			remoteRef = B77777777777777777777777 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-/* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
 		24A3D66AD03AA277EDDA0CC7 /* Resources */ = {
@@ -357,16 +295,6 @@
 		1F4AAA000000000000000004 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			productRef = 1F4AAA000000000000000003 /* plugin:SwiftLintBuildToolPlugin */;
-		};
-		B62EE119F71162DAB0F9D034 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = DevLogData;
-			targetProxy = 242875057F793AB5E271751C /* PBXContainerItemProxy */;
-		};
-		B88888888888888888888888 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = DevLogCore;
-			targetProxy = B66666666666666666666666 /* PBXContainerItemProxy */;
 		};
 		DD23C8A4110847EABDCAA271 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/Application/DevLogPersistence/DevLogPersistence.xcodeproj/project.pbxproj
+++ b/Application/DevLogPersistence/DevLogPersistence.xcodeproj/project.pbxproj
@@ -36,7 +36,6 @@
 		86E8AA2A43914F444BF5A6C2 /* DevLogPersistence.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DevLogPersistence.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		98B16FCDA8A71E2E4E1DC05E /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		A55555555555555555555555 /* DevLogCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DevLogCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		DF02DF082FB8DCCD008C7784 /* tt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = tt.swift; sourceTree = "<group>"; };
 		F334BCFC52C730D5901F6051 /* DevLogDomain.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DevLogDomain.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -251,7 +250,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DF02DF092FB8DCCD008C7784 /* tt.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Application/DevLogPersistence/DevLogPersistence.xcodeproj/project.pbxproj
+++ b/Application/DevLogPersistence/DevLogPersistence.xcodeproj/project.pbxproj
@@ -3,20 +3,20 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 77;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXBuildFile section */
 		041CEED3822FCBD881DF75CD /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 98B16FCDA8A71E2E4E1DC05E /* Foundation.framework */; };
 		3B8FAEC025F373D4CFC262D4 /* DevLogData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 493A5D0B4274807F2B948AB3 /* DevLogData.framework */; };
+		4763564ECF9942DCB6A7D3D2 /* DevLogWidgetCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5FF5E1613F059A4B77931161 /* DevLogWidgetCore.framework */; };
+		4EE7A141A66C408EB8897D4A /* DevLogPersistence.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 86E8AA2A43914F444BF5A6C2 /* DevLogPersistence.framework */; };
+		5F89EB23199E4ABEA925CF92 /* DevLogData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 493A5D0B4274807F2B948AB3 /* DevLogData.framework */; };
 		7D8DE74BD24B456D42B04806 /* DevLogDomain.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F334BCFC52C730D5901F6051 /* DevLogDomain.framework */; };
 		8A95AB09613C4F54883A7A38 /* DevLogDomain.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F334BCFC52C730D5901F6051 /* DevLogDomain.framework */; };
 		A11111111111111111111111 /* DevLogCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A55555555555555555555555 /* DevLogCore.framework */; };
 		E53E13B73BFAF0C51013ECA2 /* DevLogWidgetCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5FF5E1613F059A4B77931161 /* DevLogWidgetCore.framework */; };
 		F47DBE7D3E7E49F08D4B5530 /* DevLogCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A55555555555555555555555 /* DevLogCore.framework */; };
-		4EE7A141A66C408EB8897D4A /* DevLogPersistence.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 86E8AA2A43914F444BF5A6C2 /* DevLogPersistence.framework */; };
-		5F89EB23199E4ABEA925CF92 /* DevLogData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 493A5D0B4274807F2B948AB3 /* DevLogData.framework */; };
-		4763564ECF9942DCB6A7D3D2 /* DevLogWidgetCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5FF5E1613F059A4B77931161 /* DevLogWidgetCore.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -30,24 +30,25 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		493A5D0B4274807F2B948AB3 /* DevLogData.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DevLogData.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		5FF5E1613F059A4B77931161 /* DevLogWidgetCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DevLogWidgetCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		62B066C5B0714BC3B5F4D9D0 /* DevLogPersistenceTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DevLogPersistenceTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		86E8AA2A43914F444BF5A6C2 /* DevLogPersistence.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DevLogPersistence.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		98B16FCDA8A71E2E4E1DC05E /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		493A5D0B4274807F2B948AB3 /* DevLogData.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DevLogData.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		5FF5E1613F059A4B77931161 /* DevLogWidgetCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DevLogWidgetCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A55555555555555555555555 /* DevLogCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DevLogCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		DF02DF082FB8DCCD008C7784 /* tt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = tt.swift; sourceTree = "<group>"; };
 		F334BCFC52C730D5901F6051 /* DevLogDomain.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DevLogDomain.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
-		63CE47D539EE6F9653C99774 /* Exceptions for "Sources" folder in "DevLogPersistence" target */ = {
+		63CE47D539EE6F9653C99774 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				.swiftlint.yml,
 			);
 			target = 0C205A501EF8E79FA9A73C4B /* DevLogPersistence */;
 		};
-		D5D04ADAA14A44289CF9A22F /* Exceptions for "Tests" folder in "DevLogPersistenceTests" target */ = {
+		D5D04ADAA14A44289CF9A22F /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				.swiftlint.yml,
@@ -56,19 +57,12 @@
 		};
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		63CE47D539EE6F9653C99773 /* Sources */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (63CE47D539EE6F9653C99774 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = Sources; sourceTree = "<group>"; };
+		D5D04ADAA14A44289CF9A22E /* Tests */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (D5D04ADAA14A44289CF9A22F /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = Tests; sourceTree = "<group>"; };
+/* End PBXFileSystemSynchronizedRootGroup section */
+
 /* Begin PBXFrameworksBuildPhase section */
-		66FC24A6C49BE85AEA4B9B02 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				041CEED3822FCBD881DF75CD /* Foundation.framework in Frameworks */,
-				7D8DE74BD24B456D42B04806 /* DevLogDomain.framework in Frameworks */,
-				E53E13B73BFAF0C51013ECA2 /* DevLogWidgetCore.framework in Frameworks */,
-				3B8FAEC025F373D4CFC262D4 /* DevLogData.framework in Frameworks */,
-				A11111111111111111111111 /* DevLogCore.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		292BB970C2B54490BD9BFCDA /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -78,6 +72,18 @@
 				8A95AB09613C4F54883A7A38 /* DevLogDomain.framework in Frameworks */,
 				5F89EB23199E4ABEA925CF92 /* DevLogData.framework in Frameworks */,
 				4763564ECF9942DCB6A7D3D2 /* DevLogWidgetCore.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		66FC24A6C49BE85AEA4B9B02 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				041CEED3822FCBD881DF75CD /* Foundation.framework in Frameworks */,
+				7D8DE74BD24B456D42B04806 /* DevLogDomain.framework in Frameworks */,
+				E53E13B73BFAF0C51013ECA2 /* DevLogWidgetCore.framework in Frameworks */,
+				3B8FAEC025F373D4CFC262D4 /* DevLogData.framework in Frameworks */,
+				A11111111111111111111111 /* DevLogCore.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -98,22 +104,6 @@
 				431FFAA2A9B7604E5BF94BF0 /* iOS */,
 			);
 			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		63CE47D539EE6F9653C99773 /* Sources */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-				63CE47D539EE6F9653C99774 /* Exceptions for "Sources" folder in "DevLogPersistence" target */,
-			);
-			path = Sources;
-			sourceTree = "<group>";
-		};
-		D5D04ADAA14A44289CF9A22E /* Tests */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-				D5D04ADAA14A44289CF9A22F /* Exceptions for "Tests" folder in "DevLogPersistenceTests" target */,
-			);
-			path = Tests;
 			sourceTree = "<group>";
 		};
 		9DC6ED43838A6F065422AA8B = {
@@ -219,11 +209,9 @@
 				Base,
 			);
 			mainGroup = 9DC6ED43838A6F065422AA8B;
-			minimizedProjectReferenceProxies = 0;
 			packageReferences = (
 				9E51AA000000000000000002 /* XCRemoteSwiftPackageReference "SwiftLint" */,
 			);
-			preferredProjectObjectVersion = 77;
 			productRefGroup = C96806E27CED4BE0CA95A9B0 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -234,16 +222,15 @@
 		};
 /* End PBXProject section */
 
-
 /* Begin PBXResourcesBuildPhase section */
-		E2A3D481BE3C181451082513 /* Resources */ = {
+		416DF367E7A248D7894F701 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		416DF367E7A248D7894F701 /* Resources */ = {
+		E2A3D481BE3C181451082513 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -253,13 +240,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		D4CC01793812ABB253D6AC08 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		21B6276975A04D6D8BDC646D /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -267,42 +247,31 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		D4CC01793812ABB253D6AC08 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DF02DF092FB8DCCD008C7784 /* tt.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		9E51AA000000000000000001 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			productRef = 9E51AA000000000000000003 /* plugin:SwiftLintBuildToolPlugin */;
-		};
-		9E51AA000000000000000004 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			productRef = 9E51AA000000000000000003 /* plugin:SwiftLintBuildToolPlugin */;
-		};
 		369778EAD3564AB68A495DA7 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 0C205A501EF8E79FA9A73C4B /* DevLogPersistence */;
 			targetProxy = E235680901FF45419002A175 /* PBXContainerItemProxy */;
 		};
+		9E51AA000000000000000001 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			productRef = 9E51AA000000000000000003 /* SwiftLintBuildToolPlugin */;
+		};
+		9E51AA000000000000000004 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			productRef = 9E51AA000000000000000003 /* SwiftLintBuildToolPlugin */;
+		};
 /* End PBXTargetDependency section */
-
-/* Begin XCRemoteSwiftPackageReference section */
-		9E51AA000000000000000002 /* XCRemoteSwiftPackageReference "SwiftLint" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/realm/SwiftLint";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.62.1;
-			};
-		};
-/* End XCRemoteSwiftPackageReference section */
-
-/* Begin XCSwiftPackageProductDependency section */
-		9E51AA000000000000000003 /* plugin:SwiftLintBuildToolPlugin */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 9E51AA000000000000000002 /* XCRemoteSwiftPackageReference "SwiftLint" */;
-			productName = "plugin:SwiftLintBuildToolPlugin";
-		};
-/* End XCSwiftPackageProductDependency section */
 
 /* Begin XCBuildConfiguration section */
 		3047117C7630A6B91F1477F5 /* Debug */ = {
@@ -366,6 +335,28 @@
 			};
 			name = Debug;
 		};
+		318C40EC8339400D9F44404E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.opfic.DevLog.DevLogPersistenceTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = DevLogPersistence;
+			};
+			name = Debug;
+		};
 		586E1D6B64BF31CC733055C9 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -378,7 +369,11 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.opfic.DevLog.DevLogPersistence;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -390,24 +385,6 @@
 				VERSION_INFO_PREFIX = "";
 			};
 			name = Release;
-		};
-		318C40EC8339400D9F44404E /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.opfic.DevLog.DevLogPersistenceTests;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_TARGET_NAME = DevLogPersistence;
-			};
-			name = Debug;
 		};
 		6618F205C9EAFE00EB519ADB /* Release */ = {
 			isa = XCBuildConfiguration;
@@ -470,7 +447,11 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.opfic.DevLog.DevLogPersistenceTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -494,7 +475,11 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.opfic.DevLog.DevLogPersistence;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -509,6 +494,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		5D9A9D653D4C471C82E467D2 /* Build configuration list for PBXNativeTarget "DevLogPersistenceTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				318C40EC8339400D9F44404E /* Debug */,
+				8B4A4E1F4687464C8C17B4AF /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		7977F26B747BC5BCE5E0A6B4 /* Build configuration list for PBXProject "DevLogPersistence" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -527,16 +521,26 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		5D9A9D653D4C471C82E467D2 /* Build configuration list for PBXNativeTarget "DevLogPersistenceTests" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				318C40EC8339400D9F44404E /* Debug */,
-				8B4A4E1F4687464C8C17B4AF /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		9E51AA000000000000000002 /* XCRemoteSwiftPackageReference "SwiftLint" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/realm/SwiftLint";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.62.1;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		9E51AA000000000000000003 /* SwiftLintBuildToolPlugin */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 9E51AA000000000000000002 /* XCRemoteSwiftPackageReference "SwiftLint" */;
+			productName = "plugin:SwiftLintBuildToolPlugin";
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = DF1E7E43C1BA2439E9B82492 /* Project object */;
 }

--- a/Application/DevLogPersistence/DevLogPersistence.xcodeproj/project.pbxproj
+++ b/Application/DevLogPersistence/DevLogPersistence.xcodeproj/project.pbxproj
@@ -20,55 +20,6 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		6556E45987F0D11205D84D04 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = AEA9DB8D523E749E611B96FA /* DevLogWidgetCore.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 687DD42230CC25053ABB5FB8;
-			remoteInfo = DevLogWidgetCore;
-		};
-		025989E371CE4BBE85B584D8 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 596DB8A398F4BCB331775AB9 /* DevLogDomain.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 7D1E74925088998D68BBFBBB;
-			remoteInfo = DevLogDomain;
-		};
-		415D6054D61540DB8BBFFB10 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 52A6964627E9E20D0D6A26B9 /* DevLogData.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = D9D76C33D8B4790694BD3488;
-			remoteInfo = DevLogData;
-		};
-		703C7152F23B4FDBBE0A6FD6 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = A44444444444444444444444 /* DevLogCore.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 5755BDB768C11CE0FDEA4828;
-			remoteInfo = DevLogCore;
-		};
-		A66666666666666666666666 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = A44444444444444444444444 /* DevLogCore.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 5755BDB768C11CE0FDEA4828;
-			remoteInfo = DevLogCore;
-		};
-		A77777777777777777777777 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = A44444444444444444444444 /* DevLogCore.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 9E9FD7B09D0D7EAB8B828A5E;
-			remoteInfo = Subproject;
-		};
-		7CD34B27DE3CD401A888D01C /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = AEA9DB8D523E749E611B96FA /* DevLogWidgetCore.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 6AF1B307A7E7CC03AA2BABB1;
-			remoteInfo = Subproject;
-		};
 		E235680901FF45419002A175 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = DF1E7E43C1BA2439E9B82492 /* Project object */;
@@ -76,51 +27,16 @@
 			remoteGlobalIDString = 0C205A501EF8E79FA9A73C4B;
 			remoteInfo = DevLogPersistence;
 		};
-		E797C92EB75C449E9AE5F53F /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = AEA9DB8D523E749E611B96FA /* DevLogWidgetCore.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 687DD42230CC25053ABB5FB8;
-			remoteInfo = DevLogWidgetCore;
-		};
-		B5FF9EF1399BA2E5A9D85D03 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 596DB8A398F4BCB331775AB9 /* DevLogDomain.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 3F08F6B94839E9021FCFC466;
-			remoteInfo = Subproject;
-		};
-		C118DECC34A0AE1E3085D4AB /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 596DB8A398F4BCB331775AB9 /* DevLogDomain.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 7D1E74925088998D68BBFBBB;
-			remoteInfo = DevLogDomain;
-		};
-		C3709692ED10C6BFC0F41348 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 52A6964627E9E20D0D6A26B9 /* DevLogData.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 4AB6E00A38C37CDBF82B57FD;
-			remoteInfo = Subproject;
-		};
-		D43AB7BB6E43AEF760FBB23C /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 52A6964627E9E20D0D6A26B9 /* DevLogData.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = D9D76C33D8B4790694BD3488;
-			remoteInfo = DevLogData;
-		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		52A6964627E9E20D0D6A26B9 /* DevLogData.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = DevLogData.xcodeproj; path = ../DevLogData/DevLogData.xcodeproj; sourceTree = "<group>"; };
-		596DB8A398F4BCB331775AB9 /* DevLogDomain.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = DevLogDomain.xcodeproj; path = ../DevLogDomain/DevLogDomain.xcodeproj; sourceTree = "<group>"; };
 		62B066C5B0714BC3B5F4D9D0 /* DevLogPersistenceTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DevLogPersistenceTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		86E8AA2A43914F444BF5A6C2 /* DevLogPersistence.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DevLogPersistence.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		98B16FCDA8A71E2E4E1DC05E /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		A44444444444444444444444 /* DevLogCore.xcodeproj */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "wrapper.pb-project"; name = DevLogCore.xcodeproj; path = ../DevLogCore/DevLogCore.xcodeproj; sourceTree = "<group>"; };
-		AEA9DB8D523E749E611B96FA /* DevLogWidgetCore.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = DevLogWidgetCore.xcodeproj; path = ../../Widget/DevLogWidgetCore/DevLogWidgetCore.xcodeproj; sourceTree = "<group>"; };
+		493A5D0B4274807F2B948AB3 /* DevLogData.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DevLogData.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		5FF5E1613F059A4B77931161 /* DevLogWidgetCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DevLogWidgetCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		A55555555555555555555555 /* DevLogCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DevLogCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		F334BCFC52C730D5901F6051 /* DevLogDomain.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DevLogDomain.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -206,20 +122,8 @@
 				63CE47D539EE6F9653C99773 /* Sources */,
 				D5D04ADAA14A44289CF9A22E /* Tests */,
 				49F17FD9095E72DC89748471 /* Frameworks */,
-				C005798DC28F77FF8B0E248A /* Projects */,
 				C96806E27CED4BE0CA95A9B0 /* Products */,
 			);
-			sourceTree = "<group>";
-		};
-		C005798DC28F77FF8B0E248A /* Projects */ = {
-			isa = PBXGroup;
-			children = (
-				596DB8A398F4BCB331775AB9 /* DevLogDomain.xcodeproj */,
-				52A6964627E9E20D0D6A26B9 /* DevLogData.xcodeproj */,
-				AEA9DB8D523E749E611B96FA /* DevLogWidgetCore.xcodeproj */,
-				A44444444444444444444444 /* DevLogCore.xcodeproj */,
-			);
-			name = Projects;
 			sourceTree = "<group>";
 		};
 		C96806E27CED4BE0CA95A9B0 /* Products */ = {
@@ -261,10 +165,6 @@
 			);
 			dependencies = (
 				9E51AA000000000000000001 /* PBXTargetDependency */,
-				083FDD9BBD997A11EED7ACA9 /* PBXTargetDependency */,
-				8C9EB60C8E58A67726AF0EF1 /* PBXTargetDependency */,
-				65214D4CBB998A4369598E01 /* PBXTargetDependency */,
-				A88888888888888888888888 /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				63CE47D539EE6F9653C99773 /* Sources */,
@@ -287,10 +187,6 @@
 			dependencies = (
 				9E51AA000000000000000004 /* PBXTargetDependency */,
 				369778EAD3564AB68A495DA7 /* PBXTargetDependency */,
-				91F9976158BA483A8B9BB434 /* PBXTargetDependency */,
-				E715970F49AF4988A793106D /* PBXTargetDependency */,
-				0ADC5DDD59EB427EB1B33FC4 /* PBXTargetDependency */,
-				49EA84B99E32462D8FFD9073 /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				D5D04ADAA14A44289CF9A22E /* Tests */,
@@ -330,24 +226,6 @@
 			preferredProjectObjectVersion = 77;
 			productRefGroup = C96806E27CED4BE0CA95A9B0 /* Products */;
 			projectDirPath = "";
-			projectReferences = (
-				{
-					ProductGroup = C96806E27CED4BE0CA95A9B0 /* Products */;
-					ProjectRef = 596DB8A398F4BCB331775AB9 /* DevLogDomain.xcodeproj */;
-				},
-				{
-					ProductGroup = C96806E27CED4BE0CA95A9B0 /* Products */;
-					ProjectRef = 52A6964627E9E20D0D6A26B9 /* DevLogData.xcodeproj */;
-				},
-				{
-					ProductGroup = C96806E27CED4BE0CA95A9B0 /* Products */;
-					ProjectRef = AEA9DB8D523E749E611B96FA /* DevLogWidgetCore.xcodeproj */;
-				},
-				{
-					ProductGroup = C96806E27CED4BE0CA95A9B0 /* Products */;
-					ProjectRef = A44444444444444444444444 /* DevLogCore.xcodeproj */;
-				},
-			);
 			projectRoot = "";
 			targets = (
 				0C205A501EF8E79FA9A73C4B /* DevLogPersistence */,
@@ -356,36 +234,6 @@
 		};
 /* End PBXProject section */
 
-/* Begin PBXReferenceProxy section */
-		493A5D0B4274807F2B948AB3 /* DevLogData.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = DevLogData.framework;
-			remoteRef = C3709692ED10C6BFC0F41348 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		5FF5E1613F059A4B77931161 /* DevLogWidgetCore.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = DevLogWidgetCore.framework;
-			remoteRef = 7CD34B27DE3CD401A888D01C /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		A55555555555555555555555 /* DevLogCore.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = DevLogCore.framework;
-			remoteRef = A77777777777777777777777 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		F334BCFC52C730D5901F6051 /* DevLogDomain.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = DevLogDomain.framework;
-			remoteRef = B5FF9EF1399BA2E5A9D85D03 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-/* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
 		E2A3D481BE3C181451082513 /* Resources */ = {
@@ -430,50 +278,10 @@
 			isa = PBXTargetDependency;
 			productRef = 9E51AA000000000000000003 /* plugin:SwiftLintBuildToolPlugin */;
 		};
-		083FDD9BBD997A11EED7ACA9 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = DevLogDomain;
-			targetProxy = C118DECC34A0AE1E3085D4AB /* PBXContainerItemProxy */;
-		};
-		0ADC5DDD59EB427EB1B33FC4 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = DevLogData;
-			targetProxy = 415D6054D61540DB8BBFFB10 /* PBXContainerItemProxy */;
-		};
 		369778EAD3564AB68A495DA7 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 0C205A501EF8E79FA9A73C4B /* DevLogPersistence */;
 			targetProxy = E235680901FF45419002A175 /* PBXContainerItemProxy */;
-		};
-		49EA84B99E32462D8FFD9073 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = DevLogWidgetCore;
-			targetProxy = E797C92EB75C449E9AE5F53F /* PBXContainerItemProxy */;
-		};
-		65214D4CBB998A4369598E01 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = DevLogData;
-			targetProxy = D43AB7BB6E43AEF760FBB23C /* PBXContainerItemProxy */;
-		};
-		91F9976158BA483A8B9BB434 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = DevLogCore;
-			targetProxy = 703C7152F23B4FDBBE0A6FD6 /* PBXContainerItemProxy */;
-		};
-		8C9EB60C8E58A67726AF0EF1 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = DevLogWidgetCore;
-			targetProxy = 6556E45987F0D11205D84D04 /* PBXContainerItemProxy */;
-		};
-		E715970F49AF4988A793106D /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = DevLogDomain;
-			targetProxy = 025989E371CE4BBE85B584D8 /* PBXContainerItemProxy */;
-		};
-		A88888888888888888888888 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = DevLogCore;
-			targetProxy = A66666666666666666666666 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 

--- a/Application/DevLogPresentation/DevLogPresentation.xcodeproj/project.pbxproj
+++ b/Application/DevLogPresentation/DevLogPresentation.xcodeproj/project.pbxproj
@@ -8,7 +8,6 @@
 
 /* Begin PBXBuildFile section */
 		01D899033F573BBB31F1F1CB /* DevLogCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 045D0608DB7069603090D029 /* DevLogCore.framework */; };
-		0530C4A2CF7B413A831F5EA9 /* DevLogPresentation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5E7473315771B5D3030C5003 /* DevLogPresentation.framework */; };
 		1B8D0C5D8C506642FFB8F9FA /* OrderedCollections in Frameworks */ = {isa = PBXBuildFile; productRef = 7D6DDD31C1122286D5852621 /* OrderedCollections */; };
 		3120506A710A0B6505226C05 /* MarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = 423A6FE16D5EC7FECF77A31A /* MarkdownUI */; };
 		CC36598B842BA60E284D4A9E /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E43EBE726188C58FFB2B6CD /* Foundation.framework */; };
@@ -29,7 +28,7 @@
 /* Begin PBXFileReference section */
 		045D0608DB7069603090D029 /* DevLogCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DevLogCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3E43EBE726188C58FFB2B6CD /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		5E7473315771B5D3030C5003 /* DevLogPresentation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DevLogPresentation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		DFB2BA3C2FB8E5BE00720E6F /* DevLogPresentation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DevLogPresentation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DFE459172FB7283400441703 /* DevLogDomain.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DevLogDomain.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F8C1C9C28BDE46D39FC79A72 /* DevLogPresentationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DevLogPresentationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -61,7 +60,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0530C4A2CF7B413A831F5EA9 /* DevLogPresentation.framework in Frameworks */,
 				D5BCE781F72346A08F831AC3 /* DevLogDomain.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -87,6 +85,7 @@
 				F8C1C9C28BDE46D39FC79A72 /* DevLogPresentationTests.xctest */,
 				045D0608DB7069603090D029 /* DevLogCore.framework */,
 				DFE459172FB7283400441703 /* DevLogDomain.framework */,
+				DFB2BA3C2FB8E5BE00720E6F /* DevLogPresentation.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -98,7 +97,6 @@
 				4320D5C2F6A44B24BF69A36B /* Tests */,
 				9CC0354538B2A1DF2C74E484 /* Frameworks */,
 				03D4331F04C462F4C642860F /* Products */,
-				DF02DBC92FB8D9F1008C7784 /* Recovered References */,
 			);
 			sourceTree = "<group>";
 		};
@@ -116,14 +114,6 @@
 				9A88EA8D5BC609F90B07B726 /* iOS */,
 			);
 			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		DF02DBC92FB8D9F1008C7784 /* Recovered References */ = {
-			isa = PBXGroup;
-			children = (
-				5E7473315771B5D3030C5003 /* DevLogPresentation.framework */,
-			);
-			name = "Recovered References";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -162,7 +152,7 @@
 				7D6DDD31C1122286D5852621 /* OrderedCollections */,
 			);
 			productName = DevLogPresentation;
-			productReference = 5E7473315771B5D3030C5003 /* DevLogPresentation.framework */;
+			productReference = DFB2BA3C2FB8E5BE00720E6F /* DevLogPresentation.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 		BB5614AE13A04E97AC91BD37 /* DevLogPresentationTests */ = {

--- a/Application/DevLogPresentation/DevLogPresentation.xcodeproj/project.pbxproj
+++ b/Application/DevLogPresentation/DevLogPresentation.xcodeproj/project.pbxproj
@@ -3,17 +3,17 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 77;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXBuildFile section */
+		01D899033F573BBB31F1F1CB /* DevLogCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 045D0608DB7069603090D029 /* DevLogCore.framework */; };
+		0530C4A2CF7B413A831F5EA9 /* DevLogPresentation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5E7473315771B5D3030C5003 /* DevLogPresentation.framework */; };
 		1B8D0C5D8C506642FFB8F9FA /* OrderedCollections in Frameworks */ = {isa = PBXBuildFile; productRef = 7D6DDD31C1122286D5852621 /* OrderedCollections */; };
 		3120506A710A0B6505226C05 /* MarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = 423A6FE16D5EC7FECF77A31A /* MarkdownUI */; };
 		CC36598B842BA60E284D4A9E /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E43EBE726188C58FFB2B6CD /* Foundation.framework */; };
 		D5BCE781F72346A08F831AC3 /* DevLogDomain.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DFE459172FB7283400441703 /* DevLogDomain.framework */; };
 		E318BB71FCCC61D38115BC0C /* DevLogDomain.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DFE459172FB7283400441703 /* DevLogDomain.framework */; };
-		01D899033F573BBB31F1F1CB /* DevLogCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 045D0608DB7069603090D029 /* DevLogCore.framework */; };
-		0530C4A2CF7B413A831F5EA9 /* DevLogPresentation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5E7473315771B5D3030C5003 /* DevLogPresentation.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -27,31 +27,45 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		3E43EBE726188C58FFB2B6CD /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		045D0608DB7069603090D029 /* DevLogCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DevLogCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		5E7473315771B5D3030C5003 /* DevLogPresentation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = DevLogPresentation.framework; path = "/Users/opfic/Desktop/Github/App/SwiftUI_DevLog/Application/DevLogPresentation/build/Debug-iphoneos/DevLogPresentation.framework"; sourceTree = "<absolute>"; };
-		F8C1C9C28BDE46D39FC79A72 /* DevLogPresentationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DevLogPresentationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		3E43EBE726188C58FFB2B6CD /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		5E7473315771B5D3030C5003 /* DevLogPresentation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DevLogPresentation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DFE459172FB7283400441703 /* DevLogDomain.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DevLogDomain.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		F8C1C9C28BDE46D39FC79A72 /* DevLogPresentationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DevLogPresentationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
-		A4A427D518004ED78EB659DF /* Exceptions for "Sources" folder in "DevLogPresentation" target */ = {
-			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
-			membershipExceptions = (
-				.swiftlint.yml,
-			);
-			target = A85D2D7D1D6DAAFBF86C9C34 /* DevLogPresentation */;
-		};
-		4320D5C2F6A44B24BF69A36C /* Exceptions for "Tests" folder in "DevLogPresentationTests" target */ = {
+		4320D5C2F6A44B24BF69A36C /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				.swiftlint.yml,
 			);
 			target = BB5614AE13A04E97AC91BD37 /* DevLogPresentationTests */;
 		};
+		A4A427D518004ED78EB659DF /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				.swiftlint.yml,
+			);
+			target = A85D2D7D1D6DAAFBF86C9C34 /* DevLogPresentation */;
+		};
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		4320D5C2F6A44B24BF69A36B /* Tests */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (4320D5C2F6A44B24BF69A36C /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = Tests; sourceTree = "<group>"; };
+		A4A427D518004ED78EB659DE /* Sources */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (A4A427D518004ED78EB659DF /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = Sources; sourceTree = "<group>"; };
+/* End PBXFileSystemSynchronizedRootGroup section */
+
 /* Begin PBXFrameworksBuildPhase section */
+		51A82EDFE96F43B8900A3E8C /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0530C4A2CF7B413A831F5EA9 /* DevLogPresentation.framework in Frameworks */,
+				D5BCE781F72346A08F831AC3 /* DevLogDomain.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		583BF4C4F7EB77076D3CFEA2 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -61,15 +75,6 @@
 				01D899033F573BBB31F1F1CB /* DevLogCore.framework in Frameworks */,
 				E318BB71FCCC61D38115BC0C /* DevLogDomain.framework in Frameworks */,
 				1B8D0C5D8C506642FFB8F9FA /* OrderedCollections in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		51A82EDFE96F43B8900A3E8C /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				0530C4A2CF7B413A831F5EA9 /* DevLogPresentation.framework in Frameworks */,
-				D5BCE781F72346A08F831AC3 /* DevLogDomain.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -93,15 +98,8 @@
 				4320D5C2F6A44B24BF69A36B /* Tests */,
 				9CC0354538B2A1DF2C74E484 /* Frameworks */,
 				03D4331F04C462F4C642860F /* Products */,
+				DF02DBC92FB8D9F1008C7784 /* Recovered References */,
 			);
-			sourceTree = "<group>";
-		};
-		4320D5C2F6A44B24BF69A36B /* Tests */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-				4320D5C2F6A44B24BF69A36C /* Exceptions for "Tests" folder in "DevLogPresentationTests" target */,
-			);
-			path = Tests;
 			sourceTree = "<group>";
 		};
 		9A88EA8D5BC609F90B07B726 /* iOS */ = {
@@ -120,12 +118,12 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		A4A427D518004ED78EB659DE /* Sources */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-				A4A427D518004ED78EB659DF /* Exceptions for "Sources" folder in "DevLogPresentation" target */,
+		DF02DBC92FB8D9F1008C7784 /* Recovered References */ = {
+			isa = PBXGroup;
+			children = (
+				5E7473315771B5D3030C5003 /* DevLogPresentation.framework */,
 			);
-			path = Sources;
+			name = "Recovered References";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -227,7 +225,6 @@
 		};
 /* End PBXProject section */
 
-
 /* Begin PBXResourcesBuildPhase section */
 		5F943984CC1B4A3836CF316E /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
@@ -246,14 +243,14 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		F3DA432031981B11AF07B907 /* Sources */ = {
+		B35683B73EC04117BE5F8A9D /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		B35683B73EC04117BE5F8A9D /* Sources */ = {
+		F3DA432031981B11AF07B907 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -263,18 +260,18 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		FEEAAA000000000000000001 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			productRef = FEEAAA000000000000000003 /* plugin:SwiftLintBuildToolPlugin */;
-		};
-		FEEAAA000000000000000004 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			productRef = FEEAAA000000000000000003 /* plugin:SwiftLintBuildToolPlugin */;
-		};
 		A4FB56AD9F854F9D93800AD6 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = A85D2D7D1D6DAAFBF86C9C34 /* DevLogPresentation */;
 			targetProxy = 0829BE4E037D4E0C846B6C81 /* PBXContainerItemProxy */;
+		};
+		FEEAAA000000000000000001 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			productRef = FEEAAA000000000000000003 /* SwiftLintBuildToolPlugin */;
+		};
+		FEEAAA000000000000000004 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			productRef = FEEAAA000000000000000003 /* SwiftLintBuildToolPlugin */;
 		};
 /* End PBXTargetDependency section */
 
@@ -369,28 +366,6 @@
 			};
 			name = Release;
 		};
-		CB9C4E76716149638008AD42 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.opfic.DevLog.DevLogPresentationTests;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_TARGET_NAME = DevLogPresentation;
-			};
-			name = Debug;
-		};
 		8DD7AD0C295CF0638E03F403 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -418,29 +393,6 @@
 				VERSION_INFO_PREFIX = "";
 			};
 			name = Debug;
-		};
-		F63EFE6D267A4A16A91F429B /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.opfic.DevLog.DevLogPresentationTests;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_TARGET_NAME = DevLogPresentation;
-				VALIDATE_PRODUCT = YES;
-			};
-			name = Release;
 		};
 		973B1093961F1A8F15179643 /* Release */ = {
 			isa = XCBuildConfiguration;
@@ -493,6 +445,51 @@
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		CB9C4E76716149638008AD42 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.opfic.DevLog.DevLogPresentationTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = DevLogPresentation;
+			};
+			name = Debug;
+		};
+		F63EFE6D267A4A16A91F429B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.opfic.DevLog.DevLogPresentationTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = DevLogPresentation;
+				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
 		};
@@ -556,11 +553,6 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		FEEAAA000000000000000003 /* plugin:SwiftLintBuildToolPlugin */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = FEEAAA000000000000000002 /* XCRemoteSwiftPackageReference "SwiftLint" */;
-			productName = "plugin:SwiftLintBuildToolPlugin";
-		};
 		423A6FE16D5EC7FECF77A31A /* MarkdownUI */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 3268290C30B3BFC6DE469DE1 /* XCRemoteSwiftPackageReference "swift-markdown-ui" */;
@@ -570,6 +562,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 4A268C0F47C89BEF1B5B794F /* XCRemoteSwiftPackageReference "swift-collections" */;
 			productName = OrderedCollections;
+		};
+		FEEAAA000000000000000003 /* SwiftLintBuildToolPlugin */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = FEEAAA000000000000000002 /* XCRemoteSwiftPackageReference "SwiftLint" */;
+			productName = "plugin:SwiftLintBuildToolPlugin";
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Application/DevLogPresentation/DevLogPresentation.xcodeproj/project.pbxproj
+++ b/Application/DevLogPresentation/DevLogPresentation.xcodeproj/project.pbxproj
@@ -11,17 +11,12 @@
 		3120506A710A0B6505226C05 /* MarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = 423A6FE16D5EC7FECF77A31A /* MarkdownUI */; };
 		CC36598B842BA60E284D4A9E /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E43EBE726188C58FFB2B6CD /* Foundation.framework */; };
 		D5BCE781F72346A08F831AC3 /* DevLogDomain.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DFE459172FB7283400441703 /* DevLogDomain.framework */; };
+		E318BB71FCCC61D38115BC0C /* DevLogDomain.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DFE459172FB7283400441703 /* DevLogDomain.framework */; };
+		01D899033F573BBB31F1F1CB /* DevLogCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 045D0608DB7069603090D029 /* DevLogCore.framework */; };
 		0530C4A2CF7B413A831F5EA9 /* DevLogPresentation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5E7473315771B5D3030C5003 /* DevLogPresentation.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		0B11B22C33D44E55F6677889 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 0D11B22C33D44E55F6677889 /* DevLogCore.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 5755BDB768C11CE0FDEA4828;
-			remoteInfo = DevLogCore;
-		};
 		0829BE4E037D4E0C846B6C81 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 096704712B06C41C6A0FE074 /* Project object */;
@@ -29,35 +24,14 @@
 			remoteGlobalIDString = A85D2D7D1D6DAAFBF86C9C34;
 			remoteInfo = DevLogPresentation;
 		};
-		3D5C8EE9B4C743CFAC5CAC06 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = B2511C949378771BDB605CC6 /* DevLogDomain.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 7D1E74925088998D68BBFBBB;
-			remoteInfo = DevLogDomain;
-		};
-		63A78AEC0654C9B6030C055B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = B2511C949378771BDB605CC6 /* DevLogDomain.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 7D1E74925088998D68BBFBBB;
-			remoteInfo = DevLogDomain;
-		};
-		DFE459162FB7283400441703 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = B2511C949378771BDB605CC6 /* DevLogDomain.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 3F08F6B94839E9021FCFC466;
-			remoteInfo = DevLogDomain;
-		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		0D11B22C33D44E55F6677889 /* DevLogCore.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = DevLogCore.xcodeproj; path = ../DevLogCore/DevLogCore.xcodeproj; sourceTree = "<group>"; };
 		3E43EBE726188C58FFB2B6CD /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		045D0608DB7069603090D029 /* DevLogCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DevLogCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5E7473315771B5D3030C5003 /* DevLogPresentation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = DevLogPresentation.framework; path = "/Users/opfic/Desktop/Github/App/SwiftUI_DevLog/Application/DevLogPresentation/build/Debug-iphoneos/DevLogPresentation.framework"; sourceTree = "<absolute>"; };
-		B2511C949378771BDB605CC6 /* DevLogDomain.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = DevLogDomain.xcodeproj; path = ../DevLogDomain/DevLogDomain.xcodeproj; sourceTree = "<group>"; };
 		F8C1C9C28BDE46D39FC79A72 /* DevLogPresentationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DevLogPresentationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		DFE459172FB7283400441703 /* DevLogDomain.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DevLogDomain.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -84,6 +58,8 @@
 			files = (
 				3120506A710A0B6505226C05 /* MarkdownUI in Frameworks */,
 				CC36598B842BA60E284D4A9E /* Foundation.framework in Frameworks */,
+				01D899033F573BBB31F1F1CB /* DevLogCore.framework in Frameworks */,
+				E318BB71FCCC61D38115BC0C /* DevLogDomain.framework in Frameworks */,
 				1B8D0C5D8C506642FFB8F9FA /* OrderedCollections in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -104,6 +80,7 @@
 			isa = PBXGroup;
 			children = (
 				F8C1C9C28BDE46D39FC79A72 /* DevLogPresentationTests.xctest */,
+				045D0608DB7069603090D029 /* DevLogCore.framework */,
 				DFE459172FB7283400441703 /* DevLogDomain.framework */,
 			);
 			name = Products;
@@ -115,7 +92,6 @@
 				A4A427D518004ED78EB659DE /* Sources */,
 				4320D5C2F6A44B24BF69A36B /* Tests */,
 				9CC0354538B2A1DF2C74E484 /* Frameworks */,
-				65C85B83FD4ECCC13F82B90F /* Projects */,
 				03D4331F04C462F4C642860F /* Products */,
 			);
 			sourceTree = "<group>";
@@ -126,15 +102,6 @@
 				4320D5C2F6A44B24BF69A36C /* Exceptions for "Tests" folder in "DevLogPresentationTests" target */,
 			);
 			path = Tests;
-			sourceTree = "<group>";
-		};
-		65C85B83FD4ECCC13F82B90F /* Projects */ = {
-			isa = PBXGroup;
-			children = (
-				0D11B22C33D44E55F6677889 /* DevLogCore.xcodeproj */,
-				B2511C949378771BDB605CC6 /* DevLogDomain.xcodeproj */,
-			);
-			name = Projects;
 			sourceTree = "<group>";
 		};
 		9A88EA8D5BC609F90B07B726 /* iOS */ = {
@@ -187,8 +154,6 @@
 			);
 			dependencies = (
 				FEEAAA000000000000000001 /* PBXTargetDependency */,
-				0F11B22C33D44E55F6677889 /* PBXTargetDependency */,
-				C8EA2345A40DFA6BCCD803EE /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				A4A427D518004ED78EB659DE /* Sources */,
@@ -215,7 +180,6 @@
 			dependencies = (
 				FEEAAA000000000000000004 /* PBXTargetDependency */,
 				A4FB56AD9F854F9D93800AD6 /* PBXTargetDependency */,
-				001ED161D33049B18CFB34D9 /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				4320D5C2F6A44B24BF69A36B /* Tests */,
@@ -255,16 +219,6 @@
 			);
 			productRefGroup = 03D4331F04C462F4C642860F /* Products */;
 			projectDirPath = "";
-			projectReferences = (
-				{
-					ProductGroup = 03D4331F04C462F4C642860F /* Products */;
-					ProjectRef = 0D11B22C33D44E55F6677889 /* DevLogCore.xcodeproj */;
-				},
-				{
-					ProductGroup = 03D4331F04C462F4C642860F /* Products */;
-					ProjectRef = B2511C949378771BDB605CC6 /* DevLogDomain.xcodeproj */;
-				},
-			);
 			projectRoot = "";
 			targets = (
 				A85D2D7D1D6DAAFBF86C9C34 /* DevLogPresentation */,
@@ -273,15 +227,6 @@
 		};
 /* End PBXProject section */
 
-/* Begin PBXReferenceProxy section */
-		DFE459172FB7283400441703 /* DevLogDomain.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = DevLogDomain.framework;
-			remoteRef = DFE459162FB7283400441703 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-/* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
 		5F943984CC1B4A3836CF316E /* Resources */ = {
@@ -326,25 +271,10 @@
 			isa = PBXTargetDependency;
 			productRef = FEEAAA000000000000000003 /* plugin:SwiftLintBuildToolPlugin */;
 		};
-		0F11B22C33D44E55F6677889 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = DevLogCore;
-			targetProxy = 0B11B22C33D44E55F6677889 /* PBXContainerItemProxy */;
-		};
-		001ED161D33049B18CFB34D9 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = DevLogDomain;
-			targetProxy = 3D5C8EE9B4C743CFAC5CAC06 /* PBXContainerItemProxy */;
-		};
 		A4FB56AD9F854F9D93800AD6 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = A85D2D7D1D6DAAFBF86C9C34 /* DevLogPresentation */;
 			targetProxy = 0829BE4E037D4E0C846B6C81 /* PBXContainerItemProxy */;
-		};
-		C8EA2345A40DFA6BCCD803EE /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = DevLogDomain;
-			targetProxy = 63A78AEC0654C9B6030C055B /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 

--- a/Widget/DevLogWidgetCore/DevLogWidgetCore.xcodeproj/project.pbxproj
+++ b/Widget/DevLogWidgetCore/DevLogWidgetCore.xcodeproj/project.pbxproj
@@ -3,18 +3,18 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 77;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXBuildFile section */
 		75C99AB35C6DF930E824185E /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FBD260F923A87C1577DBFF0F /* Foundation.framework */; };
+		7E979130578F4839B3C640C1 /* DevLogData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7C18996E00A69C4BCB0F63AE /* DevLogData.framework */; };
 		80423C5F6B880409E39FD20F /* DevLogData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7C18996E00A69C4BCB0F63AE /* DevLogData.framework */; };
 		8EF4007864D24A1F9074C80A /* DevLogWidgetCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6AF1B307A7E7CC03AA2BABB1 /* DevLogWidgetCore.framework */; };
-		B69F5362A64E4C8FAA88393A /* DevLogCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B55555555555555555555555 /* DevLogCore.framework */; };
-		CE64C1569E684FD7BF6E21E7 /* DevLogDomain.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B108898FD3650BE0C116BD3C /* DevLogDomain.framework */; };
-		7E979130578F4839B3C640C1 /* DevLogData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7C18996E00A69C4BCB0F63AE /* DevLogData.framework */; };
 		A1DEB84CF3B18EC2005382C5 /* DevLogDomain.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B108898FD3650BE0C116BD3C /* DevLogDomain.framework */; };
 		B11111111111111111111111 /* DevLogCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B55555555555555555555555 /* DevLogCore.framework */; };
+		B69F5362A64E4C8FAA88393A /* DevLogCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B55555555555555555555555 /* DevLogCore.framework */; };
+		CE64C1569E684FD7BF6E21E7 /* DevLogDomain.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B108898FD3650BE0C116BD3C /* DevLogDomain.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -28,23 +28,23 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		6AF1B307A7E7CC03AA2BABB1 /* DevLogWidgetCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DevLogWidgetCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		099A7D56A0E544A28733E668 /* DevLogWidgetCoreTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DevLogWidgetCoreTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		FBD260F923A87C1577DBFF0F /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		B55555555555555555555555 /* DevLogCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DevLogCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		6AF1B307A7E7CC03AA2BABB1 /* DevLogWidgetCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DevLogWidgetCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7C18996E00A69C4BCB0F63AE /* DevLogData.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DevLogData.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B108898FD3650BE0C116BD3C /* DevLogDomain.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DevLogDomain.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		B55555555555555555555555 /* DevLogCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DevLogCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		FBD260F923A87C1577DBFF0F /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
-		B60F0C6B052E1EF8CC827ADA /* Exceptions for "Sources" folder in "DevLogWidgetCore" target */ = {
+		B60F0C6B052E1EF8CC827ADA /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				.swiftlint.yml,
 			);
 			target = 687DD42230CC25053ABB5FB8 /* DevLogWidgetCore */;
 		};
-		E69EC16509DD43B9A31327C3 /* Exceptions for "Tests" folder in "DevLogWidgetCoreTests" target */ = {
+		E69EC16509DD43B9A31327C3 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				.swiftlint.yml,
@@ -53,18 +53,12 @@
 		};
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		B60F0C6B052E1EF8CC827AD9 /* Sources */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (B60F0C6B052E1EF8CC827ADA /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = Sources; sourceTree = "<group>"; };
+		E69EC16509DD43B9A31327C2 /* Tests */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (E69EC16509DD43B9A31327C3 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = Tests; sourceTree = "<group>"; };
+/* End PBXFileSystemSynchronizedRootGroup section */
+
 /* Begin PBXFrameworksBuildPhase section */
-		ABB4D885A18FE546FC106112 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				75C99AB35C6DF930E824185E /* Foundation.framework in Frameworks */,
-				B11111111111111111111111 /* DevLogCore.framework in Frameworks */,
-				A1DEB84CF3B18EC2005382C5 /* DevLogDomain.framework in Frameworks */,
-				80423C5F6B880409E39FD20F /* DevLogData.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		3AA539BB51824CBF80B7C94A /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -73,6 +67,17 @@
 				B69F5362A64E4C8FAA88393A /* DevLogCore.framework in Frameworks */,
 				CE64C1569E684FD7BF6E21E7 /* DevLogDomain.framework in Frameworks */,
 				7E979130578F4839B3C640C1 /* DevLogData.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		ABB4D885A18FE546FC106112 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				75C99AB35C6DF930E824185E /* Foundation.framework in Frameworks */,
+				B11111111111111111111111 /* DevLogCore.framework in Frameworks */,
+				A1DEB84CF3B18EC2005382C5 /* DevLogDomain.framework in Frameworks */,
+				80423C5F6B880409E39FD20F /* DevLogData.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -107,22 +112,6 @@
 				7C18996E00A69C4BCB0F63AE /* DevLogData.framework */,
 			);
 			name = Products;
-			sourceTree = "<group>";
-		};
-		B60F0C6B052E1EF8CC827AD9 /* Sources */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-				B60F0C6B052E1EF8CC827ADA /* Exceptions for "Sources" folder in "DevLogWidgetCore" target */,
-			);
-			path = Sources;
-			sourceTree = "<group>";
-		};
-		E69EC16509DD43B9A31327C2 /* Tests */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-				E69EC16509DD43B9A31327C3 /* Exceptions for "Tests" folder in "DevLogWidgetCoreTests" target */,
-			);
-			path = Tests;
 			sourceTree = "<group>";
 		};
 		E4683C4F36BFC412C75D164A /* iOS */ = {
@@ -213,11 +202,9 @@
 				Base,
 			);
 			mainGroup = 6AE182A73B6A9D0A2981CE97;
-			minimizedProjectReferenceProxies = 0;
 			packageReferences = (
 				BEEFAA000000000000000002 /* XCRemoteSwiftPackageReference "SwiftLint" */,
 			);
-			preferredProjectObjectVersion = 77;
 			productRefGroup = A71745ED0B0D9E29633DB923 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -227,7 +214,6 @@
 			);
 		};
 /* End PBXProject section */
-
 
 /* Begin PBXResourcesBuildPhase section */
 		26D0E06B5E51FC49407674A2 /* Resources */ = {
@@ -247,14 +233,14 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		E1043BC6F578C87214D6C661 /* Sources */ = {
+		7FF66E64B14245E2A5CB8569 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		7FF66E64B14245E2A5CB8569 /* Sources */ = {
+		E1043BC6F578C87214D6C661 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -264,39 +250,20 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		BEEFAA000000000000000001 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			productRef = BEEFAA000000000000000003 /* plugin:SwiftLintBuildToolPlugin */;
-		};
-		BEEFAA000000000000000004 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			productRef = BEEFAA000000000000000003 /* plugin:SwiftLintBuildToolPlugin */;
-		};
 		0FC02D22248748E49355C84A /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 687DD42230CC25053ABB5FB8 /* DevLogWidgetCore */;
 			targetProxy = 0B7A0A7092BC4744A8B90CF1 /* PBXContainerItemProxy */;
 		};
+		BEEFAA000000000000000001 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			productRef = BEEFAA000000000000000003 /* SwiftLintBuildToolPlugin */;
+		};
+		BEEFAA000000000000000004 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			productRef = BEEFAA000000000000000003 /* SwiftLintBuildToolPlugin */;
+		};
 /* End PBXTargetDependency section */
-
-/* Begin XCRemoteSwiftPackageReference section */
-		BEEFAA000000000000000002 /* XCRemoteSwiftPackageReference "SwiftLint" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/realm/SwiftLint";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.62.1;
-			};
-		};
-/* End XCRemoteSwiftPackageReference section */
-
-/* Begin XCSwiftPackageProductDependency section */
-		BEEFAA000000000000000003 /* plugin:SwiftLintBuildToolPlugin */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = BEEFAA000000000000000002 /* XCRemoteSwiftPackageReference "SwiftLint" */;
-			productName = "plugin:SwiftLintBuildToolPlugin";
-		};
-/* End XCSwiftPackageProductDependency section */
 
 /* Begin XCBuildConfiguration section */
 		8E2FD158204AEBB5D6B1CAA7 /* Release */ = {
@@ -311,7 +278,11 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.opfic.DevLog.DevLogWidgetCore;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -324,24 +295,6 @@
 			};
 			name = Release;
 		};
-		C8AB811EE79C44E18B3C5FDA /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.opfic.DevLog.DevLogWidgetCoreTests;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_TARGET_NAME = DevLogWidgetCore;
-			};
-			name = Debug;
-		};
 		A126E2F5B68D409C837729AA /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -349,7 +302,11 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.opfic.DevLog.DevLogWidgetCoreTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -373,7 +330,11 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.opfic.DevLog.DevLogWidgetCore;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -382,6 +343,28 @@
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		C8AB811EE79C44E18B3C5FDA /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.opfic.DevLog.DevLogWidgetCoreTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = DevLogWidgetCore;
 			};
 			name = Debug;
 		};
@@ -503,20 +486,20 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		A8996A1DFD084C1D6663F586 /* Build configuration list for PBXNativeTarget "DevLogWidgetCore" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				8E2FD158204AEBB5D6B1CAA7 /* Release */,
-				C5BA4998DAC2550DE98EA22B /* Debug */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
 		6F75FCBA6A204D4FA892DEF2 /* Build configuration list for PBXNativeTarget "DevLogWidgetCoreTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				C8AB811EE79C44E18B3C5FDA /* Debug */,
 				A126E2F5B68D409C837729AA /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A8996A1DFD084C1D6663F586 /* Build configuration list for PBXNativeTarget "DevLogWidgetCore" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				8E2FD158204AEBB5D6B1CAA7 /* Release */,
+				C5BA4998DAC2550DE98EA22B /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -531,6 +514,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		BEEFAA000000000000000002 /* XCRemoteSwiftPackageReference "SwiftLint" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/realm/SwiftLint";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.62.1;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		BEEFAA000000000000000003 /* SwiftLintBuildToolPlugin */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BEEFAA000000000000000002 /* XCRemoteSwiftPackageReference "SwiftLint" */;
+			productName = "plugin:SwiftLintBuildToolPlugin";
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 836D58C848CD386B5BF2287A /* Project object */;
 }

--- a/Widget/DevLogWidgetCore/DevLogWidgetCore.xcodeproj/project.pbxproj
+++ b/Widget/DevLogWidgetCore/DevLogWidgetCore.xcodeproj/project.pbxproj
@@ -18,13 +18,6 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		2B73D2B2E8B97FFF71977120 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = ACFE372A6EC5D1CD395230F0 /* DevLogData.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 4AB6E00A38C37CDBF82B57FD;
-			remoteInfo = Subproject;
-		};
 		0B7A0A7092BC4744A8B90CF1 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 836D58C848CD386B5BF2287A /* Project object */;
@@ -32,71 +25,15 @@
 			remoteGlobalIDString = 687DD42230CC25053ABB5FB8;
 			remoteInfo = DevLogWidgetCore;
 		};
-		1080F73A70F4450B8CC531A1 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = B44444444444444444444444 /* DevLogCore.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 5755BDB768C11CE0FDEA4828;
-			remoteInfo = DevLogCore;
-		};
-		D07D2270507C4AEE86205402 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = B196335237B8C8EDB5700A7F /* DevLogDomain.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 7D1E74925088998D68BBFBBB;
-			remoteInfo = DevLogDomain;
-		};
-		D6F4AED74B7541E887C267D4 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = ACFE372A6EC5D1CD395230F0 /* DevLogData.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = D9D76C33D8B4790694BD3488;
-			remoteInfo = DevLogData;
-		};
-		406A7B367DEC67D4F9E38522 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = B196335237B8C8EDB5700A7F /* DevLogDomain.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 3F08F6B94839E9021FCFC466;
-			remoteInfo = Subproject;
-		};
-		B22222222222222222222222 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = B44444444444444444444444 /* DevLogCore.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 9E9FD7B09D0D7EAB8B828A5E;
-			remoteInfo = Subproject;
-		};
-		B33333333333333333333333 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = B44444444444444444444444 /* DevLogCore.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 5755BDB768C11CE0FDEA4828;
-			remoteInfo = DevLogCore;
-		};
-		6B58A164E93F51C78CBAE314 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = B196335237B8C8EDB5700A7F /* DevLogDomain.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 7D1E74925088998D68BBFBBB;
-			remoteInfo = DevLogDomain;
-		};
-		D3B6228D01FFA20503CC1CC5 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = ACFE372A6EC5D1CD395230F0 /* DevLogData.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = D9D76C33D8B4790694BD3488;
-			remoteInfo = DevLogData;
-		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		6AF1B307A7E7CC03AA2BABB1 /* DevLogWidgetCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DevLogWidgetCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		099A7D56A0E544A28733E668 /* DevLogWidgetCoreTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DevLogWidgetCoreTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		ACFE372A6EC5D1CD395230F0 /* DevLogData.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = DevLogData.xcodeproj; path = ../../Application/DevLogData/DevLogData.xcodeproj; sourceTree = "<group>"; };
-		B196335237B8C8EDB5700A7F /* DevLogDomain.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = DevLogDomain.xcodeproj; path = ../../Application/DevLogDomain/DevLogDomain.xcodeproj; sourceTree = "<group>"; };
-		B44444444444444444444444 /* DevLogCore.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = DevLogCore.xcodeproj; path = ../../Application/DevLogCore/DevLogCore.xcodeproj; sourceTree = "<group>"; };
 		FBD260F923A87C1577DBFF0F /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		B55555555555555555555555 /* DevLogCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DevLogCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		7C18996E00A69C4BCB0F63AE /* DevLogData.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DevLogData.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		B108898FD3650BE0C116BD3C /* DevLogDomain.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DevLogDomain.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -150,23 +87,12 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		23F6B7BB30A8782BF2FB2D92 /* Projects */ = {
-			isa = PBXGroup;
-			children = (
-				B44444444444444444444444 /* DevLogCore.xcodeproj */,
-				B196335237B8C8EDB5700A7F /* DevLogDomain.xcodeproj */,
-				ACFE372A6EC5D1CD395230F0 /* DevLogData.xcodeproj */,
-			);
-			name = Projects;
-			sourceTree = "<group>";
-		};
 		6AE182A73B6A9D0A2981CE97 = {
 			isa = PBXGroup;
 			children = (
 				B60F0C6B052E1EF8CC827AD9 /* Sources */,
 				E69EC16509DD43B9A31327C2 /* Tests */,
 				22B18020E715C5AFC73F00FA /* Frameworks */,
-				23F6B7BB30A8782BF2FB2D92 /* Projects */,
 				A71745ED0B0D9E29633DB923 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -233,9 +159,6 @@
 			);
 			dependencies = (
 				BEEFAA000000000000000001 /* PBXTargetDependency */,
-				B66666666666666666666666 /* PBXTargetDependency */,
-				504FAABF657F1D901A2B6BB9 /* PBXTargetDependency */,
-				F1C4B031EE5FEF47898D9562 /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				B60F0C6B052E1EF8CC827AD9 /* Sources */,
@@ -258,9 +181,6 @@
 			dependencies = (
 				BEEFAA000000000000000004 /* PBXTargetDependency */,
 				0FC02D22248748E49355C84A /* PBXTargetDependency */,
-				F7745FE3BB124A799D253D66 /* PBXTargetDependency */,
-				0DDA8FBB36DE47AA85B6E75E /* PBXTargetDependency */,
-				9BECD433C38843B2AF71F106 /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				E69EC16509DD43B9A31327C2 /* Tests */,
@@ -300,20 +220,6 @@
 			preferredProjectObjectVersion = 77;
 			productRefGroup = A71745ED0B0D9E29633DB923 /* Products */;
 			projectDirPath = "";
-			projectReferences = (
-				{
-					ProductGroup = A71745ED0B0D9E29633DB923 /* Products */;
-					ProjectRef = B44444444444444444444444 /* DevLogCore.xcodeproj */;
-				},
-				{
-					ProductGroup = A71745ED0B0D9E29633DB923 /* Products */;
-					ProjectRef = B196335237B8C8EDB5700A7F /* DevLogDomain.xcodeproj */;
-				},
-				{
-					ProductGroup = A71745ED0B0D9E29633DB923 /* Products */;
-					ProjectRef = ACFE372A6EC5D1CD395230F0 /* DevLogData.xcodeproj */;
-				},
-			);
 			projectRoot = "";
 			targets = (
 				687DD42230CC25053ABB5FB8 /* DevLogWidgetCore */,
@@ -322,29 +228,6 @@
 		};
 /* End PBXProject section */
 
-/* Begin PBXReferenceProxy section */
-		B55555555555555555555555 /* DevLogCore.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = DevLogCore.framework;
-			remoteRef = B22222222222222222222222 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		7C18996E00A69C4BCB0F63AE /* DevLogData.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = DevLogData.framework;
-			remoteRef = 2B73D2B2E8B97FFF71977120 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		B108898FD3650BE0C116BD3C /* DevLogDomain.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = DevLogDomain.framework;
-			remoteRef = 406A7B367DEC67D4F9E38522 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-/* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
 		26D0E06B5E51FC49407674A2 /* Resources */ = {
@@ -389,40 +272,10 @@
 			isa = PBXTargetDependency;
 			productRef = BEEFAA000000000000000003 /* plugin:SwiftLintBuildToolPlugin */;
 		};
-		B66666666666666666666666 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = DevLogCore;
-			targetProxy = B33333333333333333333333 /* PBXContainerItemProxy */;
-		};
 		0FC02D22248748E49355C84A /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 687DD42230CC25053ABB5FB8 /* DevLogWidgetCore */;
 			targetProxy = 0B7A0A7092BC4744A8B90CF1 /* PBXContainerItemProxy */;
-		};
-		F7745FE3BB124A799D253D66 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = DevLogCore;
-			targetProxy = 1080F73A70F4450B8CC531A1 /* PBXContainerItemProxy */;
-		};
-		0DDA8FBB36DE47AA85B6E75E /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = DevLogDomain;
-			targetProxy = D07D2270507C4AEE86205402 /* PBXContainerItemProxy */;
-		};
-		9BECD433C38843B2AF71F106 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = DevLogData;
-			targetProxy = D6F4AED74B7541E887C267D4 /* PBXContainerItemProxy */;
-		};
-		504FAABF657F1D901A2B6BB9 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = DevLogDomain;
-			targetProxy = 6B58A164E93F51C78CBAE314 /* PBXContainerItemProxy */;
-		};
-		F1C4B031EE5FEF47898D9562 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = DevLogData;
-			targetProxy = D3B6228D01FFA20503CC1CC5 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #470

## 🎯 의도

Xcode 네비게이터에서 각 모듈이 실제 디렉토리 구조와 동일하게 표시되도록 유지하면서 파일 생성 및 수정 시 프로젝트 파일이 불안정하게 변경되는 참조 구조 정리

## 📝 작업 내용

### 📌 요약

- workspace 내 모듈별 `.xcodeproj` 표시 구조 유지
- 모듈 간 framework 참조 방식 정리
- Xcode 프로젝트 파일 포맷 정규화

### 🔍 상세

- 각 모듈이 Xcode 네비게이터에 독립 프로젝트로 표시되도록 workspace 구조 유지
- `PBXReferenceProxy` / `projectReferences` 기반 참조를 제거하고 `BUILT_PRODUCTS_DIR` 기반 framework 참조로 변경
- 모듈 간 필요한 framework link 관계를 명시적으로 정리
- Xcode 저장 시 반복적으로 발생하던 프로젝트 파일 재직렬화 diff 정규화

## 📸 영상 / 이미지 (Optional)