### PR TITLE
[#464] Firebase 초기화보다 먼저 SDK 객체가 접근되는 순서를 개선한다

### DIFF
--- a/Application/DevLogInfra/Sources/Service/FirebaseAppServiceImpl.swift
+++ b/Application/DevLogInfra/Sources/Service/FirebaseAppServiceImpl.swift
@@ -9,9 +9,12 @@ import DevLogData
 import FirebaseCore
 
 final class FirebaseAppServiceImpl: FirebaseAppService {
+    private static var isConfigured = false
+
     func configure() {
-        if FirebaseApp.app() == nil {
-            FirebaseApp.configure()
-        }
+        guard !Self.isConfigured else { return }
+
+        FirebaseApp.configure()
+        Self.isConfigured = true
     }
 }


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #464

## 🎯 의도
Firebase 초기화 과정에서 `configure()` 이전에 Firebase 상태를 조회하며 경고가 발생하던 문제 방지

## 📝 작업 내용

### 📌 요약
- `FirebaseAppServiceImpl`의 초기화 로직 단순화
- `FirebaseApp.app()` 사전 조회 제거
- 단일 실행 보장을 위한 내부 플래그 추가

### 🔍 상세
- `FirebaseAppServiceImpl`에 정적 `isConfigured` 플래그 추가
- `configure()` 호출 시 이미 초기화된 경우 조기 반환 처리
- 기존 `FirebaseApp.app() == nil` 분기 제거
- Firebase 상태 조회 없이 `FirebaseApp.configure()`만 단일 경로로 실행되도록 정리
- `configure()` 이전 Firebase 접근으로 인한 startup 경고 방지

## 📸 영상 / 이미지 (Optional)