### PR TITLE
[#487] ProfileViewModel 생성 및 생명주기를 개선한다

### DIFF
--- a/Application/DevLogApp/Sources/Resource/Localizable.xcstrings
+++ b/Application/DevLogApp/Sources/Resource/Localizable.xcstrings
@@ -2,6 +2,7 @@
   "sourceLanguage" : "ko",
   "strings" : {
     "" : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -13,6 +14,7 @@
       "shouldTranslate" : false
     },
     "#%lld" : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -24,6 +26,7 @@
       "shouldTranslate" : false
     },
     "%lld" : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -425,23 +428,6 @@
         }
       }
     },
-    "home_select_detail" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Select an item."
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "항목을 선택해주세요."
-          }
-        }
-      }
-    },
     "home_recent_title" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -455,6 +441,23 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "최근 수정"
+          }
+        }
+      }
+    },
+    "home_select_detail" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Select an item."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "항목을 선택해주세요."
           }
         }
       }
@@ -528,45 +531,12 @@
       }
     },
     "https://" : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "https://"
-          }
-        }
-      }
-    },
-    "login_apple_sign_in" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sign in with Apple"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "애플 계정으로 로그인"
-          }
-        }
-      }
-    },
-    "login_github_sign_in" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sign in with GitHub"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "깃헙 계정으로 로그인"
           }
         }
       }
@@ -601,6 +571,40 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "이메일 확인 불가"
+          }
+        }
+      }
+    },
+    "login_apple_sign_in" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sign in with Apple"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "애플 계정으로 로그인"
+          }
+        }
+      }
+    },
+    "login_github_sign_in" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sign in with GitHub"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "깃헙 계정으로 로그인"
           }
         }
       }
@@ -1931,23 +1935,6 @@
         }
       }
     },
-    "today_select_detail" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Select a todo."
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Todo를 선택해주세요."
-          }
-        }
-      }
-    },
     "today_due_overdue" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -2322,6 +2309,23 @@
         }
       }
     },
+    "today_select_detail" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Select a todo."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Todo를 선택해주세요."
+          }
+        }
+      }
+    },
     "today_summary_all" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -2391,6 +2395,7 @@
       }
     },
     "TODO" : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -2436,6 +2441,7 @@
     },
     "todo_category_doc" : {
       "comment" : "Todo category: Documentation",
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -2453,6 +2459,7 @@
     },
     "todo_category_etc" : {
       "comment" : "Todo category: Etc",
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -2470,6 +2477,7 @@
     },
     "todo_category_feature" : {
       "comment" : "Todo category: Feature",
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -2487,6 +2495,7 @@
     },
     "todo_category_improvement" : {
       "comment" : "Todo category: Improvement",
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -2504,6 +2513,7 @@
     },
     "todo_category_issue" : {
       "comment" : "Todo category: Issue",
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -2521,6 +2531,7 @@
     },
     "todo_category_research" : {
       "comment" : "Todo category: Research",
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -2538,6 +2549,7 @@
     },
     "todo_category_review" : {
       "comment" : "Todo category: Review",
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -2555,6 +2567,7 @@
     },
     "todo_category_test" : {
       "comment" : "Todo category: Test",
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -2685,23 +2698,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "수정"
-          }
-        }
-      }
-    },
-    "todo_write" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Write"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "작성"
           }
         }
       }
@@ -3386,7 +3382,25 @@
         }
       }
     },
+    "todo_write" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Write"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "작성"
+          }
+        }
+      }
+    },
     "Todos" : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -3397,6 +3411,7 @@
       }
     },
     "Web Page" : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -3407,6 +3422,7 @@
       }
     },
     "Web Pages" : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {

--- a/Application/DevLogPresentation/Sources/Main/MainView.swift
+++ b/Application/DevLogPresentation/Sources/Main/MainView.swift
@@ -46,6 +46,8 @@ struct MainView: View {
                 homeViewCoordinator.fetchData()
             } else if newValue == .today {
                 todayViewCoordinator.fetchData()
+            } else if newValue == .profile {
+                profileViewCoordinator.fetchData()
             }
         }
         .alert(

--- a/Application/DevLogPresentation/Sources/Profile/ProfileView.swift
+++ b/Application/DevLogPresentation/Sources/Profile/ProfileView.swift
@@ -118,7 +118,6 @@ struct ProfileView: View {
                     AccountView(viewModel: coordinator.makeAccountViewModel())
                 }
             }
-            .onAppear { coordinator.viewModel.send(.onAppear) }
             .onChange(of: focused) { _, newValue in
                 withAnimation {
                     coordinator.viewModel.send(.updateStatusTextFieldFocus(newValue))

--- a/Application/DevLogPresentation/Sources/Profile/ProfileViewCoordinator.swift
+++ b/Application/DevLogPresentation/Sources/Profile/ProfileViewCoordinator.swift
@@ -38,6 +38,10 @@ final class ProfileViewCoordinator {
         )
     }
 
+    func fetchData() {
+        viewModel.send(.fetchData)
+    }
+
     func makeAccountViewModel() -> AccountViewModel {
         AccountViewModel(
             fetchProvidersUseCase: container.resolve(FetchAuthProvidersUseCase.self),

--- a/Application/DevLogPresentation/Sources/Profile/ProfileViewModel.swift
+++ b/Application/DevLogPresentation/Sources/Profile/ProfileViewModel.swift
@@ -34,7 +34,7 @@ final class ProfileViewModel: Store {
     }
 
     enum Action {
-        case onAppear, refresh
+        case fetchData, refresh
         case networkStatusChanged(Bool)
         case setLoading(Bool)
         case setAlert(Bool)
@@ -98,7 +98,7 @@ final class ProfileViewModel: Store {
         var state = self.state
         var effects: [SideEffect] = []
         switch action {
-        case .onAppear, .refresh:
+        case .fetchData, .refresh:
             if state.selectedQuarterStart == nil {
                 guard let quarterStart = quarterStart(for: Date()) else { break }
                 state.selectedQuarterStart = quarterStart

--- a/Application/DevLogPresentation/Tests/WebPage/DeleteWebPageTests.swift
+++ b/Application/DevLogPresentation/Tests/WebPage/DeleteWebPageTests.swift
@@ -45,7 +45,7 @@ struct DeleteWebPageTests {
             networkConnectivityUseCase: observeNetworkConnectivityUseCaseSpy
         )
 
-        homeViewModel.send(.loadInitialData)
+        homeViewModel.send(.fetchData)
         await waitUntil {
             !homeViewModel.state.webPages.isEmpty
         }
@@ -97,7 +97,7 @@ struct DeleteWebPageTests {
             networkConnectivityUseCase: observeNetworkConnectivityUseCaseSpy
         )
 
-        homeViewModel.send(.loadInitialData)
+        homeViewModel.send(.fetchData)
         await waitUntil {
             !homeViewModel.state.webPages.isEmpty
         }

--- a/docs/DevLog.drawio
+++ b/docs/DevLog.drawio
@@ -103,49 +103,83 @@
     </mxGraphModel>
   </diagram>
   <diagram id="delete-flow-page" name="Delete Undo Flow">
-    <mxGraphModel grid="1" page="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" pageScale="1" pageWidth="1280" pageHeight="600" background="#ffffff" math="0" shadow="0">
+    <mxGraphModel dx="1414" dy="850" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1280" pageHeight="600" background="#ffffff" math="0" shadow="0">
       <root>
         <mxCell id="0" />
         <mxCell id="1" parent="0" />
-        <mxCell id="du-request-device" link="https://github.com/opficdev/SwiftUI_DevLog/blob/main/DevLog/Presentation/ViewModel/PushNotificationListViewModel.swift" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#EAF2FF;strokeColor=#0A84FF;strokeWidth=2;fontColor=#0B1F33;fontSize=13;align=center;" value="&lt;b&gt;iOS Client&lt;/b&gt;" vertex="1">
-          <mxGeometry height="70" width="200" x="80" y="250" as="geometry" />
+        <mxCell id="du-client" link="https://github.com/opficdev/SwiftUI_DevLog/blob/main/Application/DevLogPresentation/Sources/PushNotification/PushNotificationListViewModel.swift" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#EAF2FF;strokeColor=#0A84FF;strokeWidth=2;fontColor=#0B1F33;fontSize=13;align=center;" value="&lt;b&gt;iOS Client&lt;/b&gt;&lt;br&gt;&lt;span style=&quot;font-weight: normal;&quot;&gt;즉시 숨김, Undo UI&lt;br&gt;실패 시 복구&lt;/span&gt;" vertex="1">
+          <mxGeometry height="60" width="190" x="105" y="100" as="geometry" />
         </mxCell>
-        <mxCell id="du-edge-request-functions" edge="1" parent="1" source="du-request-device" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0A84FF;strokeWidth=3;labelBackgroundColor=#FFFFFF;fontSize=12;" target="du-functions" value="삭제·Undo 요청">
-          <mxGeometry relative="1" x="-0.0909" y="15" as="geometry">
-            <mxPoint as="offset" />
+        <mxCell id="du-functions" link="https://github.com/opficdev/SwiftUI_DevLog/blob/main/Firebase/functions/src/notification/deletion.ts" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#DCFCE7;strokeColor=#16A34A;strokeWidth=2;fontColor=#14532D;fontSize=13;align=center;" value="&lt;b&gt;Cloud Functions&lt;/b&gt;&lt;br&gt;&lt;span style=&quot;font-weight: normal;&quot;&gt;삭제, Undo 상태 처리&lt;/span&gt;" vertex="1">
+          <mxGeometry height="60" width="190" x="395" y="100" as="geometry" />
+        </mxCell>
+        <mxCell id="du-firestore" link="https://github.com/opficdev/SwiftUI_DevLog/blob/main/Firebase/functions/src/notification/deletion.ts" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#64748B;strokeWidth=2;fontColor=#1F2328;fontSize=13;align=center;" value="&lt;b&gt;Firestore&lt;/b&gt;&lt;br&gt;&lt;span style=&quot;font-weight: normal;&quot;&gt;알림 삭제 상태&lt;/span&gt;" vertex="1">
+          <mxGeometry height="60" width="190" x="690" y="100" as="geometry" />
+        </mxCell>
+        <mxCell id="du-scheduler" link="https://github.com/opficdev/SwiftUI_DevLog/blob/main/Firebase/functions/src/notification/cleanup.ts" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#FEF3C7;strokeColor=#F59E0B;strokeWidth=2;fontColor=#78350F;fontSize=13;align=center;" value="&lt;b&gt;Scheduler&lt;/b&gt;&lt;br&gt;&lt;span style=&quot;font-weight: normal;&quot;&gt;soft delete 정리&lt;/span&gt;" vertex="1">
+          <mxGeometry height="60" width="190" x="985" y="100" as="geometry" />
+        </mxCell>
+        <mxCell id="du-client-line" edge="1" parent="1" style="html=1;endArrow=none;dashed=1;strokeColor=#94A3B8;strokeWidth=2;" value="">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="200" y="160" as="sourcePoint" />
+            <mxPoint x="200" y="520" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="du-edge-functions-firestore" edge="1" parent="1" source="du-functions" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#16A34A;strokeWidth=3;labelBackgroundColor=#FFFFFF;fontSize=12;" target="du-firestore" value="삭제 상태 저장&lt;div&gt;Undo 시 상태 해제&lt;/div&gt;">
-          <mxGeometry relative="1" x="-0.0909" y="29" as="geometry">
-            <mxPoint as="offset" />
+        <mxCell id="du-functions-line" edge="1" parent="1" style="html=1;endArrow=none;dashed=1;strokeColor=#94A3B8;strokeWidth=2;" value="">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="490" y="160" as="sourcePoint" />
+            <mxPoint x="490" y="520" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="du-edge-functions-undo" edge="1" parent="1" source="du-functions" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#16A34A;strokeWidth=3;labelBackgroundColor=#FFFFFF;fontSize=12;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" target="du-firestore" value="">
-          <mxGeometry relative="1" x="0.0909" y="9" as="geometry">
-            <mxPoint as="offset" />
+        <mxCell id="du-firestore-line" edge="1" parent="1" style="html=1;endArrow=none;dashed=1;strokeColor=#94A3B8;strokeWidth=2;" value="">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="785" y="160" as="sourcePoint" />
+            <mxPoint x="785" y="520" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="du-edge-firestore-request" edge="1" parent="1" source="du-firestore" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#64748B;strokeWidth=3;labelBackgroundColor=#FFFFFF;fontSize=12;exitX=1;exitY=0.25;exitDx=0;exitDy=0;entryX=-0.012;entryY=0.756;entryDx=0;entryDy=0;entryPerimeter=0;" target="du-request-list" value="서버 기준 리스트">
-          <mxGeometry relative="1" x="-0.5683" y="32" as="geometry">
-            <mxPoint as="offset" />
+        <mxCell id="du-scheduler-line" edge="1" parent="1" style="html=1;endArrow=none;dashed=1;strokeColor=#94A3B8;strokeWidth=2;" value="">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="1080" y="160" as="sourcePoint" />
+            <mxPoint x="1080" y="520" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="du-edge-firestore-other" edge="1" parent="1" source="du-firestore" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#64748B;strokeWidth=3;labelBackgroundColor=#FFFFFF;fontSize=12;exitX=1;exitY=0.75;exitDx=0;exitDy=0;entryX=0;entryY=0.25;entryDx=0;entryDy=0;" target="du-other-list" value="동일 상태 반영">
-          <mxGeometry relative="1" x="-0.4165" y="-28" as="geometry">
+        <mxCell id="du-legend" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#D8E0EA;strokeWidth=2;fontColor=#334155;fontSize=12;align=left;spacingLeft=14;" value="&lt;b&gt;화살표 의미&lt;/b&gt;&lt;br&gt;&lt;font color=&quot;#0A84FF&quot;&gt;■&lt;/font&gt; 삭제 요청&lt;br&gt;&lt;font color=&quot;#16A34A&quot;&gt;■&lt;/font&gt; 삭제 상태 저장&lt;br&gt;&lt;font color=&quot;#7C3AED&quot;&gt;■&lt;/font&gt; Undo 복구&lt;br&gt;&lt;font color=&quot;#F59E0B&quot;&gt;■&lt;/font&gt; soft delete 정리" vertex="1">
+          <mxGeometry height="100" width="120" x="1020" y="200" as="geometry" />
+        </mxCell>
+        <mxCell id="du-delete-request" edge="1" parent="1" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0A84FF;strokeWidth=3;labelBackgroundColor=#FFFFFF;fontSize=12;" value="삭제 요청">
+          <mxGeometry relative="1" as="geometry">
             <mxPoint as="offset" />
+            <mxPoint x="200" y="270" as="sourcePoint" />
+            <mxPoint x="490" y="270" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="du-functions" link="https://github.com/opficdev/SwiftUI_DevLog/blob/main/Firebase/functions/src/notification/deletion.ts" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#DCFCE7;strokeColor=#16A34A;strokeWidth=2;fontColor=#14532D;fontSize=13;align=center;" value="&lt;b&gt;Cloud Functions&lt;/b&gt;&lt;br&gt;&lt;span style=&quot;font-weight: normal;&quot;&gt;삭제·Undo 요청 처리&lt;/span&gt;" vertex="1">
-          <mxGeometry height="70" width="200" x="390" y="250" as="geometry" />
+        <mxCell id="du-delete-store" edge="1" parent="1" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#16A34A;strokeWidth=3;labelBackgroundColor=#FFFFFF;fontSize=12;" value="isDeleted = true">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint as="offset" />
+            <mxPoint x="490" y="315" as="sourcePoint" />
+            <mxPoint x="785" y="315" as="targetPoint" />
+          </mxGeometry>
         </mxCell>
-        <mxCell id="du-firestore" link="https://github.com/opficdev/SwiftUI_DevLog/blob/main/Firebase/functions/src/notification/deletion.ts" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#64748B;strokeWidth=2;fontColor=#1F2328;fontSize=13;align=center;" value="&lt;b&gt;Firestore 알림 문서&lt;/b&gt;&lt;br&gt;&lt;span style=&quot;font-weight: normal;&quot;&gt;삭제 상태 저장·해제&lt;/span&gt;" vertex="1">
-          <mxGeometry height="70" width="200" x="710" y="250" as="geometry" />
+        <mxCell id="du-undo-request" edge="1" parent="1" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#7C3AED;strokeWidth=3;labelBackgroundColor=#FFFFFF;fontSize=12;" value="Undo 요청">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint as="offset" />
+            <mxPoint x="200" y="390" as="sourcePoint" />
+            <mxPoint x="490" y="390" as="targetPoint" />
+          </mxGeometry>
         </mxCell>
-        <mxCell id="du-request-list" link="https://github.com/opficdev/SwiftUI_DevLog/blob/main/DevLog/Presentation/ViewModel/PushNotificationListViewModel.swift" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#F5F3FF;strokeColor=#7C3AED;strokeWidth=2;fontColor=#1F2328;fontSize=13;align=center;" value="&lt;b&gt;요청 기기 리스트&lt;/b&gt;&lt;br&gt;&lt;span style=&quot;font-weight: normal;&quot;&gt;서버 재조회로 동기화&lt;/span&gt;" vertex="1">
-          <mxGeometry height="70" width="200" x="1020" y="150" as="geometry" />
+        <mxCell id="du-undo-store" edge="1" parent="1" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#7C3AED;strokeWidth=3;labelBackgroundColor=#FFFFFF;fontSize=12;" value="isDeleted = false">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint as="offset" />
+            <mxPoint x="490" y="435" as="sourcePoint" />
+            <mxPoint x="785" y="435" as="targetPoint" />
+          </mxGeometry>
         </mxCell>
-        <mxCell id="du-other-list" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#F5F3FF;strokeColor=#7C3AED;strokeWidth=2;fontColor=#1F2328;fontSize=13;align=center;" value="&lt;b&gt;다른 기기 리스트&lt;/b&gt;&lt;br&gt;&lt;span style=&quot;font-weight: normal;&quot;&gt;같은 삭제 상태 반영&lt;/span&gt;" vertex="1">
-          <mxGeometry height="70" width="200" x="1020" y="350" as="geometry" />
+        <mxCell id="du-cleanup-request" edge="1" parent="1" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#F59E0B;strokeWidth=3;labelBackgroundColor=#FFFFFF;fontSize=12;" value="soft delete 문서 정리">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint as="offset" />
+            <mxPoint x="1080" y="485" as="sourcePoint" />
+            <mxPoint x="785" y="485" as="targetPoint" />
+          </mxGeometry>
         </mxCell>
       </root>
     </mxGraphModel>
@@ -155,110 +189,195 @@
       <root>
         <mxCell id="0" />
         <mxCell id="1" parent="0" />
-        <mxCell id="trv-edge-app-state" edge="1" parent="1" source="trv-app" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0A84FF;strokeWidth=3;labelBackgroundColor=#FFFFFF;fontSize=12;" target="trv-server-state" value="Timezone,&lt;div&gt;알림 설정 저장&lt;/div&gt;">
-          <mxGeometry relative="1" x="-0.2" y="17" as="geometry">
-            <mxPoint as="offset" />
-          </mxGeometry>
+        <mxCell id="trv-client" link="https://github.com/opficdev/SwiftUI_DevLog/blob/main/Application/DevLogInfra/Sources/Service/UserServiceImpl.swift" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#EAF2FF;strokeColor=#0A84FF;strokeWidth=2;fontColor=#0B1F33;fontSize=13;align=center;" value="&lt;b&gt;iOS Client&lt;/b&gt;&lt;br&gt;&lt;span style=&quot;font-weight: normal;&quot;&gt;시간대, 알림 설정&lt;/span&gt;" vertex="1">
+          <mxGeometry height="60" width="160" x="55" y="90" as="geometry" />
         </mxCell>
-        <mxCell id="trv-edge-state-batch" edge="1" parent="1" source="trv-server-state" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#64748B;strokeWidth=3;labelBackgroundColor=#FFFFFF;fontSize=12;" target="trv-batch" value="최신 기준 조회">
-          <mxGeometry relative="1" x="-0.0769" y="15" as="geometry">
-            <mxPoint as="offset" />
-          </mxGeometry>
+        <mxCell id="trv-firestore" link="https://github.com/opficdev/SwiftUI_DevLog/blob/main/Firebase/functions/src/common/firestorePath.ts" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#64748B;strokeWidth=2;fontColor=#1F2328;fontSize=13;align=center;" value="&lt;b&gt;Firestore&lt;/b&gt;&lt;br&gt;&lt;span style=&quot;font-weight: normal;&quot;&gt;설정, Todo 상태&lt;/span&gt;" vertex="1">
+          <mxGeometry height="60" width="160" x="260" y="90" as="geometry" />
         </mxCell>
-        <mxCell id="trv-edge-batch-queue" edge="1" parent="1" source="trv-batch" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#64748B;strokeWidth=3;labelBackgroundColor=#FFFFFF;fontSize=12;exitX=0;exitY=0.75;exitDx=0;exitDy=0;entryX=1;entryY=0.25;entryDx=0;entryDy=0;" target="trv-queue" value="작업 적재">
+        <mxCell id="trv-batch" link="https://github.com/opficdev/SwiftUI_DevLog/blob/main/Firebase/functions/src/fcm/schedule.ts" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#F8FAFC;strokeColor=#64748B;strokeWidth=2;fontColor=#1F2328;fontSize=13;align=center;" value="&lt;b&gt;Scheduler&lt;/b&gt;&lt;br&gt;&lt;span style=&quot;font-weight: normal;&quot;&gt;대상 재계산&lt;/span&gt;" vertex="1">
+          <mxGeometry height="60" width="160" x="465" y="90" as="geometry" />
+        </mxCell>
+        <mxCell id="trv-queue" link="https://github.com/opficdev/SwiftUI_DevLog/blob/main/Firebase/functions/src/fcm/schedule.ts" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#ECFEFF;strokeColor=#0891B2;strokeWidth=2;fontColor=#164E63;fontSize=13;align=center;" value="&lt;b&gt;Cloud Tasks&lt;/b&gt;&lt;br&gt;&lt;span style=&quot;font-weight: normal;&quot;&gt;발송 큐&lt;/span&gt;" vertex="1">
+          <mxGeometry height="60" width="160" x="670" y="90" as="geometry" />
+        </mxCell>
+        <mxCell id="trv-sender" link="https://github.com/opficdev/SwiftUI_DevLog/blob/main/Firebase/functions/src/fcm/notification.ts" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#DCFCE7;strokeColor=#16A34A;strokeWidth=2;fontColor=#14532D;fontSize=13;align=center;" value="&lt;b&gt;Send Function&lt;/b&gt;&lt;br&gt;&lt;span style=&quot;font-weight: normal;&quot;&gt;발송 전 검증&lt;/span&gt;" vertex="1">
+          <mxGeometry height="60" width="160" x="875" y="90" as="geometry" />
+        </mxCell>
+        <mxCell id="trv-fcm" link="https://github.com/opficdev/SwiftUI_DevLog/blob/main/Firebase/functions/src/fcm/notification.ts" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#F5F3FF;strokeColor=#7C3AED;strokeWidth=2;fontColor=#1F2328;fontSize=13;align=center;" value="&lt;b&gt;FCM&lt;/b&gt;&lt;br&gt;&lt;span style=&quot;font-weight: normal;&quot;&gt;푸시 발송&lt;/span&gt;" vertex="1">
+          <mxGeometry height="60" width="160" x="1080" y="90" as="geometry" />
+        </mxCell>
+        <mxCell id="trv-client-line" edge="1" parent="1" style="html=1;endArrow=none;dashed=1;strokeColor=#94A3B8;strokeWidth=2;" value="">
           <mxGeometry relative="1" as="geometry">
-            <mxPoint y="-18" as="offset" />
+            <mxPoint x="135" y="150" as="sourcePoint" />
+            <mxPoint x="135" y="515" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="trv-edge-queue-sender" edge="1" parent="1" source="trv-queue" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0891B2;strokeWidth=3;labelBackgroundColor=#FFFFFF;fontSize=12;" target="trv-sender" value="발송 요청">
+        <mxCell id="trv-firestore-line" edge="1" parent="1" style="html=1;endArrow=none;dashed=1;strokeColor=#94A3B8;strokeWidth=2;" value="">
           <mxGeometry relative="1" as="geometry">
-            <mxPoint y="-16" as="offset" />
+            <mxPoint x="340" y="150" as="sourcePoint" />
+            <mxPoint x="340" y="515" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="trv-edge-sender-fcm" edge="1" parent="1" source="trv-sender" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#16A34A;strokeWidth=3;labelBackgroundColor=#FFFFFF;fontSize=12;exitX=1;exitY=0.25;exitDx=0;exitDy=0;entryX=0;entryY=0.75;entryDx=0;entryDy=0;" target="trv-fcm" value="조건 일치">
-          <mxGeometry relative="1" x="-0.2753" y="19" as="geometry">
+        <mxCell id="trv-batch-line" edge="1" parent="1" style="html=1;endArrow=none;dashed=1;strokeColor=#94A3B8;strokeWidth=2;" value="">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="545" y="150" as="sourcePoint" />
+            <mxPoint x="545" y="515" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="trv-queue-line" edge="1" parent="1" style="html=1;endArrow=none;dashed=1;strokeColor=#94A3B8;strokeWidth=2;" value="">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="750" y="150" as="sourcePoint" />
+            <mxPoint x="750" y="515" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="trv-sender-line" edge="1" parent="1" style="html=1;endArrow=none;dashed=1;strokeColor=#94A3B8;strokeWidth=2;" value="">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="955" y="150" as="sourcePoint" />
+            <mxPoint x="955" y="515" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="trv-fcm-line" edge="1" parent="1" style="html=1;endArrow=none;dashed=1;strokeColor=#94A3B8;strokeWidth=2;" value="">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="1160" y="150" as="sourcePoint" />
+            <mxPoint x="1160" y="515" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="trv-save-setting" edge="1" parent="1" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0A84FF;strokeWidth=3;labelBackgroundColor=#FFFFFF;fontSize=12;" value="시간대, 알림 설정 저장">
+          <mxGeometry relative="1" as="geometry">
             <mxPoint as="offset" />
+            <mxPoint x="135" y="210" as="sourcePoint" />
+            <mxPoint x="340" y="210" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="trv-edge-sender-cancel" edge="1" parent="1" source="trv-sender" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#EF4444;strokeWidth=3;labelBackgroundColor=#FFFFFF;fontSize=12;exitX=1;exitY=0.75;exitDx=0;exitDy=0;entryX=0;entryY=0.25;entryDx=0;entryDy=0;" target="trv-cancel" value="조건 불일치">
-          <mxGeometry relative="1" x="-0.2503" y="-23" as="geometry">
+        <mxCell id="trv-read-state" edge="1" parent="1" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#64748B;strokeWidth=3;labelBackgroundColor=#FFFFFF;fontSize=12;" value="최신 설정, Todo 조회">
+          <mxGeometry relative="1" as="geometry">
             <mxPoint as="offset" />
+            <mxPoint x="545" y="270" as="sourcePoint" />
+            <mxPoint x="340" y="270" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="trv-app" link="https://github.com/opficdev/SwiftUI_DevLog/blob/main/DevLog/App/Handler/UserTimeZoneSyncHandler.swift" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#EAF2FF;strokeColor=#0A84FF;strokeWidth=2;fontColor=#0B1F33;fontSize=13;align=center;" value="&lt;b&gt;iOS Client&lt;/b&gt;" vertex="1">
-          <mxGeometry height="70" width="200" x="60" y="110" as="geometry" />
+        <mxCell id="trv-enqueue" edge="1" parent="1" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0891B2;strokeWidth=3;labelBackgroundColor=#FFFFFF;fontSize=12;" value="대상 재계산, 작업 적재">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint as="offset" />
+            <mxPoint x="545" y="330" as="sourcePoint" />
+            <mxPoint x="750" y="330" as="targetPoint" />
+          </mxGeometry>
         </mxCell>
-        <mxCell id="trv-server-state" link="https://github.com/opficdev/SwiftUI_DevLog/blob/main/Firebase/functions/src/common/firestorePath.ts" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#64748B;strokeWidth=2;fontColor=#1F2328;fontSize=13;align=center;" value="&lt;b&gt;Firestore 설정·Todo&lt;/b&gt;&lt;br&gt;&lt;span style=&quot;font-weight: normal;&quot;&gt;최신 발송 기준 보관&lt;/span&gt;" vertex="1">
-          <mxGeometry height="70" width="200" x="390" y="110" as="geometry" />
+        <mxCell id="trv-dispatch" edge="1" parent="1" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0891B2;strokeWidth=3;labelBackgroundColor=#FFFFFF;fontSize=12;" value="발송 시점 도달">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint as="offset" />
+            <mxPoint x="750" y="380" as="sourcePoint" />
+            <mxPoint x="955" y="380" as="targetPoint" />
+          </mxGeometry>
         </mxCell>
-        <mxCell id="trv-batch" link="https://github.com/opficdev/SwiftUI_DevLog/blob/main/Firebase/functions/src/fcm/schedule.ts" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#64748B;strokeWidth=2;fontColor=#1F2328;fontSize=13;align=center;" value="&lt;b&gt;리마인더 배치&lt;/b&gt;&lt;br&gt;&lt;span style=&quot;font-weight: normal;&quot;&gt;Timezone 기준 대상 재계산&lt;/span&gt;" vertex="1">
-          <mxGeometry height="70" width="200" x="720" y="110" as="geometry" />
+        <mxCell id="trv-validate" edge="1" parent="1" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#16A34A;strokeWidth=3;labelBackgroundColor=#FFFFFF;fontSize=12;" value="발송 시점 재검증">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint as="offset" />
+            <mxPoint x="955" y="430" as="sourcePoint" />
+            <mxPoint x="340" y="430" as="targetPoint" />
+          </mxGeometry>
         </mxCell>
-        <mxCell id="trv-queue" link="https://github.com/opficdev/SwiftUI_DevLog/blob/main/Firebase/functions/src/fcm/schedule.ts" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#ECFEFF;strokeColor=#0891B2;strokeWidth=2;fontColor=#164E63;fontSize=13;align=center;" value="&lt;b&gt;Cloud Tasks&lt;/b&gt;&lt;br&gt;&lt;span style=&quot;font-weight: normal;&quot;&gt;Todo 식별자·마감일 기준 보관&lt;/span&gt;" vertex="1">
-          <mxGeometry height="70" width="200" x="60" y="350" as="geometry" />
+        <mxCell id="trv-send" edge="1" parent="1" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#16A34A;strokeWidth=3;labelBackgroundColor=#FFFFFF;fontSize=12;" value="조건 일치 시 발송">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint as="offset" />
+            <mxPoint x="955" y="480" as="sourcePoint" />
+            <mxPoint x="1160" y="480" as="targetPoint" />
+          </mxGeometry>
         </mxCell>
-        <mxCell id="trv-sender" link="https://github.com/opficdev/SwiftUI_DevLog/blob/main/Firebase/functions/src/fcm/notification.ts" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#DCFCE7;strokeColor=#16A34A;strokeWidth=2;fontColor=#14532D;fontSize=13;align=center;" value="&lt;b&gt;알림 발송 처리&lt;/b&gt;&lt;br&gt;&lt;span style=&quot;font-weight: normal;&quot;&gt;최신 설정·Todo 재검증 후 발송/중단&lt;/span&gt;" vertex="1">
-          <mxGeometry height="70" width="200" x="390" y="350" as="geometry" />
-        </mxCell>
-        <mxCell id="Xp06P4H-ANORCYlnH8vk-1" connectable="0" parent="1" style="group" value="" vertex="1">
-          <mxGeometry height="240" width="200" x="720" y="260" as="geometry" />
-        </mxCell>
-        <mxCell id="trv-fcm" link="https://github.com/opficdev/SwiftUI_DevLog/blob/main/Firebase/functions/src/fcm/notification.ts" parent="Xp06P4H-ANORCYlnH8vk-1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#F5F3FF;strokeColor=#7C3AED;strokeWidth=2;fontColor=#1F2328;fontSize=13;align=center;" value="&lt;b&gt;FCM&lt;/b&gt;&lt;br&gt;&lt;span style=&quot;font-weight: normal;&quot;&gt;검증된 푸시 발송&lt;/span&gt;" vertex="1">
-          <mxGeometry height="70" width="200" as="geometry" />
-        </mxCell>
-        <mxCell id="trv-cancel" parent="Xp06P4H-ANORCYlnH8vk-1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#FEF2F2;strokeColor=#EF4444;strokeWidth=2;fontColor=#7F1D1D;fontSize=13;align=center;" value="&lt;b&gt;발송 중단&lt;/b&gt;&lt;br&gt;&lt;span style=&quot;font-weight: normal;&quot;&gt;조건 불일치 알림 차단&lt;/span&gt;" vertex="1">
-          <mxGeometry height="70" width="200" y="170" as="geometry" />
+        <mxCell id="trv-legend" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#D8E0EA;strokeWidth=2;fontColor=#334155;fontSize=12;align=left;spacingLeft=14;" value="&lt;b&gt;화살표 의미&lt;/b&gt;&lt;br&gt;&lt;font color=&quot;#0A84FF&quot;&gt;■&lt;/font&gt; 설정 저장&lt;br&gt;&lt;font color=&quot;#64748B&quot;&gt;■&lt;/font&gt; 최신 기준 조회&lt;div&gt;&lt;font color=&quot;#0891B2&quot;&gt;■&lt;/font&gt; 재계산·큐 적재&lt;br&gt;&lt;font color=&quot;#16A34A&quot;&gt;■&lt;/font&gt; 발송 전 검증·발송&lt;/div&gt;" vertex="1">
+          <mxGeometry height="100" width="135" x="1092.5" y="170" as="geometry" />
         </mxCell>
       </root>
     </mxGraphModel>
   </diagram>
   <diagram id="webpage-image-restore-page" name="WebPage Image Restore Flow">
-    <mxGraphModel grid="1" page="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" pageScale="1" pageWidth="1280" pageHeight="600" background="#ffffff" math="0" shadow="0">
+    <mxGraphModel dx="1414" dy="850" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1280" pageHeight="600" background="#ffffff" math="0" shadow="0">
       <root>
         <mxCell id="0" />
         <mxCell id="1" parent="0" />
-        <mxCell id="web-img-edge-fetch-read" edge="1" parent="1" source="web-img-fetch" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=0;strokeColor=#0A84FF;strokeWidth=3;labelBackgroundColor=#FFFFFF;fontSize=12;fontColor=#334155;" target="web-img-firestore-read" value="저장 데이터 조회">
+        <mxCell id="web-img-fetch" link="https://github.com/opficdev/SwiftUI_DevLog/blob/main/Application/DevLogData/Sources/Repository/WebPageRepositoryImpl.swift" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#EAF2FF;strokeColor=#0A84FF;strokeWidth=2;fontColor=#0B1F33;fontSize=13;align=center;" value="&lt;b&gt;WebPage Fetch&lt;/b&gt;&lt;br&gt;&lt;span style=&quot;font-weight: normal;&quot;&gt;목록 조회&lt;/span&gt;" vertex="1">
+          <mxGeometry height="60" width="170" x="70" y="90" as="geometry" />
+        </mxCell>
+        <mxCell id="web-img-firestore" link="https://github.com/opficdev/SwiftUI_DevLog/blob/main/Application/DevLogInfra/Sources/Service/WebPageServiceImpl.swift" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#64748B;strokeWidth=2;fontColor=#1F2328;fontSize=13;align=center;" value="&lt;b&gt;Firestore&lt;/b&gt;&lt;br&gt;&lt;span style=&quot;font-weight: normal;&quot;&gt;WebPage, imageURL&lt;/span&gt;" vertex="1">
+          <mxGeometry height="60" width="170" x="300" y="90" as="geometry" />
+        </mxCell>
+        <mxCell id="web-img-cache" link="https://github.com/opficdev/SwiftUI_DevLog/blob/main/Application/DevLogPersistence/Sources/Persistence/WebPageImageStoreImpl.swift" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#ECFEFF;strokeColor=#0891B2;strokeWidth=2;fontColor=#0E3B43;fontSize=13;align=center;" value="&lt;b&gt;Local Cache&lt;/b&gt;&lt;br&gt;&lt;span style=&quot;font-weight: normal;&quot;&gt;경로, 이미지 검증&lt;/span&gt;" vertex="1">
+          <mxGeometry height="60" width="170" x="530" y="90" as="geometry" />
+        </mxCell>
+        <mxCell id="web-img-metadata" link="https://github.com/opficdev/SwiftUI_DevLog/blob/main/Application/DevLogInfra/Sources/Service/WebPageMetadataServiceImpl.swift" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#DCFCE7;strokeColor=#16A34A;strokeWidth=2;fontColor=#14532D;fontSize=13;align=center;" value="&lt;b&gt;Metadata Fetch&lt;/b&gt;&lt;br&gt;&lt;span style=&quot;font-weight: normal;&quot;&gt;썸네일 복구&lt;/span&gt;" vertex="1">
+          <mxGeometry height="60" width="170" x="760" y="90" as="geometry" />
+        </mxCell>
+        <mxCell id="web-img-result" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#F5F3FF;strokeColor=#7C3AED;strokeWidth=2;fontColor=#2E1065;fontSize=13;align=center;" value="&lt;b&gt;WebPage List&lt;/b&gt;&lt;br&gt;&lt;span style=&quot;font-weight: normal;&quot;&gt;복구 결과 반환&lt;/span&gt;" vertex="1">
+          <mxGeometry height="60" width="170" x="990" y="90" as="geometry" />
+        </mxCell>
+        <mxCell id="web-img-fetch-line" edge="1" parent="1" style="html=1;endArrow=none;dashed=1;strokeColor=#94A3B8;strokeWidth=2;" value="">
           <mxGeometry relative="1" as="geometry">
-            <mxPoint y="-14" as="offset" />
+            <mxPoint x="155" y="150" as="sourcePoint" />
+            <mxPoint x="155" y="515" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="web-img-edge-read-check" edge="1" parent="1" source="web-img-firestore-read" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=0;strokeColor=#64748B;strokeWidth=3;labelBackgroundColor=#FFFFFF;fontSize=12;fontColor=#334155;" target="web-img-cache-check" value="imageURL 확인">
+        <mxCell id="web-img-firestore-line" edge="1" parent="1" style="html=1;endArrow=none;dashed=1;strokeColor=#94A3B8;strokeWidth=2;" value="">
           <mxGeometry relative="1" as="geometry">
-            <mxPoint y="-14" as="offset" />
+            <mxPoint x="385" y="150" as="sourcePoint" />
+            <mxPoint x="385" y="515" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="web-img-edge-check-restore" edge="1" parent="1" source="web-img-cache-check" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=0;strokeColor=#0891B2;strokeWidth=3;labelBackgroundColor=#FFFFFF;fontSize=12;fontColor=#0E3B43;exitX=0;exitY=0.75;exitDx=0;exitDy=0;entryX=0.991;entryY=0.008;entryDx=0;entryDy=0;entryPerimeter=0;" target="web-img-restore" value="캐시 유실 감지">
-          <mxGeometry relative="1" x="-0.0139" y="-26" as="geometry">
+        <mxCell id="web-img-cache-line" edge="1" parent="1" style="html=1;endArrow=none;dashed=1;strokeColor=#94A3B8;strokeWidth=2;" value="">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="615" y="150" as="sourcePoint" />
+            <mxPoint x="615" y="515" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="web-img-metadata-line" edge="1" parent="1" style="html=1;endArrow=none;dashed=1;strokeColor=#94A3B8;strokeWidth=2;" value="">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="845" y="150" as="sourcePoint" />
+            <mxPoint x="845" y="515" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="web-img-result-line" edge="1" parent="1" style="html=1;endArrow=none;dashed=1;strokeColor=#94A3B8;strokeWidth=2;" value="">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="1075" y="150" as="sourcePoint" />
+            <mxPoint x="1075" y="515" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="web-img-read" edge="1" parent="1" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0A84FF;strokeWidth=3;labelBackgroundColor=#FFFFFF;fontSize=12;" value="저장된 WebPage 조회">
+          <mxGeometry relative="1" as="geometry">
             <mxPoint as="offset" />
+            <mxPoint x="155" y="210" as="sourcePoint" />
+            <mxPoint x="385" y="210" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="web-img-edge-restore-update" edge="1" parent="1" source="web-img-restore" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=0;strokeColor=#16A34A;strokeWidth=3;labelBackgroundColor=#FFFFFF;fontSize=12;fontColor=#14532D;" target="web-img-firestore-update" value="복구된 imageURL">
+        <mxCell id="web-img-check" edge="1" parent="1" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#0891B2;strokeWidth=3;labelBackgroundColor=#FFFFFF;fontSize=12;" value="로컬 file URL 검증">
           <mxGeometry relative="1" as="geometry">
-            <mxPoint y="-14" as="offset" />
+            <mxPoint as="offset" />
+            <mxPoint x="385" y="280" as="sourcePoint" />
+            <mxPoint x="615" y="280" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="web-img-edge-update-ui" edge="1" parent="1" source="web-img-firestore-update" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=0;strokeColor=#64748B;strokeWidth=3;labelBackgroundColor=#FFFFFF;fontSize=12;fontColor=#334155;" target="web-img-ui" value="복구 결과 반환">
+        <mxCell id="web-img-restore" edge="1" parent="1" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#16A34A;strokeWidth=3;labelBackgroundColor=#FFFFFF;fontSize=12;" value="검증 실패 시 재수집">
           <mxGeometry relative="1" as="geometry">
-            <mxPoint y="-14" as="offset" />
+            <mxPoint as="offset" />
+            <mxPoint x="615" y="350" as="sourcePoint" />
+            <mxPoint x="845" y="350" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="web-img-fetch" link="https://github.com/opficdev/SwiftUI_DevLog/blob/main/DevLog/Data/Repository/WebPageRepositoryImpl.swift" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#EAF2FF;strokeColor=#0A84FF;strokeWidth=2;fontColor=#0B1F33;fontStyle=1;fontSize=15;" value="&lt;b&gt;웹페이지 fetch&lt;/b&gt;&lt;div&gt;&lt;span style=&quot;font-size:12px;font-weight:400;&quot;&gt;저장된 WebPage 조회&lt;/span&gt;&lt;/div&gt;" vertex="1">
-          <mxGeometry height="70" width="200" x="60" y="110" as="geometry" />
+        <mxCell id="web-img-update" edge="1" parent="1" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#16A34A;strokeWidth=3;labelBackgroundColor=#FFFFFF;fontSize=12;" value="복구된 imageURL 갱신">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint as="offset" />
+            <mxPoint x="845" y="410" as="sourcePoint" />
+            <mxPoint x="385" y="410" as="targetPoint" />
+          </mxGeometry>
         </mxCell>
-        <mxCell id="web-img-firestore-read" link="https://github.com/opficdev/SwiftUI_DevLog/blob/main/DevLog/Infra/Service/WebPageService.swift" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#64748B;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=15;" value="&lt;b&gt;Firestore WebPage&lt;/b&gt;&lt;div&gt;&lt;span style=&quot;font-size:12px;font-weight:400;&quot;&gt;imageURL·메타데이터 보관&lt;/span&gt;&lt;/div&gt;" vertex="1">
-          <mxGeometry height="70" width="200" x="405" y="110" as="geometry" />
+        <mxCell id="web-img-return" edge="1" parent="1" style="endArrow=blockThin;endFill=1;endSize=16;html=1;rounded=1;strokeColor=#7C3AED;strokeWidth=3;labelBackgroundColor=#FFFFFF;fontSize=12;" value="복구 결과 또는 이미지 없는 항목 반환">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint as="offset" />
+            <mxPoint x="155" y="480" as="sourcePoint" />
+            <mxPoint x="1075" y="480" as="targetPoint" />
+          </mxGeometry>
         </mxCell>
-        <mxCell id="web-img-cache-check" link="https://github.com/opficdev/SwiftUI_DevLog/blob/main/DevLog/Data/Repository/WebPageRepositoryImpl.swift" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#ECFEFF;strokeColor=#0891B2;strokeWidth=2;fontColor=#0E3B43;fontStyle=1;fontSize=15;" value="&lt;b&gt;로컬 캐시 검증&lt;/b&gt;&lt;div&gt;&lt;span style=&quot;font-size:12px;font-weight:400;&quot;&gt;파일 경로·이미지 데이터 확인&lt;/span&gt;&lt;/div&gt;" vertex="1">
-          <mxGeometry height="70" width="200" x="780" y="110" as="geometry" />
-        </mxCell>
-        <mxCell id="web-img-restore" link="https://github.com/opficdev/SwiftUI_DevLog/blob/main/DevLog/Infra/Service/WebPageMetadataService.swift" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#DCFCE7;strokeColor=#16A34A;strokeWidth=2;fontColor=#14532D;fontStyle=1;fontSize=15;" value="&lt;b&gt;메타데이터 복구&lt;/b&gt;&lt;div&gt;&lt;span style=&quot;font-size:12px;font-weight:400;&quot;&gt;썸네일 재수집·캐시 재생성&lt;/span&gt;&lt;/div&gt;" vertex="1">
-          <mxGeometry height="70" width="200" x="60" y="350" as="geometry" />
-        </mxCell>
-        <mxCell id="web-img-firestore-update" link="https://github.com/opficdev/SwiftUI_DevLog/blob/main/DevLog/Infra/Service/WebPageService.swift" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#64748B;strokeWidth=2;fontColor=#1F2328;fontStyle=1;fontSize=15;" value="&lt;b&gt;Firestore 갱신&lt;/b&gt;&lt;div&gt;&lt;span style=&quot;font-size:12px;font-weight:400;&quot;&gt;복구된 imageURL 저장&lt;/span&gt;&lt;/div&gt;" vertex="1">
-          <mxGeometry height="70" width="200" x="405" y="350" as="geometry" />
-        </mxCell>
-        <mxCell id="web-img-ui" parent="1" style="rounded=1;arcSize=14;whiteSpace=wrap;html=1;fillColor=#F5F3FF;strokeColor=#7C3AED;strokeWidth=2;fontColor=#2E1065;fontStyle=1;fontSize=15;" value="&lt;b&gt;웹페이지 리스트 UI&lt;/b&gt;&lt;div&gt;&lt;span style=&quot;font-size:12px;font-weight:400;&quot;&gt;복구 결과 기준 표시&lt;/span&gt;&lt;/div&gt;" vertex="1">
-          <mxGeometry height="70" width="200" x="780" y="350" as="geometry" />
+        <mxCell id="web-img-legend" parent="1" style="rounded=1;arcSize=18;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#D8E0EA;strokeWidth=2;fontColor=#334155;fontSize=12;align=left;spacingLeft=14;" value="&lt;b&gt;화살표 의미&lt;/b&gt;&lt;br&gt;&lt;font color=&quot;#0A84FF&quot;&gt;■&lt;/font&gt; WebPage 목록 조회&lt;br&gt;&lt;font color=&quot;#0891B2&quot;&gt;■&lt;/font&gt; 이미지 URL 검증&lt;br&gt;&lt;font color=&quot;#16A34A&quot;&gt;■&lt;/font&gt; 이미지 복구·문서 갱신&lt;br&gt;&lt;font color=&quot;#7C3AED&quot;&gt;■&lt;/font&gt; 복구 결과 반환" vertex="1">
+          <mxGeometry height="100" width="150" x="1000" y="170" as="geometry" />
         </mxCell>
       </root>
     </mxGraphModel>


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #487

## 🎯 의도

- Profile 탭의 데이터 로드 시점을 다른 탭 화면과 동일하게 탭 선택 상태 기준으로 맞추기 위함  
- 화면 재렌더링 시점의 불필요한 fetch를 줄이고, 액션 이름의 의미를 실제 동작과 일치

## 📝 작업 내용

### 📌 요약

- Profile 탭의 초기/재진입 데이터 로드 트리거를 `onAppear`에서 `MainView`의 탭 선택 변경 시점으로 이동
- `ProfileViewModel`의 루트 진입 액션명을 `onAppear`에서 `fetchData`로 변경
- 변경된 Home 액션명에 맞춰 테스트 코드 수정
- `Localizable.xcstrings` 추출 상태 메타데이터 동기화
- `docs/DevLog.drawio` 시퀀스 다이어그램 수정

### 🔍 상세

- `MainView`에서 `selectedTab` 변경 시 `.profile` 선택에 대해 `profileViewCoordinator.fetchData()` 호출 추가
- `ProfileView`의 `.onAppear { coordinator.viewModel.send(...) }` 제거
- `ProfileViewCoordinator.fetchData()` 추가 및 내부 호출을 `viewModel.send(.fetchData)`로 정리
- `ProfileViewModel.Action`의 `onAppear`를 `fetchData`로 변경하고 reducer 분기명 정리
- `DeleteWebPageTests`에서 변경된 `HomeViewModel` 액션명(`.fetchData`) 반영
- `Localizable.xcstrings`의 키 재정렬 및 `extractionState` 메타데이터 갱신 반영

## 📸 영상 / 이미지 (Optional)

<table>
<tr>
<td align="center">

https://github.com/user-attachments/assets/48a8241f-118a-4ba4-92f9-63aef715549c

<td align="center">

https://github.com/user-attachments/assets/f4c335ac-baab-4f5b-bef6-7750e6def55c

</tr>
<tr>
<td align="center">개선 전
<td align="center">개선 후
</tr>
</table>