### PR TITLE
[#484] TodoEditorView의 모드 셀렉터를 Picker로 수정한다

### DIFF
--- a/Application/DevLogApp/Sources/Resource/Localizable.xcstrings
+++ b/Application/DevLogApp/Sources/Resource/Localizable.xcstrings
@@ -2689,6 +2689,23 @@
         }
       }
     },
+    "todo_write" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Write"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "작성"
+          }
+        }
+      }
+    },
     "todo_editor_description_optional" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Application/DevLogPresentation/Sources/Home/TodoEditorView.swift
+++ b/Application/DevLogPresentation/Sources/Home/TodoEditorView.swift
@@ -120,7 +120,7 @@ struct TodoEditorView: View {
                 }
             )
         ) {
-            Text(String(localized: "todo_edit"))
+            Text(String(localized: "todo_write"))
                 .tag(TodoEditorViewModel.Tag.editor)
             Text(String(localized: "todo_preview"))
                 .tag(TodoEditorViewModel.Tag.preview)

--- a/Application/DevLogPresentation/Sources/Home/TodoEditorView.swift
+++ b/Application/DevLogPresentation/Sources/Home/TodoEditorView.swift
@@ -106,32 +106,27 @@ struct TodoEditorView: View {
     }
 
     private var tabViewSelector: some View {
-        VStack(spacing: 0) {
-            HStack(spacing: 0) {
-                Button(action: {
-                    viewModel.send(.setTabViewTag(.editor))
-                    field = .content
-                }) {
-                    Text(String(localized: "todo_edit"))
-                        .frame(maxWidth: .infinity)
-                        .foregroundStyle(
-                            viewModel.state.tabViewTag == .editor ? Color.primary : Color.secondary
-                        )
+        Picker(
+            "",
+            selection: Binding(
+                get: { viewModel.state.tabViewTag },
+                set: { tag in
+                    if tag == .editor {
+                        viewModel.send(.setTabViewTag(.editor))
+                        field = .content
+                    } else {
+                        transitionToPreview()
+                    }
                 }
-                Divider()
-                Button(action: {
-                    transitionToPreview()
-                }) {
-                    Text(String(localized: "todo_preview"))
-                        .frame(maxWidth: .infinity)
-                        .foregroundStyle(
-                            viewModel.state.tabViewTag == .preview ? Color.primary : Color.gray
-                        )
-                }
-            }
-            .padding(.vertical, 10)
-            .background(Color(.systemBackground))
+            )
+        ) {
+            Text(String(localized: "todo_edit"))
+                .tag(TodoEditorViewModel.Tag.editor)
+            Text(String(localized: "todo_preview"))
+                .tag(TodoEditorViewModel.Tag.preview)
         }
+        .pickerStyle(.segmented)
+        .padding(.horizontal)
     }
 
     private var tabView: some View {


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #484

## 🎯 의도
TodoEditorView 편집/미리보기 전환 방식 개선 및 작성 문구 명확화

## 📝 작업 내용

### 📌 요약
- TodoEditorView 전환 컨트롤의 segmented picker 적용
- 편집 탭 문구의 `todo_write` 키 분리
- 한국어 `작성`, 영어 `Write` 로컬라이즈 추가

### 🔍 상세
- `TodoEditorView`의 수정/미리보기 선택 UI를 가로 분할형 `Picker`로 교체
- 기존 `editor/preview` 상태 전환 로직과 미리보기 전환 처리 유지
- `todo_edit`를 사용하는 다른 수정 문맥은 유지하고 `TodoEditorView`의 picker 라벨에만 `todo_write` 적용
- `Localizable.xcstrings`에 `todo_write` 키 추가

## 📸 영상 / 이미지 (Optional)