### PR TITLE
[#486] TodayViewModel 생성 및 생명주기를 개선한다

### DIFF
--- a/Application/DevLogPresentation/Sources/Home/Home/HomeViewCoordinator.swift
+++ b/Application/DevLogPresentation/Sources/Home/Home/HomeViewCoordinator.swift
@@ -45,8 +45,8 @@ final class HomeViewCoordinator {
         )
     }
 
-    func loadInitialData() {
-        viewModel.send(.loadInitialData)
+    func fetchData() {
+        viewModel.send(.fetchData)
     }
 
     func makeTodoManageViewModel() -> TodoManageViewModel {

--- a/Application/DevLogPresentation/Sources/Home/Home/HomeViewModel.swift
+++ b/Application/DevLogPresentation/Sources/Home/Home/HomeViewModel.swift
@@ -38,7 +38,7 @@ final class HomeViewModel: Store {
     }
 
     enum Action {
-        case loadInitialData
+        case fetchData
         case networkStatusChanged(Bool)
         case setPresentation(Presentation, Bool)
         case setAlert(isPresented: Bool, type: AlertType? = nil)
@@ -145,7 +145,7 @@ final class HomeViewModel: Store {
         switch action {
         case .networkStatusChanged(let isConnected):
             state.isNetworkConnected = isConnected
-        case .loadInitialData, .setPresentation, .setAlert, .setToast, .refreshWebPages,
+        case .fetchData, .setPresentation, .setAlert, .setToast, .refreshWebPages,
                 .tapTodoCategory, .orderTodoCategory, .addTodo, .updateWebPageURLInput,
                 .addWebPage, .deleteWebPage, .undoDeleteWebPage:
             effects = reduceByView(action, state: &state)
@@ -274,7 +274,7 @@ private extension HomeViewModel {
     // swiftlint:disable cyclomatic_complexity
     func reduceByView(_ action: Action, state: inout State) -> [SideEffect] {
         switch action {
-        case .loadInitialData:
+        case .fetchData:
             return [.fetchTodoCategoryPreferences, .fetchRecentTodos, .fetchWebPages]
         case .refreshWebPages:
             return [.fetchWebPages]

--- a/Application/DevLogPresentation/Sources/Main/MainView.swift
+++ b/Application/DevLogPresentation/Sources/Main/MainView.swift
@@ -43,7 +43,7 @@ struct MainView: View {
         }
         .onChange(of: selectedTab, initial: true) { _, newValue in
             if newValue == .home {
-                homeViewCoordinator.loadInitialData()
+                homeViewCoordinator.fetchData()
             } else if newValue == .today {
                 todayViewCoordinator.fetchData()
             }

--- a/Application/DevLogPresentation/Sources/Main/MainView.swift
+++ b/Application/DevLogPresentation/Sources/Main/MainView.swift
@@ -44,6 +44,8 @@ struct MainView: View {
         .onChange(of: selectedTab) { _, newValue in
             if newValue == .home {
                 homeViewCoordinator.loadInitialData()
+            } else if newValue == .today {
+                todayViewCoordinator.fetchData()
             }
         }
         .alert(

--- a/Application/DevLogPresentation/Sources/Main/MainView.swift
+++ b/Application/DevLogPresentation/Sources/Main/MainView.swift
@@ -41,7 +41,7 @@ struct MainView: View {
         .onAppear {
             coordinator.mainViewModel.send(.onAppear)
         }
-        .onChange(of: selectedTab) { _, newValue in
+        .onChange(of: selectedTab, initial: true) { _, newValue in
             if newValue == .home {
                 homeViewCoordinator.loadInitialData()
             } else if newValue == .today {

--- a/Application/DevLogPresentation/Sources/Today/TodayView.swift
+++ b/Application/DevLogPresentation/Sources/Today/TodayView.swift
@@ -29,7 +29,6 @@ struct TodayView: View {
         .toolbar { toolbarContent }
         .background(NavigationBarConfigurator())
         .refreshable { coordinator.viewModel.send(.refresh) }
-        .onAppear { coordinator.viewModel.send(.onAppear) }
         .alert(
             coordinator.viewModel.state.alertTitle,
             isPresented: Binding(

--- a/Application/DevLogPresentation/Sources/Today/TodayViewCoordinator.swift
+++ b/Application/DevLogPresentation/Sources/Today/TodayViewCoordinator.swift
@@ -24,4 +24,8 @@ final class TodayViewCoordinator {
             updateTodayDisplayOptionsUseCase: container.resolve(UpdateTodayDisplayOptionsUseCase.self)
         )
     }
+
+    func fetchData() {
+        viewModel.send(.fetchData)
+    }
 }

--- a/Application/DevLogPresentation/Sources/Today/TodayViewModel.swift
+++ b/Application/DevLogPresentation/Sources/Today/TodayViewModel.swift
@@ -62,7 +62,7 @@ final class TodayViewModel: Store {
         case resetDisplayOptions
         case completeTodo(TodayTodoItem)
         case togglePinned(TodayTodoItem)
-        case onAppear
+        case fetchData
         case fetchTodos([TodayTodoItem])
         case setLoading(Bool)
         case updateTodo(TodayTodoItem)
@@ -178,7 +178,7 @@ final class TodayViewModel: Store {
         case .refresh, .setAlert, .setSectionScope, .setDueDateVisibility, .setFocusVisibility,
                 .resetDisplayOptions, .completeTodo, .togglePinned:
             effects = reduceByUser(action, state: &state)
-        case .onAppear:
+        case .fetchData:
             effects = reduceByView(action, state: &state)
         case .fetchTodos, .setLoading, .updateTodo, .removeTodo:
             effects = reduceByRun(action, state: &state)
@@ -305,7 +305,7 @@ private extension TodayViewModel {
 
     func reduceByView(_ action: Action, state: inout State) -> [SideEffect] {
         switch action {
-        case .onAppear:
+        case .fetchData:
             return [.fetchTodos]
         default:
             break


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #486

## 🎯 의도

Today 화면의 데이터 fetch가 View의 `onAppear` 생명주기에 직접 연결되어 있어 화면 재구성 시점에 따라 불필요하게 호출될 수 있는 구조 개선

## 📝 작업 내용

### 📌 요약

Today 데이터 fetch 트리거를 `TodayView.onAppear`에서 `MainView`의 탭 선택 상태 변경 기준으로 이동

### 🔍 상세

- `TodayView`의 `onAppear` 기반 fetch 트리거 제거
- `TodayViewModel.Action.onAppear`를 실제 동작 의미에 맞는 `fetchData`로 변경
- `TodayViewCoordinator.fetchData()`를 추가해 MainView가 TodayViewModel 액션을 직접 호출하지 않도록 조정
- `MainView`의 `selectedTab` 변경 감지에서 Today 탭 선택 시 `todayViewCoordinator.fetchData()` 호출
- 탭 재진입 시 Today 데이터를 다시 fetch하는 기존 정책 유지

## 📸 영상 / 이미지 (Optional)

<table>
<tr>
<td align="center">

https://github.com/user-attachments/assets/8c7be745-7eed-4faf-8d54-46b11a7409a5

<td align="center">

https://github.com/user-attachments/assets/6a9c868f-0de7-4640-8d57-8c16c6a7fdff

</tr>
<tr>
<td align="center">개선 전
<td align="center">개선 후
</tr>
</table>