### PR TITLE
[#441] Home 초기 데이터 로드 시점을 화면 생명주기에서 선택 상태 기준으로 변경한다

### DIFF
--- a/Application/DevLogPresentation/Sources/Home/Home/HomeView.swift
+++ b/Application/DevLogPresentation/Sources/Home/Home/HomeView.swift
@@ -82,9 +82,6 @@ struct HomeView: View {
                 .font(.caption)
                 .multilineTextAlignment(.center)
         }
-        .onAppear {
-            coordinator.viewModel.send(.onAppear)
-        }
         .overlay {
             if coordinator.viewModel.state.isAppending {
                 LoadingView()

--- a/Application/DevLogPresentation/Sources/Home/Home/HomeViewCoordinator.swift
+++ b/Application/DevLogPresentation/Sources/Home/Home/HomeViewCoordinator.swift
@@ -45,6 +45,10 @@ final class HomeViewCoordinator {
         )
     }
 
+    func loadInitialData() {
+        viewModel.send(.loadInitialData)
+    }
+
     func makeTodoManageViewModel() -> TodoManageViewModel {
         TodoManageViewModel(viewModel.state.preferences)
     }

--- a/Application/DevLogPresentation/Sources/Home/Home/HomeViewModel.swift
+++ b/Application/DevLogPresentation/Sources/Home/Home/HomeViewModel.swift
@@ -38,7 +38,7 @@ final class HomeViewModel: Store {
     }
 
     enum Action {
-        case onAppear
+        case loadInitialData
         case networkStatusChanged(Bool)
         case setPresentation(Presentation, Bool)
         case setAlert(isPresented: Bool, type: AlertType? = nil)
@@ -145,7 +145,7 @@ final class HomeViewModel: Store {
         switch action {
         case .networkStatusChanged(let isConnected):
             state.isNetworkConnected = isConnected
-        case .onAppear, .setPresentation, .setAlert, .setToast, .refreshWebPages,
+        case .loadInitialData, .setPresentation, .setAlert, .setToast, .refreshWebPages,
                 .tapTodoCategory, .orderTodoCategory, .addTodo, .updateWebPageURLInput,
                 .addWebPage, .deleteWebPage, .undoDeleteWebPage:
             effects = reduceByView(action, state: &state)
@@ -274,7 +274,7 @@ private extension HomeViewModel {
     // swiftlint:disable cyclomatic_complexity
     func reduceByView(_ action: Action, state: inout State) -> [SideEffect] {
         switch action {
-        case .onAppear:
+        case .loadInitialData:
             return [.fetchTodoCategoryPreferences, .fetchRecentTodos, .fetchWebPages]
         case .refreshWebPages:
             return [.fetchWebPages]

--- a/Application/DevLogPresentation/Sources/Main/MainView.swift
+++ b/Application/DevLogPresentation/Sources/Main/MainView.swift
@@ -15,11 +15,11 @@ struct MainView: View {
     @State private var homeViewCoordinator: HomeViewCoordinator
     @State private var todayViewCoordinator: TodayViewCoordinator
     @State private var profileViewCoordinator: ProfileViewCoordinator
-    @Binding var selectedTab: MainTab
+    @Binding var selectedTab: MainTab?
 
     init(
         container: DIContainer,
-        selectedTab: Binding<MainTab>
+        selectedTab: Binding<MainTab?>
     ) {
         self._coordinator = State(initialValue: MainViewCoordinator(container: container))
         self._homeViewCoordinator = State(initialValue: HomeViewCoordinator(container: container))
@@ -30,14 +30,19 @@ struct MainView: View {
 
     var body: some View {
         Group {
-            if isCompactLayout {
-                tabView
-            } else {
-                sidebarView
+            if let selectedTab {
+                if isCompactLayout {
+                    tabView
+                } else {
+                    sidebarView(for: selectedTab)
+                }
             }
         }
-        .onAppear {
+        .onChange(of: selectedTab) { oldValue, newValue in
             coordinator.mainViewModel.send(.onAppear)
+            if oldValue == nil && newValue == .home {
+                homeViewCoordinator.viewModel.send(.loadInitialData)
+            }
         }
         .alert(
             coordinator.mainViewModel.state.alertTitle,
@@ -55,37 +60,37 @@ struct MainView: View {
                 .tabItem {
                     tabLabel(.home)
                 }
-                .tag(MainTab.home)
+                .tag(MainTab.home as MainTab?)
 
             todayView
                 .tabItem {
                     tabLabel(.today)
                 }
-                .tag(MainTab.today)
+                .tag(MainTab.today as MainTab?)
 
             notificationView
                 .tabItem {
                     tabLabel(.notification)
                 }
                 .badge(coordinator.mainViewModel.state.unreadPushCount)
-                .tag(MainTab.notification)
+                .tag(MainTab.notification as MainTab?)
 
             profileView
                 .tabItem {
                     tabLabel(.profile)
                 }
-                .tag(MainTab.profile)
+                .tag(MainTab.profile as MainTab?)
         }
     }
 
     @ViewBuilder
-    private var sidebarView: some View {
+    private func sidebarView(for selectedTab: MainTab) -> some View {
         switch selectedTab.mainTabSplitStyle {
         case .detailOnly:
             NavigationSplitView {
                 mainSidebar
             } detail: {
-                selectedTabView
+                selectedTabView(for: selectedTab)
             }
         case .contentDetail:
             switch selectedTab {
@@ -138,7 +143,7 @@ struct MainView: View {
                 NavigationSplitView {
                     mainSidebar
                 } detail: {
-                    selectedTabView
+                    selectedTabView(for: selectedTab)
                 }
             }
         }
@@ -155,7 +160,7 @@ struct MainView: View {
     }
 
     @ViewBuilder
-    private var selectedTabView: some View {
+    private func selectedTabView(for selectedTab: MainTab) -> some View {
         switch selectedTab {
         case .home:
             homeView
@@ -338,9 +343,7 @@ private extension MainView {
         Binding(
             get: { selectedTab },
             set: { tab in
-                if let tab {
-                    selectedTab = tab
-                }
+                selectedTab = tab
             }
         )
     }

--- a/Application/DevLogPresentation/Sources/Main/MainView.swift
+++ b/Application/DevLogPresentation/Sources/Main/MainView.swift
@@ -343,7 +343,9 @@ private extension MainView {
         Binding(
             get: { selectedTab },
             set: { tab in
-                selectedTab = tab
+                if let tab {
+                    selectedTab = tab
+                }
             }
         )
     }

--- a/Application/DevLogPresentation/Sources/Main/MainView.swift
+++ b/Application/DevLogPresentation/Sources/Main/MainView.swift
@@ -38,8 +38,10 @@ struct MainView: View {
                 }
             }
         }
-        .onChange(of: selectedTab) { oldValue, newValue in
+        .onAppear {
             coordinator.mainViewModel.send(.onAppear)
+        }
+        .onChange(of: selectedTab) { oldValue, newValue in
             if oldValue == nil && newValue == .home {
                 homeViewCoordinator.loadInitialData()
             }

--- a/Application/DevLogPresentation/Sources/Main/MainView.swift
+++ b/Application/DevLogPresentation/Sources/Main/MainView.swift
@@ -41,7 +41,7 @@ struct MainView: View {
         .onChange(of: selectedTab) { oldValue, newValue in
             coordinator.mainViewModel.send(.onAppear)
             if oldValue == nil && newValue == .home {
-                homeViewCoordinator.viewModel.send(.loadInitialData)
+                homeViewCoordinator.loadInitialData()
             }
         }
         .alert(

--- a/Application/DevLogPresentation/Sources/Main/MainView.swift
+++ b/Application/DevLogPresentation/Sources/Main/MainView.swift
@@ -41,8 +41,8 @@ struct MainView: View {
         .onAppear {
             coordinator.mainViewModel.send(.onAppear)
         }
-        .onChange(of: selectedTab) { oldValue, newValue in
-            if oldValue == nil && newValue == .home {
+        .onChange(of: selectedTab) { _, newValue in
+            if newValue == .home {
                 homeViewCoordinator.loadInitialData()
             }
         }

--- a/Application/DevLogPresentation/Sources/Root/RootView.swift
+++ b/Application/DevLogPresentation/Sources/Root/RootView.swift
@@ -14,7 +14,7 @@ public struct RootView: View {
     @Environment(\.diContainer) var container: DIContainer
     @State var viewModel: RootViewModel
     @State private var selectedRoute: Route?
-    @State private var selectedMainTab = MainTab.home
+    @State private var selectedMainTab: MainTab?
     private let widgetURLTab: (URL) -> MainTab?
     private let pushNotificationTodoIdPublisher: AnyPublisher<String, Never>
     private let clearPushNotificationRoute: () -> Void
@@ -56,16 +56,22 @@ public struct RootView: View {
         .preferredColorScheme(viewModel.state.theme.colorScheme)
         .onAppear { viewModel.send(.onAppear) }
         .onChange(of: viewModel.state.signIn) { _, value in
-            guard value == false else { return }
-            selectedMainTab = .home
+            guard let value else { return }
+            if value {
+                selectedMainTab = .home
+            } else {
+                selectedMainTab = nil
+            }
         }
         .onOpenURL { url in
             guard let mainTab = widgetURLTab(url) else { return }
             switch viewModel.state.signIn {
             case .some(false):
-                selectedMainTab = .home
-            case .some(true), .none:
+                break
+            case .some(true):
                 selectedMainTab = mainTab
+            case .none:
+                break
             }
         }
         .alert(viewModel.state.alertTitle, isPresented: Binding(

--- a/Application/DevLogPresentation/Tests/WebPage/DeleteWebPageTests.swift
+++ b/Application/DevLogPresentation/Tests/WebPage/DeleteWebPageTests.swift
@@ -45,7 +45,7 @@ struct DeleteWebPageTests {
             networkConnectivityUseCase: observeNetworkConnectivityUseCaseSpy
         )
 
-        homeViewModel.send(.onAppear)
+        homeViewModel.send(.loadInitialData)
         await waitUntil {
             !homeViewModel.state.webPages.isEmpty
         }
@@ -97,7 +97,7 @@ struct DeleteWebPageTests {
             networkConnectivityUseCase: observeNetworkConnectivityUseCaseSpy
         )
 
-        homeViewModel.send(.onAppear)
+        homeViewModel.send(.loadInitialData)
         await waitUntil {
             !homeViewModel.state.webPages.isEmpty
         }


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #441

## 🎯 의도
- `HomeView` 생명주기에 묶여 있던 초기 데이터 로드 트리거를 상위 선택 상태 기준으로 이동하여 compact/regular UI 재구성에 따른 중복 네트워크 요청 방지

## 📝 작업 내용

### 📌 요약
- Home 초기 데이터 로드 시점을 `MainView`의 탭 선택 상태 변화로 이동
- `HomeView`의 `onAppear` 기반 fetch 제거
- `HomeViewCoordinator`를 통한 초기 로드 호출 경로 정리
- 관련 테스트 호출 액션 정리

### 🔍 상세
- `RootView`의 `selectedMainTab`을 `MainTab?`로 변경하여 로그인 성공 시 `nil -> .home` 전이를 초기 로드 기준으로 사용
- `MainView`에서 `selectedTab` 변경 시 `oldValue == nil && newValue == .home` 조건으로만 Home 초기 데이터 로드 호출
- `HomeViewModel`의 초기 로드 액션을 `loadInitialData`로 변경하여 역할 명확화
- `HomeView`에서 직접 `onAppear`로 초기 fetch를 보내던 흐름 제거
- `HomeViewCoordinator`에 초기 로드 전달 메서드 추가로 `MainView`가 `HomeViewModel`을 직접 알지 않도록 정리
- `DeleteWebPageTests`의 초기 로드 호출 액션을 변경된 흐름에 맞게 수정

## 📸 영상 / 이미지 (Optional)