### PR TITLE
[#481] 모듈러 아키텍처 전환 후 WidgetCore 중복 포함으로 TestFlight 업로드 검증에 실패하는 현상을 해결한다

### DIFF
--- a/Application/DevLogApp/DevLogApp.xcodeproj/project.pbxproj
+++ b/Application/DevLogApp/DevLogApp.xcodeproj/project.pbxproj
@@ -19,7 +19,6 @@
 		618B54224ACD6B35D9A8F841 /* DevLogWidgetCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EBFCE939492CAE5AB44E6B81 /* DevLogWidgetCore.framework */; };
 		7188DA2B6DFD13F7FF73069E /* DevLogInfra.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A6AEE3AFC586C92F1643282 /* DevLogInfra.framework */; };
 		79134AD67952720CCC5069EA /* DevLogPersistence.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6FFA0A819CB16649AC35CCE6 /* DevLogPersistence.framework */; };
-		A54A1843C2074FD4A651238F /* DevLogWidgetCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = EBFCE939492CAE5AB44E6B81 /* DevLogWidgetCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		AB11B22C33D44E55F6677889 /* DevLogCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AE11B22C33D44E55F6677889 /* DevLogCore.framework */; };
 		B38B9C91AECB49BA9C7CB8DC /* DevLogPersistence.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 6FFA0A819CB16649AC35CCE6 /* DevLogPersistence.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		B9409E4F83EB4B0A9049D245 /* DevLogInfra.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9A6AEE3AFC586C92F1643282 /* DevLogInfra.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -47,17 +46,6 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
-		274175EE34F94EC88B092534 /* Embed Frameworks */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "";
-			dstSubfolderSpec = 10;
-			files = (
-				A54A1843C2074FD4A651238F /* DevLogWidgetCore.framework in Embed Frameworks */,
-			);
-			name = "Embed Frameworks";
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		D8D4472904EC49ABB6712905 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -250,7 +238,6 @@
 				DFD3A96C2F8E89DD001DA7CD /* Sources */,
 				DFD3A96D2F8E89DD001DA7CD /* Frameworks */,
 				DFD3A96E2F8E89DD001DA7CD /* Resources */,
-				274175EE34F94EC88B092534 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #481

## 🎯 의도

모듈러 아키텍처 전환 이후 WidgetExtension에 `DevLogWidgetCore.framework`가 중복 포함되면서 TestFlight 업로드 검증이 실패하는 문제 해결

## 📝 작업 내용

### 📌 요약

- `DevLogWidgetExtension` 타깃의 `DevLogWidgetCore.framework` 임베드 제거
- extension 내부 `Frameworks` 폴더 생성 방지
- `DevLogWidgetCore` 번들 식별자 충돌 원인 제거

### 🔍 상세

- `Application/DevLogApp/DevLogApp.xcodeproj/project.pbxproj`에서 `DevLogWidgetExtension`의 `Embed Frameworks` phase 제거
- extension 타깃에 연결된 `DevLogWidgetCore.framework in Embed Frameworks` 항목 제거
- app 타깃의 framework 링크 및 임베드 설정은 유지하여 기존 런타임 의존성 구조 보존

## 📸 영상 / 이미지 (Optional)
