### PR TITLE
[#460] WebPageMetadataServiceImpl에서 Sendable 이슈를 해결한다

### DIFF
--- a/Application/DevLogInfra/Sources/Service/WebPageMetadataServiceImpl.swift
+++ b/Application/DevLogInfra/Sources/Service/WebPageMetadataServiceImpl.swift
@@ -74,10 +74,13 @@ final class WebPageMetadataServiceImpl: WebPageMetadataService {
     private func extractImageURL(from imageProvider: NSItemProvider?, url: URL) async throws -> URL? {
         guard let imageProvider else { return nil }
 
+        guard let data = try await imageData(from: imageProvider) else { return nil }
+        return try await imageStore.saveImage(data, for: url)
+    }
+
+    private func imageData(from imageProvider: NSItemProvider) async throws -> Data? {
         return try await withCheckedThrowingContinuation { continuation in
-            //  `[imageStore]`은 배열이 아니고 캡쳐 리스트
-            //  명시적으로 imageStore을 캡쳐하겠다고 작성한 것
-            imageProvider.loadObject(ofClass: UIImage.self) { [imageStore] image, error in
+            imageProvider.loadObject(ofClass: UIImage.self) { image, error in
                 if let error {
                     continuation.resume(throwing: error)
                     return
@@ -89,14 +92,7 @@ final class WebPageMetadataServiceImpl: WebPageMetadataService {
                     return
                 }
 
-                Task {
-                    do {
-                        let fileURL = try await imageStore.saveImage(data, for: url)
-                        continuation.resume(returning: fileURL)
-                    } catch {
-                        continuation.resume(throwing: error)
-                    }
-                }
+                continuation.resume(returning: data)
             }
         }
     }


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #460

## 🎯 의도

`WebPageMetadataServiceImpl`에서 `NSItemProvider.loadObject` 콜백 내부에 `WebPageImageStore`가 캡처되며 발생하는 Sendable 경고 제거

## 📝 작업 내용

### 📌 요약

- 웹페이지 메타데이터 이미지 추출 흐름에서 non-Sendable 캡처 제거
- 이미지 데이터 추출과 이미지 저장 책임 분리

### 🔍 상세

- `loadObject` 콜백에서는 `UIImage`를 `Data`로 변환하는 작업만 수행하도록 변경
- `WebPageImageStore.saveImage` 호출을 continuation 외부의 async 흐름으로 이동
- `WebPageImageStore` 프로토콜 계약 변경 없이 `DevLogInfra` 구현 내부에서 Sendable 경고를 해결

## 📸 영상 / 이미지 (Optional)