### PR TITLE
[#478] CI에서 빌드 오류가 나도 성공으로 판단되는 현상을 해결한다

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -176,8 +176,8 @@ jobs:
             -showBuildTimingSummary \
             build \
             | tee build.log
-          echo "== xcodebuild finished =="
           XC_STATUS=${PIPESTATUS[0]}
+          echo "== xcodebuild finished =="
           set -e
 
           exit $XC_STATUS

--- a/Application/DevLogCore/Sources/Calendar.swift
+++ b/Application/DevLogCore/Sources/Calendar.swift
@@ -1,6 +1,6 @@
 //
 //  Calendar.swift
-//  DevLogWidgetCore
+//  DevLogCore
 //
 //  Created by opfic on 4/30/26.
 //

--- a/Widget/DevLogWidgetCore/Sources/Common/WidgetHeatmapPlaceholderShape.swift
+++ b/Widget/DevLogWidgetCore/Sources/Common/WidgetHeatmapPlaceholderShape.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import DevLogCore
 
 public struct WidgetHeatmapPlaceholderShape {
     public let currentMonths: [WidgetHeatmapPlaceholderMonthShape]


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #478

## 🎯 의도
- iOS CI에서 `xcodebuild` 실패가 발생해도 성공으로 처리되는 문제 수정
<img width="1420" height="418" alt="image" src="https://github.com/user-attachments/assets/30a84058-4c9d-4977-8c13-7c2a1a29138b" />

## 📝 작업 내용

### 📌 요약
- `xcodebuild | tee build.log` 실행 직후 `PIPESTATUS`를 먼저 저장하도록 순서 변경
- 빌드 실패 상태가 GitHub Actions job 결과에 정상 반영되도록 수정

### 🔍 상세
- `echo "== xcodebuild finished =="` 실행으로 `PIPESTATUS[0]`가 `0`으로 덮이는 문제 확인
- `XC_STATUS=${PIPESTATUS[0]}`를 `echo`보다 앞에 배치하여 `xcodebuild` 종료 코드 보존
- 컴파일 실패 발생 시 CI가 실패 상태로 종료되도록 개선
- 아래 Github Bot 코멘트는 실제 빌드 오류가 나는 부분을 캐치하기 위해 Swift 코드를 수정하지 않은 채 테스트
- `startOfQuarter` 메서드를 `WidgetCore` 에서 `Core` 로 이동

## 📸 영상 / 이미지 (Optional)
