### PR TITLE
[#467] Persistence 레이어에서 Domain 레이어 의존성을 제거한다

### DIFF
--- a/Application/DevLogCore/Sources/ActivityKind.swift
+++ b/Application/DevLogCore/Sources/ActivityKind.swift
@@ -1,6 +1,6 @@
 //
 //  ActivityKind.swift
-//  DevLogDomain
+//  DevLogCore
 //
 //  Created by opfic on 4/4/26.
 //

--- a/Application/DevLogData/Sources/DTO/TodoDTO.swift
+++ b/Application/DevLogData/Sources/DTO/TodoDTO.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import DevLogDomain
 
 public struct TodoRequest: Encodable {
     public let id: String
@@ -100,5 +99,36 @@ public struct TodoResponse {
         self.dueDate = dueDate
         self.tags = tags
         self.category = category
+    }
+}
+
+public struct WidgetTodoSnapshot: Equatable {
+    public let id: String
+    public let number: Int?
+    public let title: String
+    public let isPinned: Bool
+    public let createdAt: Date
+    public let completedAt: Date?
+    public let deletedAt: Date?
+    public let dueDate: Date?
+
+    public init(
+        id: String,
+        number: Int?,
+        title: String,
+        isPinned: Bool,
+        createdAt: Date,
+        completedAt: Date?,
+        deletedAt: Date?,
+        dueDate: Date?
+    ) {
+        self.id = id
+        self.number = number
+        self.title = title
+        self.isPinned = isPinned
+        self.createdAt = createdAt
+        self.completedAt = completedAt
+        self.deletedAt = deletedAt
+        self.dueDate = dueDate
     }
 }

--- a/Application/DevLogData/Sources/Mapper/TodoMapping.swift
+++ b/Application/DevLogData/Sources/Mapper/TodoMapping.swift
@@ -57,6 +57,21 @@ public extension TodoResponse {
     }
 }
 
+public extension WidgetTodoSnapshot {
+    static func fromDomain(_ todo: Todo) -> Self {
+        WidgetTodoSnapshot(
+            id: todo.id,
+            number: todo.number,
+            title: todo.title,
+            isPinned: todo.isPinned,
+            createdAt: todo.createdAt,
+            completedAt: todo.completedAt,
+            deletedAt: todo.deletedAt,
+            dueDate: todo.dueDate
+        )
+    }
+}
+
 public extension TodoCursorDTO {
     func toDomain() -> TodoCursor {
         TodoCursor(

--- a/Application/DevLogData/Sources/Protocol/WidgetSnapshotPreferenceStore.swift
+++ b/Application/DevLogData/Sources/Protocol/WidgetSnapshotPreferenceStore.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 import DevLogCore
-import DevLogDomain
 
 public protocol WidgetSnapshotPreferenceStore {
     func heatmapActivityTypes() -> [String]

--- a/Application/DevLogData/Sources/Protocol/WidgetSnapshotUpdater.swift
+++ b/Application/DevLogData/Sources/Protocol/WidgetSnapshotUpdater.swift
@@ -7,22 +7,21 @@
 
 import Foundation
 import DevLogCore
-import DevLogDomain
 
 public protocol WidgetSnapshotUpdater {
     func updateTodaySnapshot(
-        todos: [Todo],
+        todos: [WidgetTodoSnapshot],
         now: Date
     )
     func updateTodaySnapshot(
-        todos: [Todo],
+        todos: [WidgetTodoSnapshot],
         displayOptions: TodayDisplayOptions,
         now: Date
     )
     func updateHeatmapSnapshot(
-        createdTodos: [Todo],
-        completedTodos: [Todo],
-        deletedTodos: [Todo],
+        createdTodos: [WidgetTodoSnapshot],
+        completedTodos: [WidgetTodoSnapshot],
+        deletedTodos: [WidgetTodoSnapshot],
         quarterStart: Date,
         now: Date
     )

--- a/Application/DevLogInfra/DevLogInfra.xcodeproj/project.pbxproj
+++ b/Application/DevLogInfra/DevLogInfra.xcodeproj/project.pbxproj
@@ -11,7 +11,6 @@
 		5F7A14F2C5294547884212E1 /* FirebaseCore in Frameworks */ = {isa = PBXBuildFile; productRef = 06ADD17826F44543B09286DA /* FirebaseCore */; };
 		65623F19F34A9A75BC72EE36 /* FirebaseFirestore in Frameworks */ = {isa = PBXBuildFile; productRef = CE8F32B22E13743B3FF3B66B /* FirebaseFirestore */; };
 		B11111111111111111111111 /* DevLogCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B55555555555555555555555 /* DevLogCore.framework */; };
-		E06504AD71E9A40ACCA85ABB /* DevLogDomain.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 05A93F27C7172C85CD7252AA /* DevLogDomain.framework */; };
 		E747320CAD03A579976E87F8 /* FirebaseFunctions in Frameworks */ = {isa = PBXBuildFile; productRef = 172AF9DE3BC54E9E0B4EFD19 /* FirebaseFunctions */; };
 		EE62AAD289D9CED31CC9E05D /* GoogleSignIn in Frameworks */ = {isa = PBXBuildFile; productRef = 7333E70E9D312E56D4A364A6 /* GoogleSignIn */; };
 		F085DED20E80F63AE071D8BA /* DevLogData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A4F874032FD57C0BBCC41C64 /* DevLogData.framework */; };
@@ -84,7 +83,6 @@
 				EE62AAD289D9CED31CC9E05D /* GoogleSignIn in Frameworks */,
 				FEBF252AD70A910C914D3D22 /* Nexa in Frameworks */,
 				F085DED20E80F63AE071D8BA /* DevLogData.framework in Frameworks */,
-				E06504AD71E9A40ACCA85ABB /* DevLogDomain.framework in Frameworks */,
 				B11111111111111111111111 /* DevLogCore.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -177,7 +175,6 @@
 			buildRules = (
 			);
 			dependencies = (
-				1F4AAA000000000000000001 /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				959D79D1263CC74E32B40D78 /* Sources */,
@@ -271,10 +268,6 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		1F4AAA000000000000000001 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			productRef = 1F4AAA000000000000000003 /* SwiftLintBuildToolPlugin */;
-		};
 		1F4AAA000000000000000004 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			productRef = 1F4AAA000000000000000003 /* SwiftLintBuildToolPlugin */;

--- a/Application/DevLogPersistence/DevLogPersistence.xcodeproj/project.pbxproj
+++ b/Application/DevLogPersistence/DevLogPersistence.xcodeproj/project.pbxproj
@@ -12,8 +12,6 @@
 		4763564ECF9942DCB6A7D3D2 /* DevLogWidgetCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5FF5E1613F059A4B77931161 /* DevLogWidgetCore.framework */; };
 		4EE7A141A66C408EB8897D4A /* DevLogPersistence.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 86E8AA2A43914F444BF5A6C2 /* DevLogPersistence.framework */; };
 		5F89EB23199E4ABEA925CF92 /* DevLogData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 493A5D0B4274807F2B948AB3 /* DevLogData.framework */; };
-		7D8DE74BD24B456D42B04806 /* DevLogDomain.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F334BCFC52C730D5901F6051 /* DevLogDomain.framework */; };
-		8A95AB09613C4F54883A7A38 /* DevLogDomain.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F334BCFC52C730D5901F6051 /* DevLogDomain.framework */; };
 		A11111111111111111111111 /* DevLogCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A55555555555555555555555 /* DevLogCore.framework */; };
 		E53E13B73BFAF0C51013ECA2 /* DevLogWidgetCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5FF5E1613F059A4B77931161 /* DevLogWidgetCore.framework */; };
 		F47DBE7D3E7E49F08D4B5530 /* DevLogCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A55555555555555555555555 /* DevLogCore.framework */; };
@@ -36,7 +34,6 @@
 		86E8AA2A43914F444BF5A6C2 /* DevLogPersistence.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DevLogPersistence.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		98B16FCDA8A71E2E4E1DC05E /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		A55555555555555555555555 /* DevLogCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DevLogCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		F334BCFC52C730D5901F6051 /* DevLogDomain.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DevLogDomain.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -68,7 +65,6 @@
 			files = (
 				4EE7A141A66C408EB8897D4A /* DevLogPersistence.framework in Frameworks */,
 				F47DBE7D3E7E49F08D4B5530 /* DevLogCore.framework in Frameworks */,
-				8A95AB09613C4F54883A7A38 /* DevLogDomain.framework in Frameworks */,
 				5F89EB23199E4ABEA925CF92 /* DevLogData.framework in Frameworks */,
 				4763564ECF9942DCB6A7D3D2 /* DevLogWidgetCore.framework in Frameworks */,
 			);
@@ -79,7 +75,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				041CEED3822FCBD881DF75CD /* Foundation.framework in Frameworks */,
-				7D8DE74BD24B456D42B04806 /* DevLogDomain.framework in Frameworks */,
 				E53E13B73BFAF0C51013ECA2 /* DevLogWidgetCore.framework in Frameworks */,
 				3B8FAEC025F373D4CFC262D4 /* DevLogData.framework in Frameworks */,
 				A11111111111111111111111 /* DevLogCore.framework in Frameworks */,
@@ -120,7 +115,6 @@
 			children = (
 				86E8AA2A43914F444BF5A6C2 /* DevLogPersistence.framework */,
 				62B066C5B0714BC3B5F4D9D0 /* DevLogPersistenceTests.xctest */,
-				F334BCFC52C730D5901F6051 /* DevLogDomain.framework */,
 				5FF5E1613F059A4B77931161 /* DevLogWidgetCore.framework */,
 				493A5D0B4274807F2B948AB3 /* DevLogData.framework */,
 				A55555555555555555555555 /* DevLogCore.framework */,

--- a/Application/DevLogPersistence/Sources/Persistence/WidgetSnapshotPreferenceStoreImpl.swift
+++ b/Application/DevLogPersistence/Sources/Persistence/WidgetSnapshotPreferenceStoreImpl.swift
@@ -8,7 +8,6 @@
 import Foundation
 import DevLogCore
 import DevLogData
-import DevLogDomain
 
 final class WidgetSnapshotPreferenceStoreImpl: WidgetSnapshotPreferenceStore {
     private enum Key: String, CaseIterable {

--- a/Application/DevLogPersistence/Sources/Persistence/WidgetSnapshotUpdaterImpl.swift
+++ b/Application/DevLogPersistence/Sources/Persistence/WidgetSnapshotUpdaterImpl.swift
@@ -8,7 +8,6 @@
 import Foundation
 import WidgetKit
 import DevLogCore
-import DevLogDomain
 import DevLogData
 import DevLogWidgetCore
 
@@ -32,7 +31,7 @@ final class WidgetSnapshotUpdaterImpl: WidgetSnapshotUpdater {
     }
 
     func updateTodaySnapshot(
-        todos: [Todo],
+        todos: [WidgetTodoSnapshot],
         now: Date = Date()
     ) {
         updateTodaySnapshot(
@@ -43,7 +42,7 @@ final class WidgetSnapshotUpdaterImpl: WidgetSnapshotUpdater {
     }
 
     func updateTodaySnapshot(
-        todos: [Todo],
+        todos: [WidgetTodoSnapshot],
         displayOptions: TodayDisplayOptions,
         now: Date = Date()
     ) {
@@ -65,9 +64,9 @@ final class WidgetSnapshotUpdaterImpl: WidgetSnapshotUpdater {
     }
 
     func updateHeatmapSnapshot(
-        createdTodos: [Todo],
-        completedTodos: [Todo],
-        deletedTodos: [Todo],
+        createdTodos: [WidgetTodoSnapshot],
+        completedTodos: [WidgetTodoSnapshot],
+        deletedTodos: [WidgetTodoSnapshot],
         quarterStart: Date,
         now: Date = Date()
     ) {

--- a/Application/DevLogPersistence/Tests/Persistence/WidgetSnapshotPreferenceStoreTests.swift
+++ b/Application/DevLogPersistence/Tests/Persistence/WidgetSnapshotPreferenceStoreTests.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import DevLogDomain
+import DevLogCore
 import Testing
 @testable import DevLogPersistence
 

--- a/Application/DevLogPersistence/Tests/Persistence/WidgetSnapshotUpdaterTests.swift
+++ b/Application/DevLogPersistence/Tests/Persistence/WidgetSnapshotUpdaterTests.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 import DevLogCore
-import DevLogDomain
+import DevLogData
 import Testing
 @testable import DevLogPersistence
 @testable import DevLogWidgetCore
@@ -150,22 +150,16 @@ struct WidgetSnapshotUpdaterTests {
         completedAt: Date? = nil,
         deletedAt: Date? = nil,
         dueDate: Date? = nil
-    ) -> Todo {
-        Todo(
+    ) -> WidgetTodoSnapshot {
+        WidgetTodoSnapshot(
             id: id,
-            isPinned: false,
-            isCompleted: completedAt != nil,
-            isChecked: false,
             number: 1,
             title: id,
-            content: "",
+            isPinned: false,
             createdAt: createdAt,
-            updatedAt: createdAt,
             completedAt: completedAt,
             deletedAt: deletedAt,
-            dueDate: dueDate,
-            tags: [],
-            category: .system(.feature)
+            dueDate: dueDate
         )
     }
 }

--- a/Application/DevLogPresentation/Sources/Profile/HeatmapView.swift
+++ b/Application/DevLogPresentation/Sources/Profile/HeatmapView.swift
@@ -6,7 +6,7 @@
 //
 
 import SwiftUI
-import DevLogDomain
+import DevLogCore
 
 struct HeatmapView: View {
     @State private var availableWidth = CGFloat.zero

--- a/Application/DevLogPresentation/Sources/Structure/Profile/ActivityKindItem.swift
+++ b/Application/DevLogPresentation/Sources/Structure/Profile/ActivityKindItem.swift
@@ -6,7 +6,7 @@
 //
 
 import SwiftUI
-import DevLogDomain
+import DevLogCore
 
 public struct ActivityKindItem: Identifiable, Hashable {
     private let activityKind: ActivityKind

--- a/Application/DevLogPresentation/Sources/Structure/Profile/HeatmapActivityItem.swift
+++ b/Application/DevLogPresentation/Sources/Structure/Profile/HeatmapActivityItem.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import DevLogCore
 import DevLogDomain
 
 public struct HeatmapActivityItem: Identifiable, Hashable, Comparable {

--- a/Widget/DevLogWidgetCore/Sources/Heatmap/HeatmapWidgetSnapshotFactory.swift
+++ b/Widget/DevLogWidgetCore/Sources/Heatmap/HeatmapWidgetSnapshotFactory.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import DevLogCore
 import DevLogDomain
 import DevLogData
 

--- a/Widget/DevLogWidgetCore/Sources/Heatmap/HeatmapWidgetSnapshotFactory.swift
+++ b/Widget/DevLogWidgetCore/Sources/Heatmap/HeatmapWidgetSnapshotFactory.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 import DevLogCore
-import DevLogDomain
 import DevLogData
 
 public struct HeatmapWidgetSnapshotFactory {
@@ -35,9 +34,9 @@ public struct HeatmapWidgetSnapshotFactory {
     }
 
     public func makeSnapshot(
-        createdTodos: [Todo],
-        completedTodos: [Todo],
-        deletedTodos: [Todo],
+        createdTodos: [WidgetTodoSnapshot],
+        completedTodos: [WidgetTodoSnapshot],
+        deletedTodos: [WidgetTodoSnapshot],
         selectedActivityKinds: Set<ActivityKind>,
         quarterStart: Date,
         now: Date = Date()
@@ -79,9 +78,9 @@ public struct HeatmapWidgetSnapshotFactory {
 
 private extension HeatmapWidgetSnapshotFactory {
     func makeDailyCountsByDate(
-        createdTodos: [Todo],
-        completedTodos: [Todo],
-        deletedTodos: [Todo],
+        createdTodos: [WidgetTodoSnapshot],
+        completedTodos: [WidgetTodoSnapshot],
+        deletedTodos: [WidgetTodoSnapshot],
         quarterStart: Date,
         nextQuarterStart: Date
     ) -> [Date: DailyCounts] {

--- a/Widget/DevLogWidgetCore/Sources/Sync/WidgetSyncEventHandler.swift
+++ b/Widget/DevLogWidgetCore/Sources/Sync/WidgetSyncEventHandler.swift
@@ -64,7 +64,7 @@ private extension WidgetSyncEventHandler {
                 todosWithoutDueDate
             )
             snapshotUpdater.updateTodaySnapshot(
-                todos: todayTodosWithDueDate + todayTodosWithoutDueDate,
+                todos: (todayTodosWithDueDate + todayTodosWithoutDueDate).map(WidgetTodoSnapshot.fromDomain),
                 now: Date()
             )
         } catch {
@@ -104,9 +104,9 @@ private extension WidgetSyncEventHandler {
                 deletedTodos
             )
             snapshotUpdater.updateHeatmapSnapshot(
-                createdTodos: createdTodoItems,
-                completedTodos: completedTodoItems,
-                deletedTodos: deletedTodoItems,
+                createdTodos: createdTodoItems.map(WidgetTodoSnapshot.fromDomain),
+                completedTodos: completedTodoItems.map(WidgetTodoSnapshot.fromDomain),
+                deletedTodos: deletedTodoItems.map(WidgetTodoSnapshot.fromDomain),
                 quarterStart: quarterStart,
                 now: currentDate
             )

--- a/Widget/DevLogWidgetCore/Sources/Sync/WidgetSyncEventHandler.swift
+++ b/Widget/DevLogWidgetCore/Sources/Sync/WidgetSyncEventHandler.swift
@@ -40,14 +40,15 @@ private extension WidgetSyncEventHandler {
         case .syncRequested:
             Task { [weak self] in
                 guard let self else { return }
-                async let todaySnapshot: Void = updateTodayWidgetSnapshot()
-                async let heatmapSnapshot: Void = updateHeatmapWidgetSnapshot()
+                let now = Date()
+                async let todaySnapshot: Void = updateTodayWidgetSnapshot(now: now)
+                async let heatmapSnapshot: Void = updateHeatmapWidgetSnapshot(now: now)
                 _ = await (todaySnapshot, heatmapSnapshot)
             }
         }
     }
 
-    func updateTodayWidgetSnapshot() async {
+    func updateTodayWidgetSnapshot(now: Date) async {
         do {
             async let todosWithDueDate = fetchTodayTodos(
                 dueDateFilter: .withDueDate,
@@ -65,7 +66,7 @@ private extension WidgetSyncEventHandler {
             )
             snapshotUpdater.updateTodaySnapshot(
                 todos: (todayTodosWithDueDate + todayTodosWithoutDueDate).map(WidgetTodoSnapshot.fromDomain),
-                now: Date()
+                now: now
             )
         } catch {
             logger.error(
@@ -75,9 +76,8 @@ private extension WidgetSyncEventHandler {
         }
     }
 
-    func updateHeatmapWidgetSnapshot() async {
-        let currentDate = Date()
-        let quarterStart = Calendar.current.startOfQuarter(for: currentDate)
+    func updateHeatmapWidgetSnapshot(now: Date) async {
+        let quarterStart = Calendar.current.startOfQuarter(for: now)
         guard let nextQuarterStart = Calendar.current.date(byAdding: .month, value: 3, to: quarterStart) else {
             return
         }
@@ -108,7 +108,7 @@ private extension WidgetSyncEventHandler {
                 completedTodos: completedTodoItems.map(WidgetTodoSnapshot.fromDomain),
                 deletedTodos: deletedTodoItems.map(WidgetTodoSnapshot.fromDomain),
                 quarterStart: quarterStart,
-                now: currentDate
+                now: now
             )
         } catch {
             logger.error(

--- a/Widget/DevLogWidgetCore/Sources/Today/TodayWidgetSnapshotFactory.swift
+++ b/Widget/DevLogWidgetCore/Sources/Today/TodayWidgetSnapshotFactory.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 import DevLogCore
-import DevLogDomain
 import DevLogData
 
 public struct TodayWidgetSnapshotFactory {
@@ -49,7 +48,7 @@ public struct TodayWidgetSnapshotFactory {
         let isPinned: Bool
         let dueDate: Date?
 
-        init?(from todo: Todo) {
+        init?(from todo: WidgetTodoSnapshot) {
             guard let number = todo.number else { return nil }
             self.id = todo.id
             self.number = number
@@ -71,7 +70,7 @@ public struct TodayWidgetSnapshotFactory {
     }
 
     public func makeSnapshot(
-        todos: [Todo],
+        todos: [WidgetTodoSnapshot],
         displayOptions: TodayDisplayOptions,
         now: Date = Date()
     ) -> TodayWidgetSnapshot {

--- a/Widget/DevLogWidgetCore/Tests/Heatmap/HeatmapWidgetSnapshotFactoryTests.swift
+++ b/Widget/DevLogWidgetCore/Tests/Heatmap/HeatmapWidgetSnapshotFactoryTests.swift
@@ -8,7 +8,7 @@
 import Foundation
 import Testing
 import DevLogCore
-import DevLogDomain
+import DevLogData
 @testable import DevLogWidgetCore
 
 struct HeatmapWidgetSnapshotFactoryTests {
@@ -216,22 +216,16 @@ struct HeatmapWidgetSnapshotFactoryTests {
         createdAt: Date,
         completedAt: Date? = nil,
         deletedAt: Date? = nil
-    ) -> Todo {
-        Todo(
+    ) -> WidgetTodoSnapshot {
+        WidgetTodoSnapshot(
             id: id,
-            isPinned: false,
-            isCompleted: completedAt != nil,
-            isChecked: false,
             number: 1,
             title: id,
-            content: "",
+            isPinned: false,
             createdAt: createdAt,
-            updatedAt: createdAt,
             completedAt: completedAt,
             deletedAt: deletedAt,
-            dueDate: nil,
-            tags: [],
-            category: .system(.feature)
+            dueDate: nil
         )
     }
 }

--- a/Widget/DevLogWidgetCore/Tests/Heatmap/HeatmapWidgetSnapshotFactoryTests.swift
+++ b/Widget/DevLogWidgetCore/Tests/Heatmap/HeatmapWidgetSnapshotFactoryTests.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import Testing
+import DevLogCore
 import DevLogDomain
 @testable import DevLogWidgetCore
 

--- a/Widget/DevLogWidgetCore/Tests/Sync/WidgetSyncEventHandlerTests.swift
+++ b/Widget/DevLogWidgetCore/Tests/Sync/WidgetSyncEventHandlerTests.swift
@@ -247,15 +247,15 @@ private actor WidgetSyncTodoRepositorySpy: TodoRepository {
 
 private final class WidgetSnapshotUpdaterSpy: WidgetSnapshotUpdater {
     struct TodayUpdate {
-        let todos: [Todo]
+        let todos: [WidgetTodoSnapshot]
         let displayOptions: TodayDisplayOptions?
         let now: Date
     }
 
     struct HeatmapUpdate {
-        let createdTodos: [Todo]
-        let completedTodos: [Todo]
-        let deletedTodos: [Todo]
+        let createdTodos: [WidgetTodoSnapshot]
+        let completedTodos: [WidgetTodoSnapshot]
+        let deletedTodos: [WidgetTodoSnapshot]
         let quarterStart: Date
         let now: Date
     }
@@ -286,7 +286,7 @@ private final class WidgetSnapshotUpdaterSpy: WidgetSnapshotUpdater {
     }
 
     func updateTodaySnapshot(
-        todos: [Todo],
+        todos: [WidgetTodoSnapshot],
         now: Date
     ) {
         appendTodayUpdate(
@@ -299,7 +299,7 @@ private final class WidgetSnapshotUpdaterSpy: WidgetSnapshotUpdater {
     }
 
     func updateTodaySnapshot(
-        todos: [Todo],
+        todos: [WidgetTodoSnapshot],
         displayOptions: TodayDisplayOptions,
         now: Date
     ) {
@@ -313,9 +313,9 @@ private final class WidgetSnapshotUpdaterSpy: WidgetSnapshotUpdater {
     }
 
     func updateHeatmapSnapshot(
-        createdTodos: [Todo],
-        completedTodos: [Todo],
-        deletedTodos: [Todo],
+        createdTodos: [WidgetTodoSnapshot],
+        completedTodos: [WidgetTodoSnapshot],
+        deletedTodos: [WidgetTodoSnapshot],
         quarterStart: Date,
         now: Date
     ) {

--- a/Widget/DevLogWidgetCore/Tests/Sync/WidgetSyncEventHandlerTests.swift
+++ b/Widget/DevLogWidgetCore/Tests/Sync/WidgetSyncEventHandlerTests.swift
@@ -49,6 +49,7 @@ struct WidgetSyncEventHandlerTests {
         #expect(heatmapUpdates.first?.createdTodos.map(\.id) == ["created"])
         #expect(heatmapUpdates.first?.completedTodos.map(\.id) == ["completed"])
         #expect(heatmapUpdates.first?.deletedTodos.map(\.id) == ["deleted"])
+        #expect(todayUpdates.first?.now == heatmapUpdates.first?.now)
         #expect(queries.count == 5)
         #expect(Set(queries.map(\.sortTarget)) == Set([
             .dueDate,

--- a/Widget/DevLogWidgetCore/Tests/Today/TodayWidgetSnapshotFactoryTests.swift
+++ b/Widget/DevLogWidgetCore/Tests/Today/TodayWidgetSnapshotFactoryTests.swift
@@ -8,7 +8,7 @@
 import Foundation
 import Testing
 import DevLogCore
-import DevLogDomain
+import DevLogData
 @testable import DevLogWidgetCore
 
 struct TodayWidgetSnapshotFactoryTests {
@@ -123,7 +123,7 @@ struct TodayWidgetSnapshotFactoryTests {
     private func makeTodayTodos(
         now: Date,
         calendar: Calendar
-    ) throws -> [Todo] {
+    ) throws -> [WidgetTodoSnapshot] {
         let overdueDate = try #require(calendar.date(byAdding: .day, value: -1, to: now))
         let dueSoonDate = try #require(calendar.date(byAdding: .day, value: 3, to: now))
         let laterDate = try #require(calendar.date(byAdding: .day, value: 9, to: now))
@@ -173,22 +173,16 @@ struct TodayWidgetSnapshotFactoryTests {
         title: String,
         isPinned: Bool,
         dueDate: Date?
-    ) -> Todo {
-        Todo(
+    ) -> WidgetTodoSnapshot {
+        WidgetTodoSnapshot(
             id: id,
-            isPinned: isPinned,
-            isCompleted: false,
-            isChecked: false,
             number: number,
             title: title,
-            content: "",
+            isPinned: isPinned,
             createdAt: .now,
-            updatedAt: .now,
             completedAt: nil,
             deletedAt: nil,
-            dueDate: dueDate,
-            tags: [],
-            category: .system(.feature)
+            dueDate: dueDate
         )
     }
 }


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #467

## 🎯 의도
Persistence 레이어가 Domain 엔티티와 프레임워크를 직접 참조하던 구조를 제거하고, 외부 레이어인 Persistence가 Data/Core 계약만 바라보도록 의존 방향 정리

## 📝 작업 내용

### 📌 요약
- `ActivityKind`를 Domain에서 Core로 이동
- 위젯 스냅샷 갱신 입력을 `Todo`에서 `WidgetTodoSnapshot` DTO로 분리
- Persistence 소스 및 테스트의 `DevLogDomain` 의존 제거
- Persistence/Infra 프로젝트 파일에 남아 있던 `DevLogDomain.framework` 참조 제거

### 🔍 상세
- `WidgetTodoSnapshot`을 `TodoDTO.swift`에 추가하고, `Todo -> WidgetTodoSnapshot` 변환은 `TodoMapping.swift`로 분리
- `WidgetSnapshotUpdater`와 Persistence 구현체가 Domain `Todo` 대신 `WidgetTodoSnapshot`을 사용하도록 수정
- WidgetCore의 스냅샷 팩토리와 동기화 핸들러를 Data DTO 기준으로 갱신
- `ActivityKind` 사용 지점을 Core import 기준으로 정리
- `DevLogPersistence.xcodeproj`의 `DevLogDomain.framework` 링크 및 orphan product reference 제거
- `DevLogInfra.xcodeproj`에 복구되어 있던 `DevLogDomain.framework` 링크 제거

## 📸 영상 / 이미지 (Optional)
