### PR TITLE
[#489] TodoList, TodoDetail, TodoEditor 플로우에 사용되는 뷰모델의 생성주기를 개선한다

### DIFF
--- a/Application/DevLogPresentation/DevLogPresentation.xcodeproj/project.pbxproj
+++ b/Application/DevLogPresentation/DevLogPresentation.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 70;
+	objectVersion = 71;
 	objects = {
 
 /* Begin PBXBuildFile section */

--- a/Application/DevLogPresentation/Sources/Home/TodoSceneCoordinator.swift
+++ b/Application/DevLogPresentation/Sources/Home/TodoSceneCoordinator.swift
@@ -1,0 +1,64 @@
+//
+//  TodoSceneCoordinator.swift
+//  DevLogPresentation
+//
+//  Created by opfic on 5/31/26.
+//
+
+import Foundation
+import DevLogCore
+import DevLogDomain
+
+@MainActor
+@Observable
+final class TodoSceneCoordinator {
+    private let diContainer: DIContainer
+    @ObservationIgnored
+    private var listViewModel: TodoListViewModel?
+    @ObservationIgnored
+    private var detailViewModel: TodoDetailViewModel?
+
+    init(container: DIContainer) {
+        self.diContainer = container
+    }
+
+    func makeListViewModel(category: TodoCategory) -> TodoListViewModel {
+        if let listViewModel,
+           listViewModel.category == category {
+            return listViewModel
+        }
+
+        let listViewModel = TodoListViewModel(
+            fetchTodosUseCase: diContainer.resolve(FetchTodosUseCase.self),
+            fetchTodoByIdUseCase: diContainer.resolve(FetchTodoByIdUseCase.self),
+            upsertTodoUseCase: diContainer.resolve(UpsertTodoUseCase.self),
+            deleteTodoUseCase: diContainer.resolve(DeleteTodoUseCase.self),
+            undoDeleteTodoUseCase: diContainer.resolve(UndoDeleteTodoUseCase.self),
+            trackAnalyticsEventUseCase: diContainer.resolve(TrackAnalyticsEventUseCase.self),
+            category: category
+        )
+        self.listViewModel = listViewModel
+        return listViewModel
+    }
+
+    func makeDetailViewModel(
+        todoId: String,
+        showEditButton: Bool = true
+    ) -> TodoDetailViewModel {
+        if let detailViewModel,
+           detailViewModel.todoId == todoId,
+           detailViewModel.showEditButton == showEditButton {
+            return detailViewModel
+        }
+
+        let detailViewModel = TodoDetailViewModel(
+            fetchTodoUseCase: diContainer.resolve(FetchTodoByIdUseCase.self),
+            fetchReferenceItemsUseCase: diContainer.resolve(FetchReferenceItemsUseCase.self),
+            upsertUseCase: diContainer.resolve(UpsertTodoUseCase.self),
+            todoId: todoId,
+            showEditButton: showEditButton
+        )
+        self.detailViewModel = detailViewModel
+        return detailViewModel
+    }
+}

--- a/Application/DevLogPresentation/Sources/Home/TodoWindowCoordinator.swift
+++ b/Application/DevLogPresentation/Sources/Home/TodoWindowCoordinator.swift
@@ -1,5 +1,5 @@
 //
-//  TodoSceneCoordinator.swift
+//  TodoWindowCoordinator.swift
 //  DevLogPresentation
 //
 //  Created by opfic on 5/31/26.
@@ -11,7 +11,7 @@ import DevLogDomain
 
 @MainActor
 @Observable
-final class TodoSceneCoordinator {
+final class TodoWindowCoordinator {
     private let diContainer: DIContainer
     @ObservationIgnored
     private var listViewModel: TodoListViewModel?

--- a/Application/DevLogPresentation/Sources/Main/MainView.swift
+++ b/Application/DevLogPresentation/Sources/Main/MainView.swift
@@ -12,6 +12,7 @@ import DevLogDomain
 struct MainView: View {
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @State private var coordinator: MainViewCoordinator
+    @State private var todoSceneCoordinator: TodoSceneCoordinator
     @State private var homeViewCoordinator: HomeViewCoordinator
     @State private var todayViewCoordinator: TodayViewCoordinator
     @State private var pushNotificationListViewCoordinator: PushNotificationListViewCoordinator
@@ -23,6 +24,7 @@ struct MainView: View {
         selectedTab: Binding<MainTab?>
     ) {
         self._coordinator = State(initialValue: MainViewCoordinator(container: container))
+        self._todoSceneCoordinator = State(initialValue: TodoSceneCoordinator(container: container))
         self._homeViewCoordinator = State(initialValue: HomeViewCoordinator(container: container))
         self._todayViewCoordinator = State(initialValue: TodayViewCoordinator(container: container))
         self._pushNotificationListViewCoordinator = State(
@@ -254,11 +256,11 @@ struct MainView: View {
         switch homeRoute {
         case .category(let item):
             TodoListView(
-                viewModel: coordinator.todoListViewModel(category: item.todoCategory)
+                viewModel: todoSceneCoordinator.makeListViewModel(category: item.todoCategory)
             )
             .id(item.id)
         case .todo(let item):
-            TodoDetailView(viewModel: coordinator.todoDetailViewModel(todoId: item.id))
+            TodoDetailView(viewModel: todoSceneCoordinator.makeDetailViewModel(todoId: item.id))
             .id(item.id)
         case .webPage(let item):
             WebView(url: item.url)
@@ -321,7 +323,7 @@ struct MainView: View {
     private func todayDestinationView(_ todayRoute: TodayRoute) -> some View {
         switch todayRoute {
         case .todo(let item):
-            TodoDetailView(viewModel: coordinator.todoDetailViewModel(todoId: item.id))
+            TodoDetailView(viewModel: todoSceneCoordinator.makeDetailViewModel(todoId: item.id))
                 .id(item.id)
         }
     }

--- a/Application/DevLogPresentation/Sources/Main/MainView.swift
+++ b/Application/DevLogPresentation/Sources/Main/MainView.swift
@@ -45,11 +45,11 @@ struct MainView: View {
             }
         }
         .onAppear {
-            coordinator.mainViewModel.send(.onAppear)
+            coordinator.viewModel.send(.onAppear)
         }
         .onChange(of: selectedTab, initial: true) { _, newValue in
             guard let newValue else { return }
-            coordinator.mainViewModel.send(.selectedTabChanged(newValue))
+            coordinator.viewModel.send(.selectedTabChanged(newValue))
             if newValue == .home {
                 homeViewCoordinator.fetchData()
             } else if newValue == .today {
@@ -61,12 +61,12 @@ struct MainView: View {
             }
         }
         .alert(
-            coordinator.mainViewModel.state.alertTitle,
+            coordinator.viewModel.state.alertTitle,
             isPresented: mainAlertPresented
         ) {
             Button(String(localized: "common_close"), role: .cancel) { }
         } message: {
-            Text(coordinator.mainViewModel.state.alertMessage)
+            Text(coordinator.viewModel.state.alertMessage)
         }
     }
 
@@ -88,7 +88,7 @@ struct MainView: View {
                 .tabItem {
                     tabLabel(.notification)
                 }
-                .badge(coordinator.mainViewModel.state.unreadPushCount)
+                .badge(coordinator.viewModel.state.unreadPushCount)
                 .tag(MainTab.notification as MainTab?)
 
             profileView
@@ -191,7 +191,7 @@ struct MainView: View {
     private func sidebarRow(_ tab: MainTab) -> some View {
         if tab == .notification {
             tabLabel(tab)
-                .badge(coordinator.mainViewModel.state.unreadPushCount)
+                .badge(coordinator.viewModel.state.unreadPushCount)
                 .tag(tab)
         } else {
             tabLabel(tab)
@@ -347,8 +347,8 @@ private extension MainView {
 
     var mainAlertPresented: Binding<Bool> {
         Binding(
-            get: { coordinator.mainViewModel.state.showAlert },
-            set: { coordinator.mainViewModel.send(.setAlert($0)) }
+            get: { coordinator.viewModel.state.showAlert },
+            set: { coordinator.viewModel.send(.setAlert($0)) }
         )
     }
 

--- a/Application/DevLogPresentation/Sources/Main/MainView.swift
+++ b/Application/DevLogPresentation/Sources/Main/MainView.swift
@@ -12,7 +12,7 @@ import DevLogDomain
 struct MainView: View {
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @State private var coordinator: MainViewCoordinator
-    @State private var todoSceneCoordinator: TodoSceneCoordinator
+    @State private var todoWindowCoordinator: TodoWindowCoordinator
     @State private var homeViewCoordinator: HomeViewCoordinator
     @State private var todayViewCoordinator: TodayViewCoordinator
     @State private var pushNotificationListViewCoordinator: PushNotificationListViewCoordinator
@@ -24,7 +24,7 @@ struct MainView: View {
         selectedTab: Binding<MainTab?>
     ) {
         self._coordinator = State(initialValue: MainViewCoordinator(container: container))
-        self._todoSceneCoordinator = State(initialValue: TodoSceneCoordinator(container: container))
+        self._todoWindowCoordinator = State(initialValue: TodoWindowCoordinator(container: container))
         self._homeViewCoordinator = State(initialValue: HomeViewCoordinator(container: container))
         self._todayViewCoordinator = State(initialValue: TodayViewCoordinator(container: container))
         self._pushNotificationListViewCoordinator = State(
@@ -256,11 +256,11 @@ struct MainView: View {
         switch homeRoute {
         case .category(let item):
             TodoListView(
-                viewModel: todoSceneCoordinator.makeListViewModel(category: item.todoCategory)
+                viewModel: todoWindowCoordinator.makeListViewModel(category: item.todoCategory)
             )
             .id(item.id)
         case .todo(let item):
-            TodoDetailView(viewModel: todoSceneCoordinator.makeDetailViewModel(todoId: item.id))
+            TodoDetailView(viewModel: todoWindowCoordinator.makeDetailViewModel(todoId: item.id))
             .id(item.id)
         case .webPage(let item):
             WebView(url: item.url)
@@ -323,7 +323,7 @@ struct MainView: View {
     private func todayDestinationView(_ todayRoute: TodayRoute) -> some View {
         switch todayRoute {
         case .todo(let item):
-            TodoDetailView(viewModel: todoSceneCoordinator.makeDetailViewModel(todoId: item.id))
+            TodoDetailView(viewModel: todoWindowCoordinator.makeDetailViewModel(todoId: item.id))
                 .id(item.id)
         }
     }

--- a/Application/DevLogPresentation/Sources/Main/MainViewCoordinator.swift
+++ b/Application/DevLogPresentation/Sources/Main/MainViewCoordinator.swift
@@ -12,10 +12,10 @@ import DevLogDomain
 @MainActor
 @Observable
 final class MainViewCoordinator {
-    let mainViewModel: MainViewModel
+    let viewModel: MainViewModel
 
     init(container: DIContainer) {
-        self.mainViewModel = MainViewModel(
+        self.viewModel = MainViewModel(
             trackAnalyticsEventUseCase: container.resolve(TrackAnalyticsEventUseCase.self),
             unreadPushCountUseCase: container.resolve(ObserveUnreadPushCountUseCase.self)
         )

--- a/Application/DevLogPresentation/Sources/Main/MainViewCoordinator.swift
+++ b/Application/DevLogPresentation/Sources/Main/MainViewCoordinator.swift
@@ -13,57 +13,11 @@ import DevLogDomain
 @Observable
 final class MainViewCoordinator {
     let mainViewModel: MainViewModel
-    private let diContainer: DIContainer
-    @ObservationIgnored
-    private var todoListViewModel: TodoListViewModel?
-    @ObservationIgnored
-    private var todoDetailViewModel: TodoDetailViewModel?
 
     init(container: DIContainer) {
-        self.diContainer = container
         self.mainViewModel = MainViewModel(
             trackAnalyticsEventUseCase: container.resolve(TrackAnalyticsEventUseCase.self),
             unreadPushCountUseCase: container.resolve(ObserveUnreadPushCountUseCase.self)
         )
-    }
-
-    func todoListViewModel(category: TodoCategory) -> TodoListViewModel {
-        if let todoListViewModel,
-           todoListViewModel.category == category {
-            return todoListViewModel
-        }
-
-        let todoListViewModel = TodoListViewModel(
-            fetchTodosUseCase: diContainer.resolve(FetchTodosUseCase.self),
-            fetchTodoByIdUseCase: diContainer.resolve(FetchTodoByIdUseCase.self),
-            upsertTodoUseCase: diContainer.resolve(UpsertTodoUseCase.self),
-            deleteTodoUseCase: diContainer.resolve(DeleteTodoUseCase.self),
-            undoDeleteTodoUseCase: diContainer.resolve(UndoDeleteTodoUseCase.self),
-            trackAnalyticsEventUseCase: diContainer.resolve(TrackAnalyticsEventUseCase.self),
-            category: category
-        )
-        self.todoListViewModel = todoListViewModel
-        return todoListViewModel
-    }
-
-    func todoDetailViewModel(
-        todoId: String,
-        showEditButton: Bool = true
-    ) -> TodoDetailViewModel {
-        if let todoDetailViewModel,
-           todoDetailViewModel.todoId == todoId,
-           todoDetailViewModel.showEditButton == showEditButton {
-            return todoDetailViewModel
-        }
-
-        let todoDetailViewModel = TodoDetailViewModel(
-            fetchTodoUseCase: diContainer.resolve(FetchTodoByIdUseCase.self),
-            fetchReferenceItemsUseCase: diContainer.resolve(FetchReferenceItemsUseCase.self),
-            upsertUseCase: diContainer.resolve(UpsertTodoUseCase.self),
-            todoId: todoId,
-            showEditButton: showEditButton
-        )
-        self.todoDetailViewModel = todoDetailViewModel
-        return todoDetailViewModel
     }
 }


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #489 

## 🎯 의도
TodoList, TodoDetail 화면에서 사용되는 ViewModel 생성 책임이 MainViewCoordinator에 함께 묶여 있어 Main 화면 조정 책임과 Todo 화면 생명주기 책임이 섞여 있던 구조 정리

## 📝 작업 내용

### 📌 요약
- TodoListViewModel, TodoDetailViewModel 생성 책임을 TodoSceneCoordinator로 분리
- MainViewCoordinator는 MainViewModel만 소유하도록 역할 축소
- MainView에서 Todo 화면 진입 시 TodoSceneCoordinator를 통해 ViewModel 생성
- MainViewCoordinator의 주 ViewModel 프로퍼티명을 viewModel로 정리

### 🔍 상세
- TodoSceneCoordinator 추가
	- TodoListViewModel 생성 및 단일 캐시 관리
	- TodoDetailViewModel 생성 및 단일 캐시 관리
	- 이후 Todo 작성/수정 화면의 멀티 윈도우 Scene 확장 시 Todo 화면 생명주기를 이어서 관리할 수 있는 기반 마련
- MainViewCoordinator 정리
	- TodoListViewModel, TodoDetailViewModel 생성 로직 제거
	- MainViewModel 소유와 Main 탭 상태 처리 책임만 유지
	- mainViewModel 프로퍼티명을 viewModel로 변경
- MainView 연결 변경
	- Todo 카테고리 진입 시 TodoSceneCoordinator.makeListViewModel 사용
	- Todo 상세 진입 시 TodoSceneCoordinator.makeDetailViewModel 사용

## 📸 영상 / 이미지 (Optional)