### PR TITLE
[#465] GoogleUtilities 중복 링크로 인한 ObjC 클래스 충돌 경고를 제거한다

### DIFF
--- a/Application/DevLogApp/DevLogApp.xcodeproj/project.pbxproj
+++ b/Application/DevLogApp/DevLogApp.xcodeproj/project.pbxproj
@@ -12,7 +12,6 @@
 		1589C1EF4029ECBF15A842F0 /* DevLogWidgetCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EBFCE939492CAE5AB44E6B81 /* DevLogWidgetCore.framework */; };
 		160E41BDADA3136CD58BE0B4 /* DevLogData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B1B97007E09855108A99428B /* DevLogData.framework */; };
 		186E9AB4F0A79C50FE853607 /* DevLogDomain.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA49949C677DDE083F7DE29E /* DevLogDomain.framework */; };
-		18D57A125ACCF0F6B11A7101 /* GoogleSignIn in Frameworks */ = {isa = PBXBuildFile; productRef = F972F1E8E0F5156FE9651020 /* GoogleSignIn */; };
 		1E452BFF04594187A06AED58 /* DevLogDomain.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = DA49949C677DDE083F7DE29E /* DevLogDomain.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		26C3DC51F23F9C590FDB282D /* DevLogPresentation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 67918B544432C45E63273D84 /* DevLogPresentation.framework */; };
 		393544DD58D941B69760727E /* DevLogPresentation.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 67918B544432C45E63273D84 /* DevLogPresentation.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -161,7 +160,6 @@
 				79134AD67952720CCC5069EA /* DevLogPersistence.framework in Frameworks */,
 				26C3DC51F23F9C590FDB282D /* DevLogPresentation.framework in Frameworks */,
 				1589C1EF4029ECBF15A842F0 /* DevLogWidgetCore.framework in Frameworks */,
-				18D57A125ACCF0F6B11A7101 /* GoogleSignIn in Frameworks */,
 				160E41BDADA3136CD58BE0B4 /* DevLogData.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -272,7 +270,6 @@
 			);
 			name = DevLog;
 			packageProductDependencies = (
-				F972F1E8E0F5156FE9651020 /* GoogleSignIn */,
 			);
 			productName = SwiftUI_DevLog;
 			productReference = DFD48B002DC4D6E2005905C5 /* DevLog.app */;
@@ -312,7 +309,6 @@
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 				DF66A07B2EA52E970098E643 /* XCRemoteSwiftPackageReference "SwiftLint" */,
-				1D75B0AFC69F88110A25217B /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 4B47FFC0E73415A65560089A /* Products */;
@@ -785,14 +781,6 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		1D75B0AFC69F88110A25217B /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/google/GoogleSignIn-iOS";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 9.0.0;
-			};
-		};
 		DF66A07B2EA52E970098E643 /* XCRemoteSwiftPackageReference "SwiftLint" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/realm/SwiftLint";
@@ -808,11 +796,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = DF66A07B2EA52E970098E643 /* XCRemoteSwiftPackageReference "SwiftLint" */;
 			productName = "plugin:SwiftLintBuildToolPlugin";
-		};
-		F972F1E8E0F5156FE9651020 /* GoogleSignIn */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 1D75B0AFC69F88110A25217B /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */;
-			productName = GoogleSignIn;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Application/DevLogApp/Sources/App/Delegate/AppDelegate.swift
+++ b/Application/DevLogApp/Sources/App/Delegate/AppDelegate.swift
@@ -8,7 +8,7 @@
 import UIKit
 import DevLogCore
 import DevLogData
-import GoogleSignIn
+import DevLogInfra
 
 class AppDelegate: UIResponder, UIApplicationDelegate {
     private let logger = Logger(category: "AppDelegate")
@@ -19,7 +19,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         open url: URL,
         options: [UIApplication.OpenURLOptionsKey: Any] = [:]
     ) -> Bool {
-        return GIDSignIn.sharedInstance.handle(url)
+        return GoogleSignInURLHandler.handle(url)
     }
 
     func application(

--- a/Application/DevLogInfra/DevLogInfra.xcodeproj/project.pbxproj
+++ b/Application/DevLogInfra/DevLogInfra.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 70;
+	objectVersion = 71;
 	objects = {
 
 /* Begin PBXBuildFile section */

--- a/Application/DevLogInfra/Sources/Service/SocialLogin/GoogleSignInURLHandler.swift
+++ b/Application/DevLogInfra/Sources/Service/SocialLogin/GoogleSignInURLHandler.swift
@@ -1,0 +1,15 @@
+//
+//  GoogleSignInURLHandler.swift
+//  DevLogInfra
+//
+//  Created by opfic on 5/23/26.
+//
+
+import Foundation
+import GoogleSignIn
+
+public enum GoogleSignInURLHandler {
+    public static func handle(_ url: URL) -> Bool {
+        GIDSignIn.sharedInstance.handle(url)
+    }
+}


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #465

## 🎯 의도
모듈러 아키텍처 전환 후 `GoogleUtilities` Objective-C 클래스가 앱 번들에 중복 포함되며 실기기 콘솔에 경고가 발생하는 문제 해결

## 📝 작업 내용

### 📌 요약
- `DevLogApp` 타깃의 `GoogleSignIn` 직접 링크 제거
- Google Sign-In URL 처리 책임의 `DevLogInfra` 이관
- `GoogleUtilities` 중복 포함 경고 제거

### 🔍 상세
- `DevLogApp.xcodeproj`에서 `GoogleSignIn-iOS` 패키지 참조 및 `GoogleSignIn` product dependency 제거
- `AppDelegate`의 `GIDSignIn.sharedInstance.handle(url)` 직접 호출 제거
- `DevLogInfra`에 `GoogleSignInURLHandler` 추가 후 URL 처리 위임
- Google Sign-In SDK 소유 위치의 `DevLogInfra` 단일화
- 실기기 Xcode 콘솔에서 `GoogleUtilities_GoogleUtilities_Logger_SWIFTPM_MODULE_BUNDLER_FINDER`, `GULLoggerWrapper` 중복 경고 미발생 확인

## 📸 영상 / 이미지 (Optional)