### PR TITLE
[#440] 맥으로 Todo를 작성 혹은 수정 시 시트 대신 새 창이 뜨도록 수정한다

### DIFF
--- a/Application/DevLogApp/Sources/App/DevLogApp.swift
+++ b/Application/DevLogApp/Sources/App/DevLogApp.swift
@@ -38,5 +38,16 @@ struct DevLogApp: App {
                 container.resolve(WidgetSyncEventBus.self).publish(.syncRequested)
             }
         }
+        WindowGroup(id: TodoEditorWindowValue.sceneId, for: TodoEditorWindowValue.self) { value in
+            if let value = value.wrappedValue {
+                TodoEditorWindowView(value: value)
+                .autocorrectionDisabled()
+            } else {
+                ContentUnavailableView(
+                    String(localized: "todo_edit"),
+                    systemImage: "square.and.pencil"
+                )
+            }
+        }
     }
 }

--- a/Application/DevLogApp/Sources/App/DevLogApp.swift
+++ b/Application/DevLogApp/Sources/App/DevLogApp.swift
@@ -30,11 +30,11 @@ struct DevLogApp: App {
                 systemThemeUseCase: container.resolve(ObserveSystemThemeUseCase.self),
                 trackAnalyticsEventUseCase: container.resolve(TrackAnalyticsEventUseCase.self),
                 widgetURLTab: { MainTab(widgetURL: $0) },
+                windowEvent: windowEvent,
                 pushNotificationTodoIdPublisher: PushNotificationRoute.shared.observe(),
                 clearPushNotificationRoute: { PushNotificationRoute.shared.clear() }
             )
             .autocorrectionDisabled()
-            .environment(windowEvent)
             .onChange(of: scenePhase) { _, phase in
                 guard phase == .background else { return }
                 container.resolve(WidgetSyncEventBus.self).publish(.syncRequested)
@@ -42,9 +42,11 @@ struct DevLogApp: App {
         }
         WindowGroup(id: TodoEditorWindowValue.sceneId, for: TodoEditorWindowValue.self) { value in
             if let value = value.wrappedValue {
-                TodoEditorWindowView(value: value)
+                TodoEditorWindowView(
+                    value: value,
+                    windowEvent: windowEvent
+                )
                 .autocorrectionDisabled()
-                .environment(windowEvent)
             } else {
                 ContentUnavailableView(
                     String(localized: "todo_edit"),

--- a/Application/DevLogApp/Sources/App/DevLogApp.swift
+++ b/Application/DevLogApp/Sources/App/DevLogApp.swift
@@ -16,6 +16,7 @@ struct DevLogApp: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) var delegate
     @Environment(\.diContainer) var container: DIContainer
     @Environment(\.scenePhase) var scenePhase
+    @State private var windowEvent = TodoEditorWindowEvent()
 
     init() {
         AppAssembler().assemble(AppDIContainer.shared)
@@ -33,6 +34,7 @@ struct DevLogApp: App {
                 clearPushNotificationRoute: { PushNotificationRoute.shared.clear() }
             )
             .autocorrectionDisabled()
+            .environment(windowEvent)
             .onChange(of: scenePhase) { _, phase in
                 guard phase == .background else { return }
                 container.resolve(WidgetSyncEventBus.self).publish(.syncRequested)
@@ -42,6 +44,7 @@ struct DevLogApp: App {
             if let value = value.wrappedValue {
                 TodoEditorWindowView(value: value)
                 .autocorrectionDisabled()
+                .environment(windowEvent)
             } else {
                 ContentUnavailableView(
                     String(localized: "todo_edit"),

--- a/Application/DevLogPresentation/Sources/Extension/EnvironmentValues+.swift
+++ b/Application/DevLogPresentation/Sources/Extension/EnvironmentValues+.swift
@@ -21,6 +21,10 @@ extension EnvironmentValues {
         self[SceneHeightKey.self]
     }
 
+    var isiOSAppOnMac: Bool {
+        self[IOSAppOnMacKey.self]
+    }
+
     private struct SafeAreaInsetsKey: EnvironmentKey {
         static var defaultValue: EdgeInsets {
             guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
@@ -46,6 +50,12 @@ extension EnvironmentValues {
                 return UIScreen.main.bounds.height
             }
             return windowScene.screen.bounds.height
+        }
+    }
+
+    private struct IOSAppOnMacKey: EnvironmentKey {
+        static var defaultValue: Bool {
+            ProcessInfo.processInfo.isiOSAppOnMac
         }
     }
 }

--- a/Application/DevLogPresentation/Sources/Home/Home/HomeView.swift
+++ b/Application/DevLogPresentation/Sources/Home/Home/HomeView.swift
@@ -9,6 +9,8 @@ import SwiftUI
 import DevLogDomain
 
 struct HomeView: View {
+    @Environment(\.openWindow) private var openWindow
+    @Environment(\.isiOSAppOnMac) private var isiOSAppOnMac
     @ScaledMetric(relativeTo: .largeTitle) private var labelWidth = CGFloat(34)
     let coordinator: HomeViewCoordinator
     let isCompactLayout: Bool
@@ -86,6 +88,9 @@ struct HomeView: View {
             if coordinator.viewModel.state.isAppending {
                 LoadingView()
             }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .todoEditorDidSubmit)) { notification in
+            handleTodoEditorSubmit(notification)
         }
     }
 
@@ -314,7 +319,7 @@ struct HomeView: View {
                         ForEach(preferences, id: \.id) { item in
                             Button {
                                 DispatchQueue.main.async {
-                                    coordinator.viewModel.send(.tapTodoCategory(item.category))
+                                    openTodoEditor(for: item.category)
                                 }
                             } label: {
                                 labelImage(
@@ -382,6 +387,24 @@ struct HomeView: View {
         }
         .padding(.vertical, -6)
         .contentShape(.rect)
+    }
+
+    private func openTodoEditor(for todoCategory: TodoCategory) {
+        if isiOSAppOnMac {
+            coordinator.viewModel.send(.setPresentation(.contentPicker, false))
+            openWindow(
+                id: TodoEditorWindowValue.sceneId,
+                value: TodoEditorWindowValue(todoCategory: todoCategory, source: .home)
+            )
+        } else {
+            coordinator.viewModel.send(.tapTodoCategory(todoCategory))
+        }
+    }
+
+    private func handleTodoEditorSubmit(_ notification: Notification) {
+        guard let submit = notification.object as? TodoEditorWindowSubmit,
+              submit.value.matchesCreate(source: .home) else { return }
+        coordinator.viewModel.send(.addTodo(submit.todo))
     }
 
 }

--- a/Application/DevLogPresentation/Sources/Home/Home/HomeView.swift
+++ b/Application/DevLogPresentation/Sources/Home/Home/HomeView.swift
@@ -9,7 +9,6 @@ import SwiftUI
 import DevLogDomain
 
 struct HomeView: View {
-    @Environment(TodoEditorWindowEvent.self) private var windowEvent
     @Environment(\.openWindow) private var openWindow
     @Environment(\.isiOSAppOnMac) private var isiOSAppOnMac
     @ScaledMetric(relativeTo: .largeTitle) private var labelWidth = CGFloat(34)
@@ -88,9 +87,6 @@ struct HomeView: View {
             if coordinator.viewModel.state.isAppending {
                 LoadingView()
             }
-        }
-        .onChange(of: windowEvent.submitted) { _, submitted in
-            handleTodoEditorSubmit(submitted)
         }
     }
 
@@ -401,11 +397,6 @@ struct HomeView: View {
         } else {
             coordinator.viewModel.send(.tapTodoCategory(todoCategory))
         }
-    }
-
-    private func handleTodoEditorSubmit(_ submit: TodoEditorWindowSubmit?) {
-        guard let submit, submit.value.matchesCreate(source: .home) else { return }
-        coordinator.viewModel.send(.fetchData)
     }
 
 }

--- a/Application/DevLogPresentation/Sources/Home/Home/HomeView.swift
+++ b/Application/DevLogPresentation/Sources/Home/Home/HomeView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 import DevLogDomain
 
 struct HomeView: View {
+    @Environment(TodoEditorWindowEvent.self) private var windowEvent
     @Environment(\.openWindow) private var openWindow
     @Environment(\.isiOSAppOnMac) private var isiOSAppOnMac
     @ScaledMetric(relativeTo: .largeTitle) private var labelWidth = CGFloat(34)
@@ -89,8 +90,8 @@ struct HomeView: View {
                 LoadingView()
             }
         }
-        .onReceive(NotificationCenter.default.publisher(for: .todoEditorDidSubmit)) { notification in
-            handleTodoEditorSubmit(notification)
+        .onChange(of: windowEvent.submitted) { _, submitted in
+            handleTodoEditorSubmit(submitted)
         }
     }
 
@@ -401,8 +402,8 @@ struct HomeView: View {
         }
     }
 
-    private func handleTodoEditorSubmit(_ notification: Notification) {
-        guard let submit = notification.object as? TodoEditorWindowSubmit,
+    private func handleTodoEditorSubmit(_ submit: TodoEditorWindowSubmit?) {
+        guard let submit,
               submit.value.matchesCreate(source: .home) else { return }
         coordinator.viewModel.send(.addTodo(submit.todo))
     }

--- a/Application/DevLogPresentation/Sources/Home/Home/HomeView.swift
+++ b/Application/DevLogPresentation/Sources/Home/Home/HomeView.swift
@@ -51,8 +51,7 @@ struct HomeView: View {
         )) {
             if let selectedCategory = coordinator.viewModel.state.selectedTodoCategory {
                 TodoEditorView(
-                    viewModel: coordinator.makeTodoEditorViewModel(category: selectedCategory),
-                    onSubmit: { coordinator.viewModel.send(.addTodo($0)) }
+                    viewModel: coordinator.makeTodoEditorViewModel(category: selectedCategory)
                 )
             }
         }
@@ -405,9 +404,8 @@ struct HomeView: View {
     }
 
     private func handleTodoEditorSubmit(_ submit: TodoEditorWindowSubmit?) {
-        guard let submit,
-              submit.value.matchesCreate(source: .home) else { return }
-        coordinator.viewModel.send(.addTodo(submit.todo))
+        guard let submit, submit.value.matchesCreate(source: .home) else { return }
+        coordinator.viewModel.send(.fetchData)
     }
 
 }

--- a/Application/DevLogPresentation/Sources/Home/Home/HomeView.swift
+++ b/Application/DevLogPresentation/Sources/Home/Home/HomeView.swift
@@ -278,6 +278,7 @@ struct HomeView: View {
             } label: {
                 RecentTodoRow(todo: item)
                     .frame(maxWidth: .infinity, alignment: .leading)
+                    .contentShape(.rect)
             }
             .buttonStyle(.plain)
         }
@@ -296,6 +297,7 @@ struct HomeView: View {
                 } label: {
                     WebItemRow(item: item, showsChevron: false)
                         .frame(maxWidth: .infinity, alignment: .leading)
+                        .contentShape(.rect)
                 }
                 .buttonStyle(.plain)
             }

--- a/Application/DevLogPresentation/Sources/Home/Home/HomeViewCoordinator.swift
+++ b/Application/DevLogPresentation/Sources/Home/Home/HomeViewCoordinator.swift
@@ -24,7 +24,6 @@ final class HomeViewCoordinator {
             addWebPageUseCase: container.resolve(AddWebPageUseCase.self),
             deleteWebPageUseCase: container.resolve(DeleteWebPageUseCase.self),
             undoDeleteWebPageUseCase: container.resolve(UndoDeleteWebPageUseCase.self),
-            upsertTodoUseCase: container.resolve(UpsertTodoUseCase.self),
             fetchTodosUseCase: container.resolve(FetchTodosUseCase.self),
             fetchWebPagesUseCase: container.resolve(FetchWebPagesUseCase.self),
             networkConnectivityUseCase: container.resolve(ObserveNetworkConnectivityUseCase.self),
@@ -44,7 +43,13 @@ final class HomeViewCoordinator {
         TodoEditorViewModel(
             category: category,
             fetchPreferencesUseCase: diContainer.resolve(FetchTodoCategoryPreferencesUseCase.self),
-            fetchReferenceItemsUseCase: diContainer.resolve(FetchReferenceItemsUseCase.self)
+            fetchReferenceItemsUseCase: diContainer.resolve(FetchReferenceItemsUseCase.self),
+            upsertTodoUseCase: diContainer.resolve(UpsertTodoUseCase.self),
+            trackAnalyticsEventUseCase: diContainer.resolve(TrackAnalyticsEventUseCase.self),
+            onUpsertSuccess: { [weak self] _ in
+                self?.viewModel.send(.setPresentation(.todoEditor, false))
+                self?.viewModel.send(.fetchData)
+            }
         )
     }
 

--- a/Application/DevLogPresentation/Sources/Home/Home/HomeViewCoordinator.swift
+++ b/Application/DevLogPresentation/Sources/Home/Home/HomeViewCoordinator.swift
@@ -15,12 +15,12 @@ import DevLogDomain
 final class HomeViewCoordinator {
     let viewModel: HomeViewModel
     let router = NavigationRouter<HomeRoute>()
-    private let diContainer: DIContainer
+    private let container: DIContainer
     @ObservationIgnored
     private var cancellable: AnyCancellable?
 
     init(container: DIContainer) {
-        self.diContainer = container
+        self.container = container
         self.viewModel = HomeViewModel(
             fetchPreferencesUseCase: container.resolve(FetchTodoCategoryPreferencesUseCase.self),
             updatePreferencesUseCase: container.resolve(UpdateTodoCategoryPreferencesUseCase.self),
@@ -55,10 +55,10 @@ final class HomeViewCoordinator {
     func makeTodoEditorViewModel(category: TodoCategory) -> TodoEditorViewModel {
         TodoEditorViewModel(
             category: category,
-            fetchPreferencesUseCase: diContainer.resolve(FetchTodoCategoryPreferencesUseCase.self),
-            fetchReferenceItemsUseCase: diContainer.resolve(FetchReferenceItemsUseCase.self),
-            upsertTodoUseCase: diContainer.resolve(UpsertTodoUseCase.self),
-            trackAnalyticsEventUseCase: diContainer.resolve(TrackAnalyticsEventUseCase.self),
+            fetchPreferencesUseCase: container.resolve(FetchTodoCategoryPreferencesUseCase.self),
+            fetchReferenceItemsUseCase: container.resolve(FetchReferenceItemsUseCase.self),
+            upsertTodoUseCase: container.resolve(UpsertTodoUseCase.self),
+            trackAnalyticsEventUseCase: container.resolve(TrackAnalyticsEventUseCase.self),
             onUpsertSuccess: { [weak self] _ in
                 self?.viewModel.send(.setPresentation(.todoEditor, false))
                 self?.viewModel.send(.fetchData)
@@ -68,10 +68,10 @@ final class HomeViewCoordinator {
 
     func makeSearchViewModel() -> SearchViewModel {
         SearchViewModel(
-            fetchWebPagesUseCase: diContainer.resolve(FetchWebPagesUseCase.self),
-            fetchTodosUseCase: diContainer.resolve(FetchTodosUseCase.self),
-            fetchRecentSearchQueriesUseCase: diContainer.resolve(FetchRecentSearchQueriesUseCase.self),
-            updateRecentSearchQueriesUseCase: diContainer.resolve(UpdateRecentSearchQueriesUseCase.self)
+            fetchWebPagesUseCase: container.resolve(FetchWebPagesUseCase.self),
+            fetchTodosUseCase: container.resolve(FetchTodosUseCase.self),
+            fetchRecentSearchQueriesUseCase: container.resolve(FetchRecentSearchQueriesUseCase.self),
+            updateRecentSearchQueriesUseCase: container.resolve(UpdateRecentSearchQueriesUseCase.self)
         )
     }
 }

--- a/Application/DevLogPresentation/Sources/Home/Home/HomeViewCoordinator.swift
+++ b/Application/DevLogPresentation/Sources/Home/Home/HomeViewCoordinator.swift
@@ -14,33 +14,19 @@ import DevLogDomain
 final class HomeViewCoordinator {
     let viewModel: HomeViewModel
     let router = NavigationRouter<HomeRoute>()
-    private let fetchTodoCategoryPreferencesUseCase: FetchTodoCategoryPreferencesUseCase
-    private let fetchReferenceItemsUseCase: FetchReferenceItemsUseCase
-    private let fetchWebPagesUseCase: FetchWebPagesUseCase
-    private let fetchTodosUseCase: FetchTodosUseCase
-    private let fetchRecentSearchQueriesUseCase: FetchRecentSearchQueriesUseCase
-    private let updateRecentSearchQueriesUseCase: UpdateRecentSearchQueriesUseCase
+    private let diContainer: DIContainer
 
     init(container: DIContainer) {
-        let fetchTodoCategoryPreferencesUseCase = container.resolve(FetchTodoCategoryPreferencesUseCase.self)
-        let fetchWebPagesUseCase = container.resolve(FetchWebPagesUseCase.self)
-        let fetchTodosUseCase = container.resolve(FetchTodosUseCase.self)
-
-        self.fetchTodoCategoryPreferencesUseCase = fetchTodoCategoryPreferencesUseCase
-        self.fetchReferenceItemsUseCase = container.resolve(FetchReferenceItemsUseCase.self)
-        self.fetchWebPagesUseCase = fetchWebPagesUseCase
-        self.fetchTodosUseCase = fetchTodosUseCase
-        self.fetchRecentSearchQueriesUseCase = container.resolve(FetchRecentSearchQueriesUseCase.self)
-        self.updateRecentSearchQueriesUseCase = container.resolve(UpdateRecentSearchQueriesUseCase.self)
+        self.diContainer = container
         self.viewModel = HomeViewModel(
-            fetchPreferencesUseCase: fetchTodoCategoryPreferencesUseCase,
+            fetchPreferencesUseCase: container.resolve(FetchTodoCategoryPreferencesUseCase.self),
             updatePreferencesUseCase: container.resolve(UpdateTodoCategoryPreferencesUseCase.self),
             addWebPageUseCase: container.resolve(AddWebPageUseCase.self),
             deleteWebPageUseCase: container.resolve(DeleteWebPageUseCase.self),
             undoDeleteWebPageUseCase: container.resolve(UndoDeleteWebPageUseCase.self),
             upsertTodoUseCase: container.resolve(UpsertTodoUseCase.self),
-            fetchTodosUseCase: fetchTodosUseCase,
-            fetchWebPagesUseCase: fetchWebPagesUseCase,
+            fetchTodosUseCase: container.resolve(FetchTodosUseCase.self),
+            fetchWebPagesUseCase: container.resolve(FetchWebPagesUseCase.self),
             networkConnectivityUseCase: container.resolve(ObserveNetworkConnectivityUseCase.self),
             trackAnalyticsEventUseCase: container.resolve(TrackAnalyticsEventUseCase.self)
         )
@@ -57,17 +43,17 @@ final class HomeViewCoordinator {
     func makeTodoEditorViewModel(category: TodoCategory) -> TodoEditorViewModel {
         TodoEditorViewModel(
             category: category,
-            fetchPreferencesUseCase: fetchTodoCategoryPreferencesUseCase,
-            fetchReferenceItemsUseCase: fetchReferenceItemsUseCase
+            fetchPreferencesUseCase: diContainer.resolve(FetchTodoCategoryPreferencesUseCase.self),
+            fetchReferenceItemsUseCase: diContainer.resolve(FetchReferenceItemsUseCase.self)
         )
     }
 
     func makeSearchViewModel() -> SearchViewModel {
         SearchViewModel(
-            fetchWebPagesUseCase: fetchWebPagesUseCase,
-            fetchTodosUseCase: fetchTodosUseCase,
-            fetchRecentSearchQueriesUseCase: fetchRecentSearchQueriesUseCase,
-            updateRecentSearchQueriesUseCase: updateRecentSearchQueriesUseCase
+            fetchWebPagesUseCase: diContainer.resolve(FetchWebPagesUseCase.self),
+            fetchTodosUseCase: diContainer.resolve(FetchTodosUseCase.self),
+            fetchRecentSearchQueriesUseCase: diContainer.resolve(FetchRecentSearchQueriesUseCase.self),
+            updateRecentSearchQueriesUseCase: diContainer.resolve(UpdateRecentSearchQueriesUseCase.self)
         )
     }
 }

--- a/Application/DevLogPresentation/Sources/Home/Home/HomeViewCoordinator.swift
+++ b/Application/DevLogPresentation/Sources/Home/Home/HomeViewCoordinator.swift
@@ -5,6 +5,7 @@
 //  Created by opfic on 5/10/26.
 //
 
+import Combine
 import Foundation
 import DevLogCore
 import DevLogDomain
@@ -15,6 +16,8 @@ final class HomeViewCoordinator {
     let viewModel: HomeViewModel
     let router = NavigationRouter<HomeRoute>()
     private let diContainer: DIContainer
+    @ObservationIgnored
+    private var cancellable: AnyCancellable?
 
     init(container: DIContainer) {
         self.diContainer = container
@@ -33,6 +36,16 @@ final class HomeViewCoordinator {
 
     func fetchData() {
         viewModel.send(.fetchData)
+    }
+
+    func bindWindowEvent(_ windowEvent: TodoEditorWindowEvent) {
+        guard cancellable == nil else { return }
+
+        cancellable = windowEvent.submits
+            .sink { [weak self] submit in
+                guard submit.value.matchesCreate(source: .home) else { return }
+                self?.viewModel.send(.fetchData)
+            }
     }
 
     func makeTodoManageViewModel() -> TodoManageViewModel {

--- a/Application/DevLogPresentation/Sources/Home/Home/HomeViewModel.swift
+++ b/Application/DevLogPresentation/Sources/Home/Home/HomeViewModel.swift
@@ -50,7 +50,6 @@ final class HomeViewModel: Store {
         case tapTodoCategory(TodoCategory)
         case orderTodoCategory([TodoCategoryItem])
         case setTodoCategory([TodoCategoryItem])
-        case addTodo(Todo)
         case updateRecentTodos([RecentTodoItem])
         case updateWebPageURLInput(String)
         case addWebPage
@@ -60,7 +59,6 @@ final class HomeViewModel: Store {
     }
 
     enum SideEffect {
-        case addTodo(Todo)
         case addWebPage(String)
         case deleteWebPage(WebPageItem)
         case undoDeleteWebPage(String)
@@ -103,7 +101,6 @@ final class HomeViewModel: Store {
     private(set) var state = State()
     private let fetchPreferencesUseCase: FetchTodoCategoryPreferencesUseCase
     private let updatePreferencesUseCase: UpdateTodoCategoryPreferencesUseCase
-    private let upsertTodoUseCase: UpsertTodoUseCase
     private let addWebPageUseCase: AddWebPageUseCase
     private let deleteWebPageUseCase: DeleteWebPageUseCase
     private let undoDeleteWebPageUseCase: UndoDeleteWebPageUseCase
@@ -121,7 +118,6 @@ final class HomeViewModel: Store {
         addWebPageUseCase: AddWebPageUseCase,
         deleteWebPageUseCase: DeleteWebPageUseCase,
         undoDeleteWebPageUseCase: UndoDeleteWebPageUseCase,
-        upsertTodoUseCase: UpsertTodoUseCase,
         fetchTodosUseCase: FetchTodosUseCase,
         fetchWebPagesUseCase: FetchWebPagesUseCase,
         networkConnectivityUseCase: ObserveNetworkConnectivityUseCase,
@@ -132,7 +128,6 @@ final class HomeViewModel: Store {
         self.addWebPageUseCase = addWebPageUseCase
         self.deleteWebPageUseCase = deleteWebPageUseCase
         self.undoDeleteWebPageUseCase = undoDeleteWebPageUseCase
-        self.upsertTodoUseCase = upsertTodoUseCase
         self.fetchTodosUseCase = fetchTodosUseCase
         self.fetchWebPagesUseCase = fetchWebPagesUseCase
         self.networkConnectivityUseCase = networkConnectivityUseCase
@@ -149,7 +144,7 @@ final class HomeViewModel: Store {
         case .networkStatusChanged(let isConnected):
             state.isNetworkConnected = isConnected
         case .fetchData, .setPresentation, .setAlert, .setToast, .refreshWebPages,
-                .tapTodoCategory, .orderTodoCategory, .addTodo, .updateWebPageURLInput,
+                .tapTodoCategory, .orderTodoCategory, .updateWebPageURLInput,
                 .addWebPage, .deleteWebPage, .undoDeleteWebPage:
             effects = reduceByView(action, state: &state)
 
@@ -179,23 +174,6 @@ final class HomeViewModel: Store {
             Task {
                 do {
                     try await updatePreferencesUseCase.execute(items.map(\.preference))
-                } catch {
-                    send(.setAlert(isPresented: true, type: .error))
-                }
-            }
-        case .addTodo(let todo):
-            beginLoading(for: .overlay, mode: .delayed)
-            Task {
-                do {
-                    defer { endLoading(for: .overlay, mode: .delayed) }
-                    try await upsertTodoUseCase.execute(todo)
-                    trackAnalyticsEventUseCase.execute(.todoCreate)
-                    let page = try await fetchRecentTodos()
-                    let items = page.items
-                        .filter { $0.createdAt != $0.updatedAt }
-                        .prefix(5)
-                        .compactMap { RecentTodoItem(from: $0) }
-                    send(.updateRecentTodos(items))
                 } catch {
                     send(.setAlert(isPresented: true, type: .error))
                 }
@@ -305,8 +283,6 @@ private extension HomeViewModel {
             state.preferences = preferences
             state.recentTodos = syncRecentTodos(state.recentTodos, preferences: preferences)
             return [.updateTodoCategoryPreferences(preferences)]
-        case .addTodo(let todo):
-            return [.addTodo(todo)]
         case .updateWebPageURLInput(let text):
             state.webPageURLInput = text
         case .addWebPage:

--- a/Application/DevLogPresentation/Sources/Home/TodoDetailView.swift
+++ b/Application/DevLogPresentation/Sources/Home/TodoDetailView.swift
@@ -50,7 +50,6 @@ struct TodoDetailView: View {
                 TodoDetailView(viewModel: TodoDetailViewModel(
                     fetchTodoUseCase: container.resolve(FetchTodoByIdUseCase.self),
                     fetchReferenceItemsUseCase: container.resolve(FetchReferenceItemsUseCase.self),
-                    upsertUseCase: container.resolve(UpsertTodoUseCase.self),
                     todoId: item.id,
                     showEditButton: false
                 ))
@@ -72,9 +71,13 @@ struct TodoDetailView: View {
                     viewModel: TodoEditorViewModel(
                         todo: todo,
                         fetchPreferencesUseCase: container.resolve(FetchTodoCategoryPreferencesUseCase.self),
-                        fetchReferenceItemsUseCase: container.resolve(FetchReferenceItemsUseCase.self)
-                    ),
-                    onSubmit: { viewModel.send(.upsertTodo($0)) }
+                        fetchReferenceItemsUseCase: container.resolve(FetchReferenceItemsUseCase.self),
+                        upsertTodoUseCase: container.resolve(UpsertTodoUseCase.self),
+                        onUpsertSuccess: { todo in
+                            viewModel.send(.setShowEditor(false))
+                            viewModel.send(.setTodo(todo))
+                        }
+                    )
                 )
             }
         }
@@ -119,7 +122,7 @@ struct TodoDetailView: View {
     private func handleTodoEditorSubmit(_ submit: TodoEditorWindowSubmit?) {
         guard let submit,
               submit.value.matchesEdit(todoId: viewModel.todoId) else { return }
-        viewModel.send(.upsertTodo(submit.todo))
+        viewModel.send(.setTodo(submit.todo))
     }
 
     @ViewBuilder

--- a/Application/DevLogPresentation/Sources/Home/TodoDetailView.swift
+++ b/Application/DevLogPresentation/Sources/Home/TodoDetailView.swift
@@ -11,6 +11,7 @@ import DevLogDomain
 
 struct TodoDetailView: View {
     @Environment(\.diContainer) private var container: DIContainer
+    @Environment(TodoEditorWindowEvent.self) private var windowEvent
     @Environment(\.openWindow) private var openWindow
     @Environment(\.isiOSAppOnMac) private var isiOSAppOnMac
     @State var viewModel: TodoDetailViewModel
@@ -31,8 +32,8 @@ struct TodoDetailView: View {
             }
         }
         .onAppear { viewModel.send(.onAppear) }
-        .onReceive(NotificationCenter.default.publisher(for: .todoEditorDidSubmit)) { notification in
-            handleTodoEditorSubmit(notification)
+        .onChange(of: windowEvent.submitted) { _, submitted in
+            handleTodoEditorSubmit(submitted)
         }
         .navigationBarTitleDisplayMode(.inline)
         .sheet(isPresented: Binding(
@@ -115,8 +116,8 @@ struct TodoDetailView: View {
         }
     }
 
-    private func handleTodoEditorSubmit(_ notification: Notification) {
-        guard let submit = notification.object as? TodoEditorWindowSubmit,
+    private func handleTodoEditorSubmit(_ submit: TodoEditorWindowSubmit?) {
+        guard let submit,
               submit.value.matchesEdit(todoId: viewModel.todoId) else { return }
         viewModel.send(.upsertTodo(submit.todo))
     }

--- a/Application/DevLogPresentation/Sources/Home/TodoDetailView.swift
+++ b/Application/DevLogPresentation/Sources/Home/TodoDetailView.swift
@@ -11,7 +11,6 @@ import DevLogDomain
 
 struct TodoDetailView: View {
     @Environment(\.diContainer) private var container: DIContainer
-    @Environment(TodoEditorWindowEvent.self) private var windowEvent
     @Environment(\.openWindow) private var openWindow
     @Environment(\.isiOSAppOnMac) private var isiOSAppOnMac
     @State var viewModel: TodoDetailViewModel
@@ -32,9 +31,6 @@ struct TodoDetailView: View {
             }
         }
         .onAppear { viewModel.send(.onAppear) }
-        .onChange(of: windowEvent.submitted) { _, submitted in
-            handleTodoEditorSubmit(submitted)
-        }
         .navigationBarTitleDisplayMode(.inline)
         .sheet(isPresented: Binding(
             get: { viewModel.state.showInfo },
@@ -117,12 +113,6 @@ struct TodoDetailView: View {
         } else {
             viewModel.send(.setShowEditor(true))
         }
-    }
-
-    private func handleTodoEditorSubmit(_ submit: TodoEditorWindowSubmit?) {
-        guard let submit,
-              submit.value.matchesEdit(todoId: viewModel.todoId) else { return }
-        viewModel.send(.setTodo(submit.todo))
     }
 
     @ViewBuilder

--- a/Application/DevLogPresentation/Sources/Home/TodoDetailView.swift
+++ b/Application/DevLogPresentation/Sources/Home/TodoDetailView.swift
@@ -11,6 +11,8 @@ import DevLogDomain
 
 struct TodoDetailView: View {
     @Environment(\.diContainer) private var container: DIContainer
+    @Environment(\.openWindow) private var openWindow
+    @Environment(\.isiOSAppOnMac) private var isiOSAppOnMac
     @State var viewModel: TodoDetailViewModel
 
     var body: some View {
@@ -29,6 +31,9 @@ struct TodoDetailView: View {
             }
         }
         .onAppear { viewModel.send(.onAppear) }
+        .onReceive(NotificationCenter.default.publisher(for: .todoEditorDidSubmit)) { notification in
+            handleTodoEditorSubmit(notification)
+        }
         .navigationBarTitleDisplayMode(.inline)
         .sheet(isPresented: Binding(
             get: { viewModel.state.showInfo },
@@ -90,12 +95,30 @@ struct TodoDetailView: View {
             }
             ToolbarItem(placement: .topBarTrailing) {
                 Button {
-                    viewModel.send(.setShowEditor(true))
+                    openTodoEditor()
                 } label: {
                     Text(String(localized: "todo_edit"))
                 }
             }
         }
+    }
+
+    private func openTodoEditor() {
+        if isiOSAppOnMac {
+            guard let todo = viewModel.state.todo else { return }
+            openWindow(
+                id: TodoEditorWindowValue.sceneId,
+                value: TodoEditorWindowValue(todo: todo)
+            )
+        } else {
+            viewModel.send(.setShowEditor(true))
+        }
+    }
+
+    private func handleTodoEditorSubmit(_ notification: Notification) {
+        guard let submit = notification.object as? TodoEditorWindowSubmit,
+              submit.value.matchesEdit(todoId: viewModel.todoId) else { return }
+        viewModel.send(.upsertTodo(submit.todo))
     }
 
     @ViewBuilder

--- a/Application/DevLogPresentation/Sources/Home/TodoDetailViewModel.swift
+++ b/Application/DevLogPresentation/Sources/Home/TodoDetailViewModel.swift
@@ -31,13 +31,11 @@ final class TodoDetailViewModel: Store {
         case setTodo(Todo)
         case setReferenceItems([Int: TodoReferenceItem])
         case setLoading(Bool)
-        case upsertTodo(Todo)
     }
 
     enum SideEffect {
         case fetchTodo
         case resolveMarkdown(String)
-        case upsertTodo(Todo)
     }
 
     private(set) var state: State = .init()
@@ -45,19 +43,16 @@ final class TodoDetailViewModel: Store {
     let showEditButton: Bool
     private let fetchTodoUseCase: FetchTodoByIdUseCase
     private let fetchReferenceItemsUseCase: FetchReferenceItemsUseCase
-    private let upsertUseCase: UpsertTodoUseCase
     private let loadingState = LoadingState()
 
     init(
         fetchTodoUseCase: FetchTodoByIdUseCase,
         fetchReferenceItemsUseCase: FetchReferenceItemsUseCase,
-        upsertUseCase: UpsertTodoUseCase,
         todoId: String,
         showEditButton: Bool = true
     ) {
         self.fetchTodoUseCase = fetchTodoUseCase
         self.fetchReferenceItemsUseCase = fetchReferenceItemsUseCase
-        self.upsertUseCase = upsertUseCase
         self.todoId = todoId
         self.showEditButton = showEditButton
     }
@@ -85,8 +80,6 @@ final class TodoDetailViewModel: Store {
             state.referenceItems = items
         case .setLoading(let value):
             state.isLoading = value
-        case .upsertTodo(let todo):
-            effects = [.upsertTodo(todo)]
         }
 
         if self.state != state { self.state = state }
@@ -121,17 +114,6 @@ final class TodoDetailViewModel: Store {
                 }
 
                 send(.setReferenceItems(referenceItems))
-            }
-        case .upsertTodo(let todo):
-            beginLoading(.delayed)
-            Task {
-                do {
-                    defer { endLoading(.delayed) }
-                    try await upsertUseCase.execute(todo)
-                    send(.setTodo(todo))
-                } catch {
-                    send(.setAlert(true))
-                }
             }
         }
     }

--- a/Application/DevLogPresentation/Sources/Home/TodoEditorView.swift
+++ b/Application/DevLogPresentation/Sources/Home/TodoEditorView.swift
@@ -18,7 +18,6 @@ struct TodoEditorView: View {
     @Environment(\.isiOSAppOnMac) private var isiOSAppOnMac
     @FocusState private var field: Field?
     private let calendar = Calendar.current
-    var onSubmit: ((Todo) -> Void)?
     var onClose: (() -> Void)?
 
     var body: some View {
@@ -65,7 +64,6 @@ struct TodoEditorView: View {
                     TodoDetailView(viewModel: TodoDetailViewModel(
                         fetchTodoUseCase: container.resolve(FetchTodoByIdUseCase.self),
                         fetchReferenceItemsUseCase: container.resolve(FetchReferenceItemsUseCase.self),
-                        upsertUseCase: container.resolve(UpsertTodoUseCase.self),
                         todoId: item.id,
                         showEditButton: false
                     ))
@@ -92,7 +90,18 @@ struct TodoEditorView: View {
                 ToolbarTrailingButton {
                     submit()
                 }
-                .disabled(!viewModel.isReadyToSubmit)
+                .disabled(!viewModel.isReadyToSubmit || viewModel.state.isLoading)
+            }
+            .alert(
+                viewModel.state.alertTitle,
+                isPresented: Binding(
+                    get: { viewModel.state.showAlert },
+                    set: { viewModel.send(.setAlert($0)) }
+                )
+            ) {
+                Button(String(localized: "common_close"), role: .cancel) { }
+            } message: {
+                Text(viewModel.state.alertMessage)
             }
         }
     }
@@ -200,8 +209,7 @@ struct TodoEditorView: View {
 
     private func submit() {
         let todo = viewModel.makeTodo()
-        onSubmit?(todo)
-        close()
+        viewModel.send(.upsertTodo(todo))
     }
 
     private func close() {

--- a/Application/DevLogPresentation/Sources/Home/TodoEditorView.swift
+++ b/Application/DevLogPresentation/Sources/Home/TodoEditorView.swift
@@ -18,6 +18,7 @@ struct TodoEditorView: View {
     @FocusState private var field: Field?
     private let calendar = Calendar.current
     var onSubmit: ((Todo) -> Void)?
+    var onClose: (() -> Void)?
 
     var body: some View {
         NavigationStack {
@@ -74,7 +75,7 @@ struct TodoEditorView: View {
                 .presentationDragIndicator(.visible)
             }
             .toolbar {
-                ToolbarLeadingButton { dismiss() }
+                ToolbarLeadingButton { close() }
                 ToolbarItem(placement: .topBarTrailing) {
                     Button {
                         viewModel.send(.setShowInfo(true))
@@ -180,7 +181,15 @@ struct TodoEditorView: View {
     private func submit() {
         let todo = viewModel.makeTodo()
         onSubmit?(todo)
-        dismiss()
+        close()
+    }
+
+    private func close() {
+        if let onClose {
+            onClose()
+        } else {
+            dismiss()
+        }
     }
 
     private func transitionToPreview() {

--- a/Application/DevLogPresentation/Sources/Home/TodoEditorView.swift
+++ b/Application/DevLogPresentation/Sources/Home/TodoEditorView.swift
@@ -15,6 +15,7 @@ struct TodoEditorView: View {
     @State var viewModel: TodoEditorViewModel
     @Environment(\.diContainer) private var container: DIContainer
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.isiOSAppOnMac) private var isiOSAppOnMac
     @FocusState private var field: Field?
     private let calendar = Calendar.current
     var onSubmit: ((Todo) -> Void)?
@@ -24,7 +25,7 @@ struct TodoEditorView: View {
         NavigationStack {
             ScrollView {
                 LazyVStack(spacing: 10) {
-                    titleField
+                    titleSection
                     LazyVStack(
                         alignment: .leading,
                         spacing: 0,
@@ -33,7 +34,10 @@ struct TodoEditorView: View {
                         Section {
                             tabView
                         } header: {
-                            tabViewSelector
+                            if !isiOSAppOnMac {
+                                tabPicker
+                                    .padding(.horizontal)
+                            }
                         }
                     }
                 }
@@ -75,7 +79,9 @@ struct TodoEditorView: View {
                 .presentationDragIndicator(.visible)
             }
             .toolbar {
-                ToolbarLeadingButton { close() }
+                if !isiOSAppOnMac {
+                    ToolbarLeadingButton { close() }
+                }
                 ToolbarItem(placement: .topBarTrailing) {
                     Button {
                         viewModel.send(.setShowInfo(true))
@@ -91,6 +97,22 @@ struct TodoEditorView: View {
         }
     }
 
+    @ViewBuilder
+    private var titleSection: some View {
+        Group {
+            if isiOSAppOnMac {
+                HStack(spacing: 12) {
+                    titleField
+                    tabPicker
+                        .frame(width: 180)
+                }
+            } else {
+                titleField
+            }
+        }
+        .padding(.horizontal)
+    }
+
     private var titleField: some View {
         TextField(
             "",
@@ -103,10 +125,9 @@ struct TodoEditorView: View {
         .font(.title2)
         .frame(height: 30)
         .focused($field, equals: .title)
-        .padding(.horizontal)
     }
 
-    private var tabViewSelector: some View {
+    private var tabPicker: some View {
         Picker(
             "",
             selection: Binding(
@@ -127,7 +148,6 @@ struct TodoEditorView: View {
                 .tag(TodoEditorViewModel.Tag.preview)
         }
         .pickerStyle(.segmented)
-        .padding(.horizontal)
     }
 
     private var tabView: some View {

--- a/Application/DevLogPresentation/Sources/Home/TodoEditorViewModel.swift
+++ b/Application/DevLogPresentation/Sources/Home/TodoEditorViewModel.swift
@@ -54,6 +54,10 @@ final class TodoEditorViewModel: Store {
         var referenceItems: [Int: TodoReferenceItem] = [:]
         var dueDate: Date?
         var showInfo: Bool = false
+        var showAlert: Bool = false
+        var alertTitle: String = ""
+        var alertMessage: String = ""
+        var isLoading: Bool = false
         var tags: OrderedSet<String> = []
         var tagText: String = ""
         var focusOnEditor: Bool = false
@@ -77,6 +81,8 @@ final class TodoEditorViewModel: Store {
         case setCompleted(Bool)
         case setDueDate(Date?)
         case setCategory(TodoCategoryItem)
+        case setAlert(Bool)
+        case setLoading(Bool)
         case setPinned(Bool)
         case setShowInfo(Bool)
         case setSelectedTodoId(TodoIdItem?)
@@ -85,17 +91,22 @@ final class TodoEditorViewModel: Store {
         case setTitle(String)
         case setCategories([TodoCategoryItem])
         case setReferenceItems([Int: TodoReferenceItem])
+        case upsertTodo(Todo)
     }
 
     enum SideEffect {
         case fetchCategories
         case resolveMarkdown(String)
+        case upsertTodo(Todo)
     }
 
     private(set) var state = State()
     private let calendar = Calendar.current
     private let fetchPreferencesUseCase: FetchTodoCategoryPreferencesUseCase
     private let fetchReferenceItemsUseCase: FetchReferenceItemsUseCase
+    private let upsertTodoUseCase: UpsertTodoUseCase
+    private let trackAnalyticsEventUseCase: TrackAnalyticsEventUseCase?
+    private let onUpsertSuccess: ((Todo) -> Void)?
     private let id: String
     private let isCompleted: Bool
     private let isChecked: Bool
@@ -128,10 +139,16 @@ final class TodoEditorViewModel: Store {
     init(
         category: TodoCategory,
         fetchPreferencesUseCase: FetchTodoCategoryPreferencesUseCase,
-        fetchReferenceItemsUseCase: FetchReferenceItemsUseCase
+        fetchReferenceItemsUseCase: FetchReferenceItemsUseCase,
+        upsertTodoUseCase: UpsertTodoUseCase,
+        trackAnalyticsEventUseCase: TrackAnalyticsEventUseCase? = nil,
+        onUpsertSuccess: ((Todo) -> Void)? = nil
     ) {
         self.fetchPreferencesUseCase = fetchPreferencesUseCase
         self.fetchReferenceItemsUseCase = fetchReferenceItemsUseCase
+        self.upsertTodoUseCase = upsertTodoUseCase
+        self.trackAnalyticsEventUseCase = trackAnalyticsEventUseCase
+        self.onUpsertSuccess = onUpsertSuccess
         self.id = UUID().uuidString
         self.isCompleted = false
         self.isChecked = false
@@ -147,10 +164,16 @@ final class TodoEditorViewModel: Store {
     init(
         todo: Todo,
         fetchPreferencesUseCase: FetchTodoCategoryPreferencesUseCase,
-        fetchReferenceItemsUseCase: FetchReferenceItemsUseCase
+        fetchReferenceItemsUseCase: FetchReferenceItemsUseCase,
+        upsertTodoUseCase: UpsertTodoUseCase,
+        trackAnalyticsEventUseCase: TrackAnalyticsEventUseCase? = nil,
+        onUpsertSuccess: ((Todo) -> Void)? = nil
     ) {
         self.fetchPreferencesUseCase = fetchPreferencesUseCase
         self.fetchReferenceItemsUseCase = fetchReferenceItemsUseCase
+        self.upsertTodoUseCase = upsertTodoUseCase
+        self.trackAnalyticsEventUseCase = trackAnalyticsEventUseCase
+        self.onUpsertSuccess = onUpsertSuccess
         self.id = todo.id
         self.isCompleted = todo.isCompleted
         self.isChecked = todo.isChecked
@@ -201,6 +224,10 @@ final class TodoEditorViewModel: Store {
             state.isCompleted = isCompleted
         case .setCategory(let todoCategoryItem):
             state.category = todoCategoryItem
+        case .setAlert(let isPresented):
+            setAlert(&state, isPresented: isPresented)
+        case .setLoading(let value):
+            state.isLoading = value
         case .setPinned(let isPinned):
             state.isPinned = isPinned
         case .setShowInfo(let isPresented):
@@ -216,6 +243,8 @@ final class TodoEditorViewModel: Store {
             state.categories = categories
         case .setReferenceItems(let items):
             state.referenceItems = items
+        case .upsertTodo(let todo):
+            effects = [.upsertTodo(todo)]
         }
 
         if self.state != state { self.state = state }
@@ -247,6 +276,20 @@ final class TodoEditorViewModel: Store {
 
                 send(.setReferenceItems(referenceItems))
             }
+        case .upsertTodo(let todo):
+            send(.setLoading(true))
+            Task {
+                do {
+                    defer { send(.setLoading(false)) }
+                    try await upsertTodoUseCase.execute(todo)
+                    if originalDraft == nil {
+                        trackAnalyticsEventUseCase?.execute(.todoCreate)
+                    }
+                    onUpsertSuccess?(todo)
+                } catch {
+                    send(.setAlert(true))
+                }
+            }
         }
     }
 }
@@ -267,6 +310,15 @@ extension TodoEditorViewModel {
         default:
             break
         }
+    }
+
+    private func setAlert(
+        _ state: inout State,
+        isPresented: Bool
+    ) {
+        state.alertTitle = String(localized: "common_error_title")
+        state.alertMessage = String(localized: "common_error_message")
+        state.showAlert = isPresented
     }
 
     func makeTodo() -> Todo {

--- a/Application/DevLogPresentation/Sources/Home/TodoEditorWindowEvent.swift
+++ b/Application/DevLogPresentation/Sources/Home/TodoEditorWindowEvent.swift
@@ -5,13 +5,15 @@
 //  Created by opfic on 5/31/26.
 //
 
-import Foundation
+import Combine
 import DevLogDomain
 
-@MainActor
-@Observable
 public final class TodoEditorWindowEvent {
-    var submitted: TodoEditorWindowSubmit?
+    private let subject = PassthroughSubject<TodoEditorWindowSubmit, Never>()
+
+    var submits: AnyPublisher<TodoEditorWindowSubmit, Never> {
+        subject.eraseToAnyPublisher()
+    }
 
     public init() { }
 
@@ -19,6 +21,6 @@ public final class TodoEditorWindowEvent {
         value: TodoEditorWindowValue,
         todo: Todo
     ) {
-        submitted = TodoEditorWindowSubmit(value: value, todo: todo)
+        subject.send(TodoEditorWindowSubmit(value: value, todo: todo))
     }
 }

--- a/Application/DevLogPresentation/Sources/Home/TodoEditorWindowEvent.swift
+++ b/Application/DevLogPresentation/Sources/Home/TodoEditorWindowEvent.swift
@@ -1,0 +1,24 @@
+//
+//  TodoEditorWindowEvent.swift
+//  DevLogPresentation
+//
+//  Created by opfic on 5/31/26.
+//
+
+import Foundation
+import DevLogDomain
+
+@MainActor
+@Observable
+public final class TodoEditorWindowEvent {
+    var submitted: TodoEditorWindowSubmit?
+
+    public init() { }
+
+    func submit(
+        value: TodoEditorWindowValue,
+        todo: Todo
+    ) {
+        submitted = TodoEditorWindowSubmit(value: value, todo: todo)
+    }
+}

--- a/Application/DevLogPresentation/Sources/Home/TodoEditorWindowValue.swift
+++ b/Application/DevLogPresentation/Sources/Home/TodoEditorWindowValue.swift
@@ -136,7 +136,8 @@ public struct TodoEditorWindowTodo: Codable, Hashable {
     }
 }
 
-struct TodoEditorWindowSubmit {
+struct TodoEditorWindowSubmit: Equatable {
+    let id = UUID()
     let value: TodoEditorWindowValue
     let todo: Todo
 }
@@ -157,8 +158,4 @@ extension TodoEditorWindowValue {
         guard case .edit(let windowTodo) = self else { return false }
         return windowTodo.todo.id == todoId
     }
-}
-
-extension Notification.Name {
-    static let todoEditorDidSubmit = Notification.Name("DevLogPresentation.todoEditorDidSubmit")
 }

--- a/Application/DevLogPresentation/Sources/Home/TodoEditorWindowValue.swift
+++ b/Application/DevLogPresentation/Sources/Home/TodoEditorWindowValue.swift
@@ -147,7 +147,8 @@ extension TodoEditorWindowValue {
         category: TodoCategory? = nil,
         source: TodoEditorWindowSource
     ) -> Bool {
-        guard case .create(let windowCategory, source) = self else { return false }
+        guard case .create(let windowCategory, let windowSource) = self,
+              windowSource == source else { return false }
         if let category {
             return windowCategory.todoCategory == category
         }

--- a/Application/DevLogPresentation/Sources/Home/TodoEditorWindowValue.swift
+++ b/Application/DevLogPresentation/Sources/Home/TodoEditorWindowValue.swift
@@ -1,0 +1,164 @@
+//
+//  TodoEditorWindowValue.swift
+//  DevLogPresentation
+//
+//  Created by opfic on 5/31/26.
+//
+
+import Foundation
+import DevLogDomain
+
+public enum TodoEditorWindowValue: Codable, Hashable {
+    case create(TodoEditorWindowCategory, TodoEditorWindowSource)
+    case edit(TodoEditorWindowTodo)
+
+    public static let sceneId = "todo-editor"
+
+    public init(
+        todoCategory: TodoCategory,
+        source: TodoEditorWindowSource
+    ) {
+        self = .create(TodoEditorWindowCategory(todoCategory: todoCategory), source)
+    }
+
+    init(todo: Todo) {
+        self = .edit(TodoEditorWindowTodo(todo: todo))
+    }
+}
+
+public enum TodoEditorWindowSource: String, Codable, Hashable {
+    case home
+    case list
+}
+
+public struct TodoEditorWindowCategory: Codable, Hashable {
+    private enum Kind: String, Codable {
+        case system
+        case user
+    }
+
+    private let kind: Kind
+    private let id: String
+    private let name: String
+    private let colorHex: String
+
+    init(todoCategory: TodoCategory) {
+        switch todoCategory {
+        case .system(let systemTodoCategory):
+            self.kind = .system
+            self.id = systemTodoCategory.rawValue
+            self.name = ""
+            self.colorHex = ""
+        case .user(let userTodoCategory):
+            self.kind = .user
+            self.id = userTodoCategory.id
+            self.name = userTodoCategory.name
+            self.colorHex = userTodoCategory.colorHex
+        }
+    }
+
+    var todoCategory: TodoCategory {
+        switch kind {
+        case .system:
+            let systemTodoCategory = SystemTodoCategory(rawValue: id) ?? .etc
+            return .system(systemTodoCategory)
+        case .user:
+            return .user(UserTodoCategory(
+                id: id,
+                name: name,
+                colorHex: colorHex
+            ))
+        }
+    }
+}
+
+public struct TodoEditorWindowTodo: Codable, Hashable {
+    private let id: String
+    private let isPinned: Bool
+    private let isCompleted: Bool
+    private let isChecked: Bool
+    private let number: Int?
+    private let title: String
+    private let content: String
+    private let createdAt: Date
+    private let updatedAt: Date
+    private let completedAt: Date?
+    private let deletedAt: Date?
+    private let dueDate: Date?
+    private let tags: [String]
+    private let category: TodoEditorWindowCategory
+
+    init(todo: Todo) {
+        self.id = todo.id
+        self.isPinned = todo.isPinned
+        self.isCompleted = todo.isCompleted
+        self.isChecked = todo.isChecked
+        self.number = todo.number
+        self.title = todo.title
+        self.content = todo.content
+        self.createdAt = todo.createdAt
+        self.updatedAt = todo.updatedAt
+        self.completedAt = todo.completedAt
+        self.deletedAt = todo.deletedAt
+        self.dueDate = todo.dueDate
+        self.tags = todo.tags
+        self.category = TodoEditorWindowCategory(todoCategory: todo.category)
+    }
+
+    public static func == (
+        lhs: TodoEditorWindowTodo,
+        rhs: TodoEditorWindowTodo
+    ) -> Bool {
+        lhs.id == rhs.id
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
+
+    var todo: Todo {
+        Todo(
+            id: id,
+            isPinned: isPinned,
+            isCompleted: isCompleted,
+            isChecked: isChecked,
+            number: number,
+            title: title,
+            content: content,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+            completedAt: completedAt,
+            deletedAt: deletedAt,
+            dueDate: dueDate,
+            tags: tags,
+            category: category.todoCategory
+        )
+    }
+}
+
+struct TodoEditorWindowSubmit {
+    let value: TodoEditorWindowValue
+    let todo: Todo
+}
+
+extension TodoEditorWindowValue {
+    func matchesCreate(
+        category: TodoCategory? = nil,
+        source: TodoEditorWindowSource
+    ) -> Bool {
+        guard case .create(let windowCategory, source) = self else { return false }
+        if let category {
+            return windowCategory.todoCategory == category
+        }
+        return true
+    }
+
+    func matchesEdit(todoId: String) -> Bool {
+        guard case .edit(let windowTodo) = self else { return false }
+        return windowTodo.todo.id == todoId
+    }
+}
+
+extension Notification.Name {
+    static let todoEditorDidSubmit = Notification.Name("DevLogPresentation.todoEditorDidSubmit")
+}

--- a/Application/DevLogPresentation/Sources/Home/TodoEditorWindowView.swift
+++ b/Application/DevLogPresentation/Sources/Home/TodoEditorWindowView.swift
@@ -11,12 +11,16 @@ import DevLogDomain
 
 public struct TodoEditorWindowView: View {
     @Environment(\.diContainer) private var container: DIContainer
-    @Environment(TodoEditorWindowEvent.self) private var windowEvent
     @State private var windowScene: UIWindowScene?
     private let value: TodoEditorWindowValue
+    private let windowEvent: TodoEditorWindowEvent
 
-    public init(value: TodoEditorWindowValue) {
+    public init(
+        value: TodoEditorWindowValue,
+        windowEvent: TodoEditorWindowEvent
+    ) {
         self.value = value
+        self.windowEvent = windowEvent
     }
 
     public var body: some View {

--- a/Application/DevLogPresentation/Sources/Home/TodoEditorWindowView.swift
+++ b/Application/DevLogPresentation/Sources/Home/TodoEditorWindowView.swift
@@ -26,9 +26,11 @@ public struct TodoEditorWindowView: View {
                 viewModel: TodoEditorViewModel(
                     category: windowCategory.todoCategory,
                     fetchPreferencesUseCase: container.resolve(FetchTodoCategoryPreferencesUseCase.self),
-                    fetchReferenceItemsUseCase: container.resolve(FetchReferenceItemsUseCase.self)
+                    fetchReferenceItemsUseCase: container.resolve(FetchReferenceItemsUseCase.self),
+                    upsertTodoUseCase: container.resolve(UpsertTodoUseCase.self),
+                    trackAnalyticsEventUseCase: container.resolve(TrackAnalyticsEventUseCase.self),
+                    onUpsertSuccess: upsert
                 ),
-                onSubmit: submit,
                 onClose: closeWindow
             )
         case .edit(let windowTodo):
@@ -36,9 +38,10 @@ public struct TodoEditorWindowView: View {
                 viewModel: TodoEditorViewModel(
                     todo: windowTodo.todo,
                     fetchPreferencesUseCase: container.resolve(FetchTodoCategoryPreferencesUseCase.self),
-                    fetchReferenceItemsUseCase: container.resolve(FetchReferenceItemsUseCase.self)
+                    fetchReferenceItemsUseCase: container.resolve(FetchReferenceItemsUseCase.self),
+                    upsertTodoUseCase: container.resolve(UpsertTodoUseCase.self),
+                    onUpsertSuccess: upsert
                 ),
-                onSubmit: submit,
                 onClose: closeWindow
             )
         }
@@ -48,7 +51,8 @@ public struct TodoEditorWindowView: View {
         dismissWindow(id: TodoEditorWindowValue.sceneId, value: value)
     }
 
-    private func submit(_ todo: Todo) {
+    private func upsert(_ todo: Todo) {
         windowEvent.submit(value: value, todo: todo)
+        closeWindow()
     }
 }

--- a/Application/DevLogPresentation/Sources/Home/TodoEditorWindowView.swift
+++ b/Application/DevLogPresentation/Sources/Home/TodoEditorWindowView.swift
@@ -1,0 +1,56 @@
+//
+//  TodoEditorWindowView.swift
+//  DevLogPresentation
+//
+//  Created by opfic on 5/31/26.
+//
+
+import SwiftUI
+import DevLogCore
+import DevLogDomain
+
+public struct TodoEditorWindowView: View {
+    @Environment(\.diContainer) private var container: DIContainer
+    @Environment(\.dismissWindow) private var dismissWindow
+    private let value: TodoEditorWindowValue
+
+    public init(value: TodoEditorWindowValue) {
+        self.value = value
+    }
+
+    public var body: some View {
+        switch value {
+        case .create(let windowCategory, _):
+            TodoEditorView(
+                viewModel: TodoEditorViewModel(
+                    category: windowCategory.todoCategory,
+                    fetchPreferencesUseCase: container.resolve(FetchTodoCategoryPreferencesUseCase.self),
+                    fetchReferenceItemsUseCase: container.resolve(FetchReferenceItemsUseCase.self)
+                ),
+                onSubmit: submit,
+                onClose: closeWindow
+            )
+        case .edit(let windowTodo):
+            TodoEditorView(
+                viewModel: TodoEditorViewModel(
+                    todo: windowTodo.todo,
+                    fetchPreferencesUseCase: container.resolve(FetchTodoCategoryPreferencesUseCase.self),
+                    fetchReferenceItemsUseCase: container.resolve(FetchReferenceItemsUseCase.self)
+                ),
+                onSubmit: submit,
+                onClose: closeWindow
+            )
+        }
+    }
+
+    private func closeWindow() {
+        dismissWindow(id: TodoEditorWindowValue.sceneId, value: value)
+    }
+
+    private func submit(_ todo: Todo) {
+        NotificationCenter.default.post(
+            name: .todoEditorDidSubmit,
+            object: TodoEditorWindowSubmit(value: value, todo: todo)
+        )
+    }
+}

--- a/Application/DevLogPresentation/Sources/Home/TodoEditorWindowView.swift
+++ b/Application/DevLogPresentation/Sources/Home/TodoEditorWindowView.swift
@@ -11,8 +11,8 @@ import DevLogDomain
 
 public struct TodoEditorWindowView: View {
     @Environment(\.diContainer) private var container: DIContainer
-    @Environment(\.dismissWindow) private var dismissWindow
     @Environment(TodoEditorWindowEvent.self) private var windowEvent
+    @State private var windowScene: UIWindowScene?
     private let value: TodoEditorWindowValue
 
     public init(value: TodoEditorWindowValue) {
@@ -20,39 +20,69 @@ public struct TodoEditorWindowView: View {
     }
 
     public var body: some View {
-        switch value {
-        case .create(let windowCategory, _):
-            TodoEditorView(
-                viewModel: TodoEditorViewModel(
-                    category: windowCategory.todoCategory,
-                    fetchPreferencesUseCase: container.resolve(FetchTodoCategoryPreferencesUseCase.self),
-                    fetchReferenceItemsUseCase: container.resolve(FetchReferenceItemsUseCase.self),
-                    upsertTodoUseCase: container.resolve(UpsertTodoUseCase.self),
-                    trackAnalyticsEventUseCase: container.resolve(TrackAnalyticsEventUseCase.self),
-                    onUpsertSuccess: upsert
-                ),
-                onClose: closeWindow
-            )
-        case .edit(let windowTodo):
-            TodoEditorView(
-                viewModel: TodoEditorViewModel(
-                    todo: windowTodo.todo,
-                    fetchPreferencesUseCase: container.resolve(FetchTodoCategoryPreferencesUseCase.self),
-                    fetchReferenceItemsUseCase: container.resolve(FetchReferenceItemsUseCase.self),
-                    upsertTodoUseCase: container.resolve(UpsertTodoUseCase.self),
-                    onUpsertSuccess: upsert
-                ),
-                onClose: closeWindow
-            )
+        Group {
+            switch value {
+            case .create(let windowCategory, _):
+                TodoEditorView(
+                    viewModel: TodoEditorViewModel(
+                        category: windowCategory.todoCategory,
+                        fetchPreferencesUseCase: container.resolve(FetchTodoCategoryPreferencesUseCase.self),
+                        fetchReferenceItemsUseCase: container.resolve(FetchReferenceItemsUseCase.self),
+                        upsertTodoUseCase: container.resolve(UpsertTodoUseCase.self),
+                        trackAnalyticsEventUseCase: container.resolve(TrackAnalyticsEventUseCase.self),
+                        onUpsertSuccess: upsert
+                    ),
+                    onClose: closeWindow
+                )
+            case .edit(let windowTodo):
+                TodoEditorView(
+                    viewModel: TodoEditorViewModel(
+                        todo: windowTodo.todo,
+                        fetchPreferencesUseCase: container.resolve(FetchTodoCategoryPreferencesUseCase.self),
+                        fetchReferenceItemsUseCase: container.resolve(FetchReferenceItemsUseCase.self),
+                        upsertTodoUseCase: container.resolve(UpsertTodoUseCase.self),
+                        onUpsertSuccess: upsert
+                    ),
+                    onClose: closeWindow
+                )
+            }
         }
-    }
-
-    private func closeWindow() {
-        dismissWindow(id: TodoEditorWindowValue.sceneId, value: value)
+        .background {
+            WindowSceneReader { windowScene = $0 }
+        }
     }
 
     private func upsert(_ todo: Todo) {
         windowEvent.submit(value: value, todo: todo)
         closeWindow()
+    }
+
+    private func closeWindow() {
+        guard let windowScene else { return }
+        UIApplication.shared.requestSceneSessionDestruction(
+            windowScene.session,
+            options: nil,
+            errorHandler: nil
+        )
+    }
+}
+
+private struct WindowSceneReader: UIViewRepresentable {
+    let onResolve: (UIWindowScene?) -> Void
+
+    func makeUIView(context: Context) -> UIView {
+        let view = UIView()
+        resolve(from: view)
+        return view
+    }
+
+    func updateUIView(_ view: UIView, context: Context) {
+        resolve(from: view)
+    }
+
+    private func resolve(from view: UIView) {
+        DispatchQueue.main.async {
+            onResolve(view.window?.windowScene)
+        }
     }
 }

--- a/Application/DevLogPresentation/Sources/Home/TodoEditorWindowView.swift
+++ b/Application/DevLogPresentation/Sources/Home/TodoEditorWindowView.swift
@@ -12,6 +12,7 @@ import DevLogDomain
 public struct TodoEditorWindowView: View {
     @Environment(\.diContainer) private var container: DIContainer
     @Environment(\.dismissWindow) private var dismissWindow
+    @Environment(TodoEditorWindowEvent.self) private var windowEvent
     private let value: TodoEditorWindowValue
 
     public init(value: TodoEditorWindowValue) {
@@ -48,9 +49,6 @@ public struct TodoEditorWindowView: View {
     }
 
     private func submit(_ todo: Todo) {
-        NotificationCenter.default.post(
-            name: .todoEditorDidSubmit,
-            object: TodoEditorWindowSubmit(value: value, todo: todo)
-        )
+        windowEvent.submit(value: value, todo: todo)
     }
 }

--- a/Application/DevLogPresentation/Sources/Home/TodoListView.swift
+++ b/Application/DevLogPresentation/Sources/Home/TodoListView.swift
@@ -85,9 +85,14 @@ struct TodoListView: View {
                 viewModel: TodoEditorViewModel(
                     category: viewModel.category,
                     fetchPreferencesUseCase: container.resolve(FetchTodoCategoryPreferencesUseCase.self),
-                    fetchReferenceItemsUseCase: container.resolve(FetchReferenceItemsUseCase.self)
-                ),
-                onSubmit: { viewModel.send(.upsertTodo($0)) }
+                    fetchReferenceItemsUseCase: container.resolve(FetchReferenceItemsUseCase.self),
+                    upsertTodoUseCase: container.resolve(UpsertTodoUseCase.self),
+                    trackAnalyticsEventUseCase: container.resolve(TrackAnalyticsEventUseCase.self),
+                    onUpsertSuccess: { _ in
+                        viewModel.send(.setShowEditor(false))
+                        viewModel.send(.refresh)
+                    }
+                )
             )
         }
         .toolbar {
@@ -250,7 +255,7 @@ struct TodoListView: View {
     private func handleTodoEditorSubmit(_ submit: TodoEditorWindowSubmit?) {
         guard let submit,
               submit.value.matchesCreate(category: viewModel.category, source: .list) else { return }
-        viewModel.send(.upsertTodo(submit.todo))
+        viewModel.send(.refresh)
     }
 
     @ViewBuilder

--- a/Application/DevLogPresentation/Sources/Home/TodoListView.swift
+++ b/Application/DevLogPresentation/Sources/Home/TodoListView.swift
@@ -11,7 +11,6 @@ import DevLogDomain
 
 struct TodoListView: View {
     @Environment(NavigationRouter<HomeRoute>.self) private var router
-    @Environment(TodoEditorWindowEvent.self) private var windowEvent
     @Environment(\.diContainer) var container: DIContainer
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.openWindow) private var openWindow
@@ -118,9 +117,6 @@ struct TodoListView: View {
         }
         .background(NavigationBarConfigurator())
         .task { viewModel.send(.onAppear) }
-        .onChange(of: windowEvent.submitted) { _, submitted in
-            handleTodoEditorSubmit(submitted)
-        }
     }
 
     @ViewBuilder
@@ -250,12 +246,6 @@ struct TodoListView: View {
         } else {
             viewModel.send(.setShowEditor(true))
         }
-    }
-
-    private func handleTodoEditorSubmit(_ submit: TodoEditorWindowSubmit?) {
-        guard let submit,
-              submit.value.matchesCreate(category: viewModel.category, source: .list) else { return }
-        viewModel.send(.refresh)
     }
 
     @ViewBuilder

--- a/Application/DevLogPresentation/Sources/Home/TodoListView.swift
+++ b/Application/DevLogPresentation/Sources/Home/TodoListView.swift
@@ -11,6 +11,7 @@ import DevLogDomain
 
 struct TodoListView: View {
     @Environment(NavigationRouter<HomeRoute>.self) private var router
+    @Environment(TodoEditorWindowEvent.self) private var windowEvent
     @Environment(\.diContainer) var container: DIContainer
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.openWindow) private var openWindow
@@ -112,8 +113,8 @@ struct TodoListView: View {
         }
         .background(NavigationBarConfigurator())
         .task { viewModel.send(.onAppear) }
-        .onReceive(NotificationCenter.default.publisher(for: .todoEditorDidSubmit)) { notification in
-            handleTodoEditorSubmit(notification)
+        .onChange(of: windowEvent.submitted) { _, submitted in
+            handleTodoEditorSubmit(submitted)
         }
     }
 
@@ -246,8 +247,8 @@ struct TodoListView: View {
         }
     }
 
-    private func handleTodoEditorSubmit(_ notification: Notification) {
-        guard let submit = notification.object as? TodoEditorWindowSubmit,
+    private func handleTodoEditorSubmit(_ submit: TodoEditorWindowSubmit?) {
+        guard let submit,
               submit.value.matchesCreate(category: viewModel.category, source: .list) else { return }
         viewModel.send(.upsertTodo(submit.todo))
     }

--- a/Application/DevLogPresentation/Sources/Home/TodoListView.swift
+++ b/Application/DevLogPresentation/Sources/Home/TodoListView.swift
@@ -13,6 +13,8 @@ struct TodoListView: View {
     @Environment(NavigationRouter<HomeRoute>.self) private var router
     @Environment(\.diContainer) var container: DIContainer
     @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.openWindow) private var openWindow
+    @Environment(\.isiOSAppOnMac) private var isiOSAppOnMac
     @ScaledMetric(relativeTo: .body) private var headerHeight = 41
     @State private var headerOffset: CGFloat = .zero
     @State private var isScrollTrackingEnabled = false
@@ -90,7 +92,7 @@ struct TodoListView: View {
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
                 Button {
-                    viewModel.send(.setShowEditor(true))
+                    openTodoEditor()
                 } label: {
                     Image(systemName: "plus")
                 }
@@ -110,6 +112,9 @@ struct TodoListView: View {
         }
         .background(NavigationBarConfigurator())
         .task { viewModel.send(.onAppear) }
+        .onReceive(NotificationCenter.default.publisher(for: .todoEditorDidSubmit)) { notification in
+            handleTodoEditorSubmit(notification)
+        }
     }
 
     @ViewBuilder
@@ -228,6 +233,23 @@ struct TodoListView: View {
                     )
                 )
             )
+    }
+
+    private func openTodoEditor() {
+        if isiOSAppOnMac {
+            openWindow(
+                id: TodoEditorWindowValue.sceneId,
+                value: TodoEditorWindowValue(todoCategory: viewModel.category, source: .list)
+            )
+        } else {
+            viewModel.send(.setShowEditor(true))
+        }
+    }
+
+    private func handleTodoEditorSubmit(_ notification: Notification) {
+        guard let submit = notification.object as? TodoEditorWindowSubmit,
+              submit.value.matchesCreate(category: viewModel.category, source: .list) else { return }
+        viewModel.send(.upsertTodo(submit.todo))
     }
 
     @ViewBuilder

--- a/Application/DevLogPresentation/Sources/Home/TodoListViewModel.swift
+++ b/Application/DevLogPresentation/Sources/Home/TodoListViewModel.swift
@@ -50,7 +50,6 @@ final class TodoListViewModel: Store {
         case loadNextPage
         case setSearchText(String)
         case setToast(isPresented: Bool)
-        case upsertTodo(Todo)
 
         // Run
         case applySearchQuery(String)
@@ -70,7 +69,6 @@ final class TodoListViewModel: Store {
         case fetch
         case loadNextPage
         case search(String)
-        case upsert(Todo)
         case delete(TodoListItem)
         case undoDelete(String)
         case toggleCompleted(TodoListItem)
@@ -138,7 +136,7 @@ final class TodoListViewModel: Store {
                 .setShowAllSearchResults, .tapToggleCompleted, .tapTogglePinned, .undoDelete:
             effects = reduceByUser(action, state: &state)
 
-        case .onAppear, .loadNextPage, .setSearchText, .setToast, .upsertTodo:
+        case .onAppear, .loadNextPage, .setSearchText, .setToast:
             effects = reduceByView(action, state: &state)
 
         case .applySearchQuery, .fetchSearchResults, .didToggleCompleted, .didTogglePinned,
@@ -206,18 +204,6 @@ final class TodoListViewModel: Store {
                 }
             }
             searchTasks[.request] = requestTask
-        case .upsert(let item):
-            beginLoading(.delayed)
-            Task {
-                do {
-                    defer { endLoading(.delayed) }
-                    try await upsertTodoUseCase.execute(item)
-                    trackAnalyticsEventUseCase.execute(.todoCreate)
-                    send(.refresh)
-                } catch {
-                    send(.setAlert(true))
-                }
-            }
         case .toggleCompleted(let item):
             beginLoading(.delayed)
             Task {
@@ -369,8 +355,6 @@ private extension TodoListViewModel {
                 state.searchResults.removeAll { $0.isHidden }
                 self.undoTodoId = nil
             }
-        case .upsertTodo(let todo):
-            return [.upsert(todo)]
         default:
             break
         }

--- a/Application/DevLogPresentation/Sources/Home/TodoWindowCoordinator.swift
+++ b/Application/DevLogPresentation/Sources/Home/TodoWindowCoordinator.swift
@@ -5,6 +5,7 @@
 //  Created by opfic on 5/31/26.
 //
 
+import Combine
 import Foundation
 import DevLogCore
 import DevLogDomain
@@ -17,9 +18,20 @@ final class TodoWindowCoordinator {
     private var listViewModel: TodoListViewModel?
     @ObservationIgnored
     private var detailViewModel: TodoDetailViewModel?
+    @ObservationIgnored
+    private var cancellable: AnyCancellable?
 
     init(container: DIContainer) {
         self.diContainer = container
+    }
+
+    func bindWindowEvent(_ windowEvent: TodoEditorWindowEvent) {
+        guard cancellable == nil else { return }
+
+        cancellable = windowEvent.submits
+            .sink { [weak self] submit in
+                self?.handleTodoEditorSubmit(submit)
+            }
     }
 
     func makeListViewModel(category: TodoCategory) -> TodoListViewModel {
@@ -59,5 +71,17 @@ final class TodoWindowCoordinator {
         )
         self.detailViewModel = detailViewModel
         return detailViewModel
+    }
+
+    private func handleTodoEditorSubmit(_ submit: TodoEditorWindowSubmit) {
+        if let listViewModel,
+           submit.value.matchesCreate(category: listViewModel.category, source: .list) {
+            listViewModel.send(.refresh)
+        }
+
+        if let detailViewModel,
+           submit.value.matchesEdit(todoId: detailViewModel.todoId) {
+            detailViewModel.send(.setTodo(submit.todo))
+        }
     }
 }

--- a/Application/DevLogPresentation/Sources/Home/TodoWindowCoordinator.swift
+++ b/Application/DevLogPresentation/Sources/Home/TodoWindowCoordinator.swift
@@ -13,7 +13,7 @@ import DevLogDomain
 @MainActor
 @Observable
 final class TodoWindowCoordinator {
-    private let diContainer: DIContainer
+    private let container: DIContainer
     @ObservationIgnored
     private var listViewModel: TodoListViewModel?
     @ObservationIgnored
@@ -22,7 +22,7 @@ final class TodoWindowCoordinator {
     private var cancellable: AnyCancellable?
 
     init(container: DIContainer) {
-        self.diContainer = container
+        self.container = container
     }
 
     func bindWindowEvent(_ windowEvent: TodoEditorWindowEvent) {
@@ -41,12 +41,12 @@ final class TodoWindowCoordinator {
         }
 
         let listViewModel = TodoListViewModel(
-            fetchTodosUseCase: diContainer.resolve(FetchTodosUseCase.self),
-            fetchTodoByIdUseCase: diContainer.resolve(FetchTodoByIdUseCase.self),
-            upsertTodoUseCase: diContainer.resolve(UpsertTodoUseCase.self),
-            deleteTodoUseCase: diContainer.resolve(DeleteTodoUseCase.self),
-            undoDeleteTodoUseCase: diContainer.resolve(UndoDeleteTodoUseCase.self),
-            trackAnalyticsEventUseCase: diContainer.resolve(TrackAnalyticsEventUseCase.self),
+            fetchTodosUseCase: container.resolve(FetchTodosUseCase.self),
+            fetchTodoByIdUseCase: container.resolve(FetchTodoByIdUseCase.self),
+            upsertTodoUseCase: container.resolve(UpsertTodoUseCase.self),
+            deleteTodoUseCase: container.resolve(DeleteTodoUseCase.self),
+            undoDeleteTodoUseCase: container.resolve(UndoDeleteTodoUseCase.self),
+            trackAnalyticsEventUseCase: container.resolve(TrackAnalyticsEventUseCase.self),
             category: category
         )
         self.listViewModel = listViewModel
@@ -64,8 +64,8 @@ final class TodoWindowCoordinator {
         }
 
         let detailViewModel = TodoDetailViewModel(
-            fetchTodoUseCase: diContainer.resolve(FetchTodoByIdUseCase.self),
-            fetchReferenceItemsUseCase: diContainer.resolve(FetchReferenceItemsUseCase.self),
+            fetchTodoUseCase: container.resolve(FetchTodoByIdUseCase.self),
+            fetchReferenceItemsUseCase: container.resolve(FetchReferenceItemsUseCase.self),
             todoId: todoId,
             showEditButton: showEditButton
         )

--- a/Application/DevLogPresentation/Sources/Home/TodoWindowCoordinator.swift
+++ b/Application/DevLogPresentation/Sources/Home/TodoWindowCoordinator.swift
@@ -54,7 +54,6 @@ final class TodoWindowCoordinator {
         let detailViewModel = TodoDetailViewModel(
             fetchTodoUseCase: diContainer.resolve(FetchTodoByIdUseCase.self),
             fetchReferenceItemsUseCase: diContainer.resolve(FetchReferenceItemsUseCase.self),
-            upsertUseCase: diContainer.resolve(UpsertTodoUseCase.self),
             todoId: todoId,
             showEditButton: showEditButton
         )

--- a/Application/DevLogPresentation/Sources/Main/MainView.swift
+++ b/Application/DevLogPresentation/Sources/Main/MainView.swift
@@ -18,9 +18,11 @@ struct MainView: View {
     @State private var pushNotificationListViewCoordinator: PushNotificationListViewCoordinator
     @State private var profileViewCoordinator: ProfileViewCoordinator
     @Binding var selectedTab: MainTab?
+    private let windowEvent: TodoEditorWindowEvent
 
     init(
         container: DIContainer,
+        windowEvent: TodoEditorWindowEvent,
         selectedTab: Binding<MainTab?>
     ) {
         self._coordinator = State(initialValue: MainViewCoordinator(container: container))
@@ -31,6 +33,7 @@ struct MainView: View {
             initialValue: PushNotificationListViewCoordinator(container: container)
         )
         self._profileViewCoordinator = State(initialValue: ProfileViewCoordinator(container: container))
+        self.windowEvent = windowEvent
         self._selectedTab = selectedTab
     }
 
@@ -46,6 +49,8 @@ struct MainView: View {
         }
         .onAppear {
             coordinator.viewModel.send(.onAppear)
+            homeViewCoordinator.bindWindowEvent(windowEvent)
+            todoWindowCoordinator.bindWindowEvent(windowEvent)
         }
         .onChange(of: selectedTab, initial: true) { _, newValue in
             guard let newValue else { return }

--- a/Application/DevLogPresentation/Sources/Profile/ProfileViewCoordinator.swift
+++ b/Application/DevLogPresentation/Sources/Profile/ProfileViewCoordinator.swift
@@ -61,7 +61,6 @@ final class ProfileViewCoordinator {
         TodoDetailViewModel(
             fetchTodoUseCase: container.resolve(FetchTodoByIdUseCase.self),
             fetchReferenceItemsUseCase: container.resolve(FetchReferenceItemsUseCase.self),
-            upsertUseCase: container.resolve(UpsertTodoUseCase.self),
             todoId: todoId,
             showEditButton: false
         )

--- a/Application/DevLogPresentation/Sources/PushNotification/PushNotificationListViewCoordinator.swift
+++ b/Application/DevLogPresentation/Sources/PushNotification/PushNotificationListViewCoordinator.swift
@@ -14,12 +14,12 @@ import DevLogDomain
 final class PushNotificationListViewCoordinator {
     let viewModel: PushNotificationListViewModel
     var todoIdToPresent: TodoIdItem?
-    private let diContainer: DIContainer
+    private let container: DIContainer
     @ObservationIgnored
     private var todoDetailViewModel: TodoDetailViewModel?
 
     init(container: DIContainer) {
-        self.diContainer = container
+        self.container = container
         self.viewModel = PushNotificationListViewModel(
             fetchUseCase: container.resolve(FetchPushNotificationsUseCase.self),
             deleteUseCase: container.resolve(DeletePushNotificationUseCase.self),
@@ -42,8 +42,8 @@ final class PushNotificationListViewCoordinator {
         }
 
         let todoDetailViewModel = TodoDetailViewModel(
-            fetchTodoUseCase: diContainer.resolve(FetchTodoByIdUseCase.self),
-            fetchReferenceItemsUseCase: diContainer.resolve(FetchReferenceItemsUseCase.self),
+            fetchTodoUseCase: container.resolve(FetchTodoByIdUseCase.self),
+            fetchReferenceItemsUseCase: container.resolve(FetchReferenceItemsUseCase.self),
             todoId: todoId,
             showEditButton: false
         )

--- a/Application/DevLogPresentation/Sources/PushNotification/PushNotificationListViewCoordinator.swift
+++ b/Application/DevLogPresentation/Sources/PushNotification/PushNotificationListViewCoordinator.swift
@@ -44,7 +44,6 @@ final class PushNotificationListViewCoordinator {
         let todoDetailViewModel = TodoDetailViewModel(
             fetchTodoUseCase: diContainer.resolve(FetchTodoByIdUseCase.self),
             fetchReferenceItemsUseCase: diContainer.resolve(FetchReferenceItemsUseCase.self),
-            upsertUseCase: diContainer.resolve(UpsertTodoUseCase.self),
             todoId: todoId,
             showEditButton: false
         )

--- a/Application/DevLogPresentation/Sources/Root/RootView.swift
+++ b/Application/DevLogPresentation/Sources/Root/RootView.swift
@@ -16,6 +16,7 @@ public struct RootView: View {
     @State private var selectedRoute: Route?
     @State private var selectedMainTab: MainTab?
     private let widgetURLTab: (URL) -> MainTab?
+    private let windowEvent: TodoEditorWindowEvent
     private let pushNotificationTodoIdPublisher: AnyPublisher<String, Never>
     private let clearPushNotificationRoute: () -> Void
 
@@ -25,6 +26,7 @@ public struct RootView: View {
         systemThemeUseCase: ObserveSystemThemeUseCase,
         trackAnalyticsEventUseCase: TrackAnalyticsEventUseCase,
         widgetURLTab: @escaping (URL) -> MainTab?,
+        windowEvent: TodoEditorWindowEvent,
         pushNotificationTodoIdPublisher: AnyPublisher<String, Never>,
         clearPushNotificationRoute: @escaping () -> Void
     ) {
@@ -35,6 +37,7 @@ public struct RootView: View {
             trackAnalyticsEventUseCase: trackAnalyticsEventUseCase
         ))
         self.widgetURLTab = widgetURLTab
+        self.windowEvent = windowEvent
         self.pushNotificationTodoIdPublisher = pushNotificationTodoIdPublisher
         self.clearPushNotificationRoute = clearPushNotificationRoute
     }
@@ -46,6 +49,7 @@ public struct RootView: View {
                 if signIn {
                     MainView(
                         container: container,
+                        windowEvent: windowEvent,
                         selectedTab: $selectedMainTab
                     )
                 } else {

--- a/Application/DevLogPresentation/Sources/Root/RootView.swift
+++ b/Application/DevLogPresentation/Sources/Root/RootView.swift
@@ -91,7 +91,6 @@ public struct RootView: View {
                     TodoDetailView(viewModel: TodoDetailViewModel(
                         fetchTodoUseCase: container.resolve(FetchTodoByIdUseCase.self),
                         fetchReferenceItemsUseCase: container.resolve(FetchReferenceItemsUseCase.self),
-                        upsertUseCase: container.resolve(UpsertTodoUseCase.self),
                         todoId: todoId,
                         showEditButton: false
                     ))

--- a/Application/DevLogPresentation/Sources/Search/SearchView.swift
+++ b/Application/DevLogPresentation/Sources/Search/SearchView.swift
@@ -24,7 +24,6 @@ struct SearchView: View {
                         TodoDetailView(viewModel: TodoDetailViewModel(
                             fetchTodoUseCase: container.resolve(FetchTodoByIdUseCase.self),
                             fetchReferenceItemsUseCase: container.resolve(FetchReferenceItemsUseCase.self),
-                            upsertUseCase: container.resolve(UpsertTodoUseCase.self),
                             todoId: todoId
                         ))
                     case .web(let page):


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #440

## 🎯 의도
Mac에서 Todo 작성 및 수정 시 기존 시트/풀스크린 커버가 아닌 별도 윈도우 기반 편집 경험 제공

## 📝 작업 내용

### 📌 요약
- iOS App on Mac 실행 환경 판별 값 추가
- Mac 환경에서 Todo 작성 및 수정 화면을 새 WindowGroup으로 표시
- TodoEditorView 재사용 유지 및 저장 책임을 기존 부모 ViewModel로 위임
- Todo 편집 윈도우 제출 이벤트를 typed observable 객체로 전달
- Mac 전용 TodoEditorView 상단 UI 분리
- HomeView 일부 버튼 탭 영역 보강

### 🔍 상세
- `ProcessInfo.processInfo.isiOSAppOnMac` 기반 `isiOSAppOnMac` 환경 값 추가
- `TodoEditorWindowValue`를 통해 작성/수정 윈도우에 필요한 값 전달
- `TodoEditorWindowView`에서 기존 `TodoEditorView`를 재사용해 윈도우 전용 편집 화면 구성
- `TodoEditorWindowEvent`를 기본 WindowGroup과 TodoEditor WindowGroup에 주입해 내부 이벤트 전달
- `HomeView`, `TodoListView`, `TodoDetailView`에서 TodoEditorWindow 제출 이벤트를 수신해 기존 ViewModel action으로 위임
- NotificationCenter 기반 내부 이벤트 전달 제거
- Mac 실행 시 TodoEditorView의 leading 닫기 버튼 숨김 처리
- Mac 실행 시 write/preview Picker를 제목 입력 필드 우측에 배치
- RecentTodoRow 및 WebItemRow 버튼의 탭 인식 영역 보강

## 📸 영상 / 이미지 (Optional)

Uploading 화면 기록 2026-06-01 오전 12.42.10.mov…