### PR TITLE
[#504] ProfileView 탭 모드를 content, detail로 수정한다

### DIFF
--- a/Application/DevLogApp/Sources/Resource/Localizable.xcstrings
+++ b/Application/DevLogApp/Sources/Resource/Localizable.xcstrings
@@ -966,6 +966,23 @@
         }
       }
     },
+    "profile_select_detail" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Select an activity."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "활동을 선택해주세요."
+          }
+        }
+      }
+    },
     "profile_select_quarter" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Application/DevLogPresentation/Sources/Main/MainView.swift
+++ b/Application/DevLogPresentation/Sources/Main/MainView.swift
@@ -331,28 +331,22 @@ struct MainView: View {
     }
 
     private var profileRegularDetailView: some View {
-        Group {
-            if let profileRoute = profileViewCoordinator.router.root {
-                switch profileRoute {
-                case .activity(let todoId):
-                    TodoDetailView(viewModel: profileViewCoordinator.makeTodoDetailViewModel(todoId: todoId))
-                        .id(todoId)
-                case .settings, .theme, .pushNotification, .account:
-                    NavigationStack(path: Binding(
-                        get: { profileViewCoordinator.router.detailPath },
-                        set: { profileViewCoordinator.router.detailPath = $0 }
-                    )) {
-                        profileRegularDestinationView(profileRoute)
-                            .navigationDestination(for: ProfileRoute.self) { route in
-                                profileRegularDestinationView(route)
-                            }
-                    }
+        NavigationStack(path: Binding(
+            get: { profileViewCoordinator.router.detailPath },
+            set: { profileViewCoordinator.router.detailPath = $0 }
+        )) {
+            Group {
+                if let profileRoute = profileViewCoordinator.router.root {
+                    profileRegularDestinationView(profileRoute)
+                } else {
+                    ContentUnavailableView(
+                        String(localized: "profile_select_detail"),
+                        systemImage: "person.crop.circle"
+                    )
                 }
-            } else {
-                ContentUnavailableView(
-                    String(localized: "profile_select_detail"),
-                    systemImage: "person.crop.circle"
-                )
+            }
+            .navigationDestination(for: ProfileRoute.self) { route in
+                profileRegularDestinationView(route)
             }
         }
         .background(Color(.secondarySystemBackground).ignoresSafeArea())

--- a/Application/DevLogPresentation/Sources/Main/MainView.swift
+++ b/Application/DevLogPresentation/Sources/Main/MainView.swift
@@ -328,9 +328,22 @@ struct MainView: View {
 
     private var profileRegularDetailView: some View {
         Group {
-            if let todoId = profileSelectedTodoId {
-                TodoDetailView(viewModel: profileViewCoordinator.makeTodoDetailViewModel(todoId: todoId))
-                    .id(todoId)
+            if let profileRoute = profileViewCoordinator.router.root {
+                switch profileRoute {
+                case .activity(let todoId):
+                    TodoDetailView(viewModel: profileViewCoordinator.makeTodoDetailViewModel(todoId: todoId))
+                        .id(todoId)
+                case .settings, .theme, .pushNotification, .account:
+                    NavigationStack(path: Binding(
+                        get: { profileViewCoordinator.router.detailPath },
+                        set: { profileViewCoordinator.router.detailPath = $0 }
+                    )) {
+                        profileRegularDestinationView(profileRoute)
+                            .navigationDestination(for: ProfileRoute.self) { route in
+                                profileRegularDestinationView(route)
+                            }
+                    }
+                }
             } else {
                 ContentUnavailableView(
                     String(localized: "profile_select_detail"),
@@ -339,6 +352,31 @@ struct MainView: View {
             }
         }
         .background(Color(.secondarySystemBackground).ignoresSafeArea())
+    }
+
+    @ViewBuilder
+    private func profileRegularDestinationView(_ route: ProfileRoute) -> some View {
+        switch route {
+        case .activity(let todoId):
+            TodoDetailView(viewModel: profileViewCoordinator.makeTodoDetailViewModel(todoId: todoId))
+                .id(todoId)
+        case .settings:
+            SettingView(viewModel: profileViewCoordinator.settingViewModel)
+                .environment(profileViewCoordinator.router)
+        case .theme:
+            ThemeView(
+                theme: Binding(
+                    get: { profileViewCoordinator.settingViewModel.state.theme },
+                    set: { profileViewCoordinator.settingViewModel.send(.setTheme($0)) }
+                )
+            )
+        case .pushNotification:
+            PushNotificationSettingsView(
+                viewModel: profileViewCoordinator.makePushNotificationSettingsViewModel()
+            )
+        case .account:
+            AccountView(viewModel: profileViewCoordinator.makeAccountViewModel())
+        }
     }
 }
 
@@ -391,15 +429,6 @@ private extension MainView {
             get: { todayViewCoordinator.router.detailPath },
             set: { todayViewCoordinator.router.detailPath = $0 }
         )
-    }
-
-    var profileSelectedTodoId: String? {
-        for route in profileViewCoordinator.router.path.reversed() {
-            if case let .activity(todoId) = route {
-                return todoId
-            }
-        }
-        return nil
     }
 
 }

--- a/Application/DevLogPresentation/Sources/Main/MainView.swift
+++ b/Application/DevLogPresentation/Sources/Main/MainView.swift
@@ -112,6 +112,7 @@ struct MainView: View {
                 mainSidebar
             } content: {
                 homeView
+                    .navigationSplitViewColumnWidth(min: 350, ideal: 450, max: nil)
             } detail: {
                 homeRegularDetailView
             }
@@ -121,6 +122,7 @@ struct MainView: View {
                 mainSidebar
             } content: {
                 todayView
+                    .navigationSplitViewColumnWidth(min: 350, ideal: 450, max: nil)
             } detail: {
                 todayRegularDetailView
             }
@@ -132,6 +134,7 @@ struct MainView: View {
                     coordinator: pushNotificationListViewCoordinator,
                     isCompactLayout: isCompactLayout
                 )
+                .navigationSplitViewColumnWidth(min: 350, ideal: 450, max: nil)
             } detail: {
                 Group {
                     if let todoId = pushNotificationListViewCoordinator.todoIdToPresent?.id {
@@ -155,6 +158,7 @@ struct MainView: View {
                 mainSidebar
             } content: {
                 profileView
+                    .navigationSplitViewColumnWidth(min: 350, ideal: 450, max: nil)
             } detail: {
                 profileRegularDetailView
             }

--- a/Application/DevLogPresentation/Sources/Main/MainView.swift
+++ b/Application/DevLogPresentation/Sources/Main/MainView.swift
@@ -106,64 +106,57 @@ struct MainView: View {
 
     @ViewBuilder
     private func sidebarView(for selectedTab: MainTab) -> some View {
-        switch selectedTab.mainTabSplitStyle {
-        case .detailOnly:
+        switch selectedTab {
+        case .home:
             NavigationSplitView {
                 mainSidebar
+            } content: {
+                homeView
             } detail: {
-                selectedTabView(for: selectedTab)
+                homeRegularDetailView
             }
-        case .contentDetail:
-            switch selectedTab {
-            case .home:
-                NavigationSplitView {
-                    mainSidebar
-                } content: {
-                    homeView
-                } detail: {
-                    homeRegularDetailView
-                }
-                .environment(homeViewCoordinator.router)
-            case .today:
-                NavigationSplitView {
-                    mainSidebar
-                } content: {
-                    todayView
-                } detail: {
-                    todayRegularDetailView
-                }
-            case .notification:
-                NavigationSplitView {
-                    mainSidebar
-                } content: {
-                    PushNotificationListView(
-                        coordinator: pushNotificationListViewCoordinator,
-                        isCompactLayout: isCompactLayout
-                    )
-                } detail: {
-                    Group {
-                        if let todoId = pushNotificationListViewCoordinator.todoIdToPresent?.id {
-                            TodoDetailView(
-                                viewModel: pushNotificationListViewCoordinator.makeTodoDetailViewModel(
-                                    todoId: todoId
-                                )
+            .environment(homeViewCoordinator.router)
+        case .today:
+            NavigationSplitView {
+                mainSidebar
+            } content: {
+                todayView
+            } detail: {
+                todayRegularDetailView
+            }
+        case .notification:
+            NavigationSplitView {
+                mainSidebar
+            } content: {
+                PushNotificationListView(
+                    coordinator: pushNotificationListViewCoordinator,
+                    isCompactLayout: isCompactLayout
+                )
+            } detail: {
+                Group {
+                    if let todoId = pushNotificationListViewCoordinator.todoIdToPresent?.id {
+                        TodoDetailView(
+                            viewModel: pushNotificationListViewCoordinator.makeTodoDetailViewModel(
+                                todoId: todoId
                             )
-                            .id(todoId)
-                        } else {
-                            ContentUnavailableView(
-                                String(localized: "push_notifications_select_detail"),
-                                systemImage: "bell.badge"
-                            )
-                        }
+                        )
+                        .id(todoId)
+                    } else {
+                        ContentUnavailableView(
+                            String(localized: "push_notifications_select_detail"),
+                            systemImage: "bell.badge"
+                        )
                     }
-                    .background(Color(.secondarySystemBackground).ignoresSafeArea())
                 }
-            case .profile:
-                NavigationSplitView {
-                    mainSidebar
-                } detail: {
-                    selectedTabView(for: selectedTab)
-                }
+            }
+            .background(Color(.secondarySystemBackground).ignoresSafeArea())
+        case .profile:
+            NavigationSplitView {
+                mainSidebar
+            } content: {
+                profileView
+            } detail: {
+                profileRegularDetailView
             }
         }
     }
@@ -176,20 +169,6 @@ struct MainView: View {
             sidebarRow(.profile)
         }
         .listStyle(.sidebar)
-    }
-
-    @ViewBuilder
-    private func selectedTabView(for selectedTab: MainTab) -> some View {
-        switch selectedTab {
-        case .home:
-            homeView
-        case .today:
-            todayView
-        case .notification:
-            notificationView
-        case .profile:
-            profileView
-        }
     }
 
     @ViewBuilder
@@ -341,7 +320,25 @@ struct MainView: View {
     }
 
     private var profileView: some View {
-        ProfileView(coordinator: profileViewCoordinator)
+        ProfileView(
+            coordinator: profileViewCoordinator,
+            isCompactLayout: isCompactLayout
+        )
+    }
+
+    private var profileRegularDetailView: some View {
+        Group {
+            if let todoId = profileSelectedTodoId {
+                TodoDetailView(viewModel: profileViewCoordinator.makeTodoDetailViewModel(todoId: todoId))
+                    .id(todoId)
+            } else {
+                ContentUnavailableView(
+                    String(localized: "profile_select_detail"),
+                    systemImage: "person.crop.circle"
+                )
+            }
+        }
+        .background(Color(.secondarySystemBackground).ignoresSafeArea())
     }
 }
 
@@ -396,23 +393,17 @@ private extension MainView {
         )
     }
 
-}
-
-private enum MainTabSplitStyle {
-    case detailOnly
-    case contentDetail
-}
-
-private extension MainTab {
-    var mainTabSplitStyle: MainTabSplitStyle {
-        switch self {
-        case .home, .today, .notification:
-            .contentDetail
-        case .profile:
-            .detailOnly
+    var profileSelectedTodoId: String? {
+        for route in profileViewCoordinator.router.path.reversed() {
+            if case let .activity(todoId) = route {
+                return todoId
+            }
         }
+        return nil
     }
 
+}
+private extension MainTab {
     var title: String {
         switch self {
         case .home:

--- a/Application/DevLogPresentation/Sources/Profile/ProfileView.swift
+++ b/Application/DevLogPresentation/Sources/Profile/ProfileView.swift
@@ -11,137 +11,151 @@ import DevLogDomain
 
 struct ProfileView: View {
     let coordinator: ProfileViewCoordinator
+    let isCompactLayout: Bool
     @FocusState private var focused: Bool
 
     var body: some View {
-        NavigationStack(path: navigationPath) {
-            ScrollView {
-                LazyVStack(alignment: .leading, spacing: 16) {
-                    HStack {
-                        CacheableImage(url: coordinator.viewModel.state.avatarURL) {
-                            Image(systemName: "person.crop.circle.fill")
-                                .resizable()
-                                .scaledToFill()
-                                .foregroundStyle(Color(.systemGray2))
-                        }
-                        .frame(width: 60, height: 60)
-                        .cornerRadius(30)
-                        .foregroundStyle(Color.gray)
-
-                        VStack(alignment: .leading) {
-                            Text(coordinator.viewModel.state.name)
-                                .font(.title2)
-                                .bold()
-                            Text(coordinator.viewModel.state.email)
-                                .font(.caption2)
-                                .foregroundStyle(Color.gray)
-                        }
-                    }
-                    let connected = coordinator.viewModel.state.isNetworkConnected
-                    HStack {
-                        HStack {
-                            Image(systemName: "face.smiling")
-                            TextField(
-                                text: Binding(
-                                    get: { coordinator.viewModel.state.statusMessage },
-                                    set: { coordinator.viewModel.send(.updateStatusMessage($0)) }
-                                )
-                            ) {
-                                Text(String(localized: "profile_status_placeholder"))
-                            }
-                            .frame(height: UIFont.preferredFont(forTextStyle: .body).lineHeight)
-                            .focused($focused)
-                            .disabled(!connected)
-
-                            if !coordinator.viewModel.state.statusMessage.isEmpty,
-                               coordinator.viewModel.state.showDoneButton {
-                                Button(action: {
-                                    coordinator.viewModel.send(.tapResetStatusMessageButton)
-                                }) {
-                                    Image(systemName: "xmark.circle.fill")
+        Group {
+            if isCompactLayout {
+                NavigationStack(path: navigationPath) {
+                    profileContentView
+                        .toolbar {
+                            ToolbarItem(placement: .topBarTrailing) {
+                                Button {
+                                    coordinator.router.push(.settings)
+                                } label: {
+                                    Image(systemName: "gearshape")
                                 }
-                                .transition(.move(edge: .trailing).combined(with: .opacity))
                             }
                         }
-                        .foregroundStyle(Color.gray)
-                        .padding(8)
-                        .background(
-                            RoundedRectangle(cornerRadius: 10)
-                                .fill(Color(.secondarySystemGroupedBackground))
-                        )
-                        if coordinator.viewModel.state.showDoneButton {
+                        .navigationDestination(for: ProfileRoute.self) { route in
+                            profileDestinationView(route)
+                        }
+                }
+            } else {
+                profileContentView
+            }
+        }
+        .onChange(of: focused) { _, newValue in
+            withAnimation {
+                coordinator.viewModel.send(.updateStatusTextFieldFocus(newValue))
+            }
+        }
+        .alert(
+            "",
+            isPresented: Binding(
+                get: { coordinator.viewModel.state.showAlert },
+                set: { coordinator.viewModel.send(.setAlert($0)) }
+            )
+        ) {
+            Button(String(localized: "common_close"), role: .cancel) { }
+        } message: {
+            Text(coordinator.viewModel.state.alertMessage)
+        }
+        .sheet(
+            isPresented: Binding(
+                get: { coordinator.viewModel.state.showQuarterPicker },
+                set: { coordinator.viewModel.send(.setQuarterPickerPresented($0)) }
+            )
+        ) {
+            quarterPickerSheet
+        }
+    }
+
+    private var profileContentView: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 16) {
+                HStack {
+                    CacheableImage(url: coordinator.viewModel.state.avatarURL) {
+                        Image(systemName: "person.crop.circle.fill")
+                            .resizable()
+                            .scaledToFill()
+                            .foregroundStyle(Color(.systemGray2))
+                    }
+                    .frame(width: 60, height: 60)
+                    .cornerRadius(30)
+                    .foregroundStyle(Color.gray)
+
+                    VStack(alignment: .leading) {
+                        Text(coordinator.viewModel.state.name)
+                            .font(.title2)
+                            .bold()
+                        Text(coordinator.viewModel.state.email)
+                            .font(.caption2)
+                            .foregroundStyle(Color.gray)
+                    }
+                }
+                let connected = coordinator.viewModel.state.isNetworkConnected
+                HStack {
+                    HStack {
+                        Image(systemName: "face.smiling")
+                        TextField(
+                            text: Binding(
+                                get: { coordinator.viewModel.state.statusMessage },
+                                set: { coordinator.viewModel.send(.updateStatusMessage($0)) }
+                            )
+                        ) {
+                            Text(String(localized: "profile_status_placeholder"))
+                        }
+                        .frame(height: UIFont.preferredFont(forTextStyle: .body).lineHeight)
+                        .focused($focused)
+                        .disabled(!connected)
+
+                        if !coordinator.viewModel.state.statusMessage.isEmpty,
+                           coordinator.viewModel.state.showDoneButton {
                             Button(action: {
-                                focused = false
-                                coordinator.viewModel.send(.willUpdateStatusMessage)
+                                coordinator.viewModel.send(.tapResetStatusMessageButton)
                             }) {
-                                Text(String(localized: "profile_done"))
+                                Image(systemName: "xmark.circle.fill")
                             }
                             .transition(.move(edge: .trailing).combined(with: .opacity))
                         }
                     }
-                    .opacity(connected ? 1 : 0.7)
-                    activityHeatmapSection
-                }
-                .padding(.horizontal, 16)
-            }
-            .refreshable { coordinator.viewModel.send(.refresh) }
-            .frame(maxWidth: .infinity)
-            .background(Color(.systemGroupedBackground))
-            .toolbar {
-                ToolbarItem(placement: .topBarTrailing) {
-                    HStack(spacing: 0) {
-                        Button {
-                            coordinator.router.push(.settings)
-                        } label: {
-                            Image(systemName: "gearshape")
+                    .foregroundStyle(Color.gray)
+                    .padding(8)
+                    .background(
+                        RoundedRectangle(cornerRadius: 10)
+                            .fill(Color(.secondarySystemGroupedBackground))
+                    )
+                    if coordinator.viewModel.state.showDoneButton {
+                        Button(action: {
+                            focused = false
+                            coordinator.viewModel.send(.willUpdateStatusMessage)
+                        }) {
+                            Text(String(localized: "profile_done"))
                         }
+                        .transition(.move(edge: .trailing).combined(with: .opacity))
                     }
                 }
+                .opacity(connected ? 1 : 0.7)
+                activityHeatmapSection
             }
-            .navigationDestination(for: ProfileRoute.self) { route in
-                switch route {
-                case .settings:
-                    SettingView(viewModel: coordinator.settingViewModel)
-                        .environment(coordinator.router)
-                case .activity(let todoId):
-                    TodoDetailView(viewModel: coordinator.makeTodoDetailViewModel(todoId: todoId))
-                case .theme:
-                    ThemeView(
-                        theme: Binding(
-                            get: { coordinator.settingViewModel.state.theme },
-                            set: { coordinator.settingViewModel.send(.setTheme($0)) }
-                        )
-                    )
-                case .pushNotification:
-                    PushNotificationSettingsView(viewModel: coordinator.makePushNotificationSettingsViewModel())
-                case .account:
-                    AccountView(viewModel: coordinator.makeAccountViewModel())
-                }
-            }
-            .onChange(of: focused) { _, newValue in
-                withAnimation {
-                    coordinator.viewModel.send(.updateStatusTextFieldFocus(newValue))
-                }
-            }
-            .alert(
-                "",
-                isPresented: Binding(
-                    get: { coordinator.viewModel.state.showAlert },
-                    set: { coordinator.viewModel.send(.setAlert($0)) }
+            .padding(.horizontal, 16)
+        }
+        .refreshable { coordinator.viewModel.send(.refresh) }
+        .frame(maxWidth: .infinity)
+        .background(Color(.systemGroupedBackground))
+    }
+
+    @ViewBuilder
+    private func profileDestinationView(_ route: ProfileRoute) -> some View {
+        switch route {
+        case .settings:
+            SettingView(viewModel: coordinator.settingViewModel)
+                .environment(coordinator.router)
+        case .activity(let todoId):
+            TodoDetailView(viewModel: coordinator.makeTodoDetailViewModel(todoId: todoId))
+        case .theme:
+            ThemeView(
+                theme: Binding(
+                    get: { coordinator.settingViewModel.state.theme },
+                    set: { coordinator.settingViewModel.send(.setTheme($0)) }
                 )
-            ) {
-                Button(String(localized: "common_close"), role: .cancel) { }
-            } message: {
-                Text(coordinator.viewModel.state.alertMessage)
-            }
-            .sheet(
-                isPresented: Binding(
-                    get: { coordinator.viewModel.state.showQuarterPicker },
-                    set: { coordinator.viewModel.send(.setQuarterPickerPresented($0)) }
-                )
-            ) {
-                quarterPickerSheet
-            }
+            )
+        case .pushNotification:
+            PushNotificationSettingsView(viewModel: coordinator.makePushNotificationSettingsViewModel())
+        case .account:
+            AccountView(viewModel: coordinator.makeAccountViewModel())
         }
     }
 

--- a/Application/DevLogPresentation/Sources/Profile/ProfileView.swift
+++ b/Application/DevLogPresentation/Sources/Profile/ProfileView.swift
@@ -19,15 +19,6 @@ struct ProfileView: View {
             if isCompactLayout {
                 NavigationStack(path: navigationPath) {
                     profileContentView
-                        .toolbar {
-                            ToolbarItem(placement: .topBarTrailing) {
-                                Button {
-                                    coordinator.router.push(.settings)
-                                } label: {
-                                    Image(systemName: "gearshape")
-                                }
-                            }
-                        }
                         .navigationDestination(for: ProfileRoute.self) { route in
                             profileDestinationView(route)
                         }
@@ -36,6 +27,7 @@ struct ProfileView: View {
                 profileContentView
             }
         }
+        .toolbar { profileToolbarContent }
         .onChange(of: focused) { _, newValue in
             withAnimation {
                 coordinator.viewModel.send(.updateStatusTextFieldFocus(newValue))
@@ -135,6 +127,21 @@ struct ProfileView: View {
         .refreshable { coordinator.viewModel.send(.refresh) }
         .frame(maxWidth: .infinity)
         .background(Color(.systemGroupedBackground))
+    }
+
+    @ToolbarContentBuilder
+    private var profileToolbarContent: some ToolbarContent {
+        ToolbarItem(placement: .topBarTrailing) {
+            Button {
+                if isCompactLayout {
+                    coordinator.router.push(.settings)
+                } else {
+                    coordinator.router.replace(with: .settings)
+                }
+            } label: {
+                Image(systemName: "gearshape")
+            }
+        }
     }
 
     @ViewBuilder
@@ -368,7 +375,11 @@ struct ProfileView: View {
                 ForEach(activities) { activity in
                     Button {
                         if !activity.isDeleted {
-                            coordinator.router.push(.activity(activity.todoId))
+                            if isCompactLayout {
+                                coordinator.router.push(.activity(activity.todoId))
+                            } else {
+                                coordinator.router.replace(with: .activity(activity.todoId))
+                            }
                         }
                     } label: {
                         let item = TodoCategoryItem(from: activity.category)


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #504

## 🎯 의도
- Profile 화면의 regular UI에서 detail 패널 동작 일관성 확보
- Profile 관련 설정 진입 경로 복구
- 각 탭의 split view content 컬럼 너비 정책 정리

## 📝 작업 내용

### 📌 요약
- Profile 탭을 `contentDetail` 구조로 정리
- Profile regular UI에서 활동 선택 시 detail 패널에 `TodoDetailView` 노출 방식 적용
- Profile regular UI에서 toolbar 설정 버튼 탭 시 detail 패널에 `SettingView` 노출 방식 적용
- Profile detail placeholder 문구를 Profile 문맥에 맞게 분리
- Home, Today, Notification, Profile의 content 컬럼에 `navigationSplitViewColumnWidth(min: 350, ideal: 450, max: nil)` 적용
- 불필요해진 `mainTabSplitStyle` 관련 분기 제거

### 🔍 상세
- `MainView`
  - `sidebarView(for:)`를 `selectedTab` 직접 분기 구조로 정리
  - Profile 탭 regular detail 영역이 `ProfileRoute`의 현재 root에 따라 `TodoDetailView` 또는 설정 관련 화면을 표시하도록 구성
  - Home, Today, Notification, Profile의 `content` 컬럼에 동일한 split view width 정책 적용

- `ProfileView`
  - compact / regular 레이아웃을 구분하는 구조로 정리
  - toolbar gear 버튼을 공통 배치로 변경
  - compact에서는 기존처럼 `push(.settings)` 유지
  - regular에서는 `replace(with: .settings)`로 detail 패널 교체 방식 적용
  - 활동 선택 시 compact는 push, regular는 replace 동작 적용

- `Localizable.xcstrings`
  - `profile_select_detail` 추가
  - Profile detail placeholder를 `활동을 선택해주세요.` 문구로 분리

## 📸 영상 / 이미지 (Optional)

<table>
<tr>
<td align="center">

<img width="1024" height="800" alt="image" src="https://github.com/user-attachments/assets/37cdb98d-8707-451a-8da5-0f78699d6bea" />

<td align="center">

<img width="1024" height="800" alt="image" src="https://github.com/user-attachments/assets/3fba3794-2896-4725-8f6f-8cca0e35a38d" />

</tr>
<tr>
<td align="center">설정
<td align="center">활동 체크
</tr>
</table>