### PR TITLE
[#415] 위젯 싱크 트리거를 수정한다

### DIFF
--- a/Application/DevLogApp/Sources/App/Assembler/AppLayerAssembler.swift
+++ b/Application/DevLogApp/Sources/App/Assembler/AppLayerAssembler.swift
@@ -39,7 +39,7 @@ final class AppLayerAssembler: Assembler {
         }
         container.register(PushNotificationOpenHandler.self) {
             PushNotificationOpenHandler(
-                trackAnalyticsEventUseCase: container.resolve(TrackAnalyticsEventUseCase.self)
+                analyticsService: container.resolve(AnalyticsService.self)
             )
         }
     }

--- a/Application/DevLogApp/Sources/App/Assembler/AppLayerAssembler.swift
+++ b/Application/DevLogApp/Sources/App/Assembler/AppLayerAssembler.swift
@@ -21,6 +21,12 @@ final class AppLayerAssembler: Assembler {
                 snapshotUpdater: container.resolve(WidgetSnapshotUpdater.self)
             )
         }
+        container.register(WidgetSessionSyncHandler.self) {
+            WidgetSessionSyncHandler(
+                authService: container.resolve(AuthService.self),
+                widgetSyncEventBus: container.resolve(WidgetSyncEventBus.self)
+            )
+        }
         container.register(FCMTokenSyncHandler.self) {
             FCMTokenSyncHandler(
                 userService: container.resolve(UserService.self)

--- a/Application/DevLogApp/Sources/App/Delegate/AppDelegate.swift
+++ b/Application/DevLogApp/Sources/App/Delegate/AppDelegate.swift
@@ -30,6 +30,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         _ = container.resolve(FCMTokenSyncHandler.self)
         _ = container.resolve(UserTimeZoneSyncHandler.self)
         _ = container.resolve(WidgetSyncEventHandler.self)
+        _ = container.resolve(WidgetSessionSyncHandler.self)
 
         // 알림 권한 요청
         UNUserNotificationCenter.current().delegate = self

--- a/Application/DevLogApp/Sources/App/Handler/PushNotificationOpenHandler.swift
+++ b/Application/DevLogApp/Sources/App/Handler/PushNotificationOpenHandler.swift
@@ -6,17 +6,17 @@
 //
 
 import Foundation
-import DevLogDomain
+import DevLogData
 
 final class PushNotificationOpenHandler {
-    private let trackAnalyticsEventUseCase: TrackAnalyticsEventUseCase
+    private let analyticsService: AnalyticsService
 
-    init(trackAnalyticsEventUseCase: TrackAnalyticsEventUseCase) {
-        self.trackAnalyticsEventUseCase = trackAnalyticsEventUseCase
+    init(analyticsService: AnalyticsService) {
+        self.analyticsService = analyticsService
     }
 
     func handlePushOpen(userInfo: [AnyHashable: Any]) {
-        trackAnalyticsEventUseCase.execute(.pushOpen)
+        analyticsService.trackPushOpen()
         PushNotificationRoute.shared.handlePushTap(userInfo: userInfo)
     }
 }

--- a/Application/DevLogApp/Sources/App/Handler/WidgetSessionSyncHandler.swift
+++ b/Application/DevLogApp/Sources/App/Handler/WidgetSessionSyncHandler.swift
@@ -6,6 +6,7 @@
 //
 
 import Combine
+import Foundation
 import DevLogData
 
 final class WidgetSessionSyncHandler {
@@ -23,6 +24,7 @@ final class WidgetSessionSyncHandler {
 
         authService.observeSignedIn()
             .removeDuplicates()
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] isSignedIn in
                 self?.handleSessionUpdate(isSignedIn: isSignedIn)
             }

--- a/Application/DevLogApp/Sources/App/Handler/WidgetSessionSyncHandler.swift
+++ b/Application/DevLogApp/Sources/App/Handler/WidgetSessionSyncHandler.swift
@@ -1,0 +1,47 @@
+//
+//  WidgetSessionSyncHandler.swift
+//  DevLog
+//
+//  Created by opfic on 6/1/26.
+//
+
+import Combine
+import DevLogData
+
+final class WidgetSessionSyncHandler {
+    private let authService: AuthService
+    private let widgetSyncEventBus: WidgetSyncEventBus
+    private var hasRequestedWidgetSync = false
+    private var cancellables = Set<AnyCancellable>()
+
+    init(
+        authService: AuthService,
+        widgetSyncEventBus: WidgetSyncEventBus
+    ) {
+        self.authService = authService
+        self.widgetSyncEventBus = widgetSyncEventBus
+
+        authService.observeSignedIn()
+            .removeDuplicates()
+            .sink { [weak self] isSignedIn in
+                self?.handleSessionUpdate(isSignedIn: isSignedIn)
+            }
+            .store(in: &cancellables)
+    }
+}
+
+private extension WidgetSessionSyncHandler {
+    func handleSessionUpdate(isSignedIn: Bool) {
+        guard isSignedIn else {
+            hasRequestedWidgetSync = false
+            return
+        }
+
+        guard hasRequestedWidgetSync == false else {
+            return
+        }
+
+        hasRequestedWidgetSync = true
+        widgetSyncEventBus.publish(.syncRequested)
+    }
+}

--- a/Application/DevLogApp/Tests/App/WidgetSessionSyncHandlerTests.swift
+++ b/Application/DevLogApp/Tests/App/WidgetSessionSyncHandlerTests.swift
@@ -1,0 +1,82 @@
+//
+//  WidgetSessionSyncHandlerTests.swift
+//  DevLogAppTests
+//
+//  Created by opfic on 6/1/26.
+//
+
+import Combine
+import Testing
+import DevLogData
+@testable import DevLog
+
+struct WidgetSessionSyncHandlerTests {
+    @Test("로그인 세션 true 첫 진입에서만 위젯 초기 동기화를 요청한다")
+    func 로그인_세션_true_첫_진입에서만_위젯_초기_동기화를_요청한다() {
+        let authServiceSpy = AuthServiceSpy()
+        let widgetSyncEventBusSpy = WidgetSyncEventBusSpy()
+        let widgetSessionSyncHandler = WidgetSessionSyncHandler(
+            authService: authServiceSpy,
+            widgetSyncEventBus: widgetSyncEventBusSpy
+        )
+
+        authServiceSpy.send(true)
+        authServiceSpy.send(true)
+
+        #expect(widgetSyncEventBusSpy.events == [.syncRequested])
+        _ = widgetSessionSyncHandler
+    }
+
+    @Test("로그아웃 이후 재로그인 시 위젯 초기 동기화를 다시 요청한다")
+    func 로그아웃_이후_재로그인_시_위젯_초기_동기화를_다시_요청한다() {
+        let authServiceSpy = AuthServiceSpy()
+        let widgetSyncEventBusSpy = WidgetSyncEventBusSpy()
+        let widgetSessionSyncHandler = WidgetSessionSyncHandler(
+            authService: authServiceSpy,
+            widgetSyncEventBus: widgetSyncEventBusSpy
+        )
+
+        authServiceSpy.send(true)
+        authServiceSpy.send(false)
+        authServiceSpy.send(true)
+
+        #expect(widgetSyncEventBusSpy.events == [.syncRequested, .syncRequested])
+        _ = widgetSessionSyncHandler
+    }
+}
+
+private final class AuthServiceSpy: AuthService {
+    private let currentValueSubject = CurrentValueSubject<Bool, Never>(false)
+
+    var uid: String? { nil }
+    var providerIDs: [String] { [] }
+    var currentUserEmail: String? { nil }
+    var providerCount: Int { 0 }
+
+    func observeSignedIn() -> AnyPublisher<Bool, Never> {
+        currentValueSubject.eraseToAnyPublisher()
+    }
+
+    func beginSignIn() { }
+    func completeSignIn() { }
+    func cancelSignIn() { }
+    func getProviderID() async throws -> String? { nil }
+    func deleteCurrentUser() async throws { }
+    func clearCurrentSession() async throws { }
+
+    func send(_ isSignedIn: Bool) {
+        currentValueSubject.send(isSignedIn)
+    }
+}
+
+private final class WidgetSyncEventBusSpy: WidgetSyncEventBus {
+    private(set) var events = [WidgetSyncEvent]()
+
+    func publish(_ event: WidgetSyncEvent) {
+        events.append(event)
+    }
+
+    func observe() -> AnyPublisher<WidgetSyncEvent, Never> {
+        Empty().eraseToAnyPublisher()
+    }
+}

--- a/Application/DevLogApp/Tests/App/WidgetSessionSyncHandlerTests.swift
+++ b/Application/DevLogApp/Tests/App/WidgetSessionSyncHandlerTests.swift
@@ -6,13 +6,14 @@
 //
 
 import Combine
+import Foundation
 import Testing
 import DevLogData
 @testable import DevLog
 
 struct WidgetSessionSyncHandlerTests {
     @Test("로그인 세션 true 첫 진입에서만 위젯 초기 동기화를 요청한다")
-    func 로그인_세션_true_첫_진입에서만_위젯_초기_동기화를_요청한다() {
+    func 로그인_세션_true_첫_진입에서만_위젯_초기_동기화를_요청한다() async {
         let authServiceSpy = AuthServiceSpy()
         let widgetSyncEventBusSpy = WidgetSyncEventBusSpy()
         let widgetSessionSyncHandler = WidgetSessionSyncHandler(
@@ -23,12 +24,17 @@ struct WidgetSessionSyncHandlerTests {
         authServiceSpy.send(true)
         authServiceSpy.send(true)
 
+        await withCheckedContinuation { continuation in
+            DispatchQueue.main.async {
+                continuation.resume()
+            }
+        }
         #expect(widgetSyncEventBusSpy.events == [.syncRequested])
         _ = widgetSessionSyncHandler
     }
 
     @Test("로그아웃 이후 재로그인 시 위젯 초기 동기화를 다시 요청한다")
-    func 로그아웃_이후_재로그인_시_위젯_초기_동기화를_다시_요청한다() {
+    func 로그아웃_이후_재로그인_시_위젯_초기_동기화를_다시_요청한다() async {
         let authServiceSpy = AuthServiceSpy()
         let widgetSyncEventBusSpy = WidgetSyncEventBusSpy()
         let widgetSessionSyncHandler = WidgetSessionSyncHandler(
@@ -40,6 +46,11 @@ struct WidgetSessionSyncHandlerTests {
         authServiceSpy.send(false)
         authServiceSpy.send(true)
 
+        await withCheckedContinuation { continuation in
+            DispatchQueue.main.async {
+                continuation.resume()
+            }
+        }
         #expect(widgetSyncEventBusSpy.events == [.syncRequested, .syncRequested])
         _ = widgetSessionSyncHandler
     }

--- a/Application/DevLogData/DevLogData.xcodeproj/project.pbxproj
+++ b/Application/DevLogData/DevLogData.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 70;
+	objectVersion = 71;
 	objects = {
 
 /* Begin PBXBuildFile section */

--- a/Application/DevLogData/Sources/DataAssembler.swift
+++ b/Application/DevLogData/Sources/DataAssembler.swift
@@ -110,7 +110,8 @@ public final class DataAssembler: Assembler {
             UserPreferencesRepositoryImpl(
                 store: container.resolve(UserDefaultsStore.self),
                 themeStore: container.resolve(ThemeStore.self),
-                widgetSnapshotPreferenceStore: container.resolve(WidgetSnapshotPreferenceStore.self)
+                widgetSnapshotPreferenceStore: container.resolve(WidgetSnapshotPreferenceStore.self),
+                widgetSyncEventBus: container.resolve(WidgetSyncEventBus.self)
             )
         }
     }

--- a/Application/DevLogData/Sources/DataAssembler.swift
+++ b/Application/DevLogData/Sources/DataAssembler.swift
@@ -35,7 +35,8 @@ public final class DataAssembler: Assembler {
         container.register(TodoRepository.self) {
             TodoRepositoryImpl(
                 todoService: container.resolve(TodoService.self),
-                todoCategoryService: container.resolve(TodoCategoryService.self)
+                todoCategoryService: container.resolve(TodoCategoryService.self),
+                widgetSyncEventBus: container.resolve(WidgetSyncEventBus.self)
             )
         }
 

--- a/Application/DevLogData/Sources/Repository/TodoRepositoryImpl.swift
+++ b/Application/DevLogData/Sources/Repository/TodoRepositoryImpl.swift
@@ -12,13 +12,16 @@ import DevLogDomain
 final class TodoRepositoryImpl: TodoRepository {
     private let todoService: TodoService
     private let todoCategoryService: TodoCategoryService
+    private let widgetSyncEventBus: WidgetSyncEventBus
 
     init(
         todoService: TodoService,
-        todoCategoryService: TodoCategoryService
+        todoCategoryService: TodoCategoryService,
+        widgetSyncEventBus: WidgetSyncEventBus
     ) {
         self.todoService = todoService
         self.todoCategoryService = todoCategoryService
+        self.widgetSyncEventBus = widgetSyncEventBus
     }
 
     func fetchTodos(_ query: TodoQuery, cursor: TodoCursor?) async throws -> TodoPage {
@@ -105,6 +108,7 @@ final class TodoRepositoryImpl: TodoRepository {
         let request = TodoRequest.fromDomain(todo)
         do {
             try await todoService.upsertTodo(request: request)
+            widgetSyncEventBus.publish(.syncRequested)
         } catch {
             throw error.toDomain()
         }
@@ -113,6 +117,7 @@ final class TodoRepositoryImpl: TodoRepository {
     func deleteTodo(_ todoId: String) async throws {
         do {
             try await todoService.deleteTodo(todoId: todoId)
+            widgetSyncEventBus.publish(.syncRequested)
         } catch {
             throw error.toDomain()
         }
@@ -121,6 +126,7 @@ final class TodoRepositoryImpl: TodoRepository {
     func undoDeleteTodo(_ todoId: String) async throws {
         do {
             try await todoService.undoDeleteTodo(todoId: todoId)
+            widgetSyncEventBus.publish(.syncRequested)
         } catch {
             throw error.toDomain()
         }

--- a/Application/DevLogData/Sources/Repository/UserPreferencesRepositoryImpl.swift
+++ b/Application/DevLogData/Sources/Repository/UserPreferencesRepositoryImpl.swift
@@ -22,15 +22,18 @@ final class UserPreferencesRepositoryImpl: UserPreferencesRepository {
     private let store: UserDefaultsStore
     private let themeStore: ThemeStore
     private let widgetSnapshotPreferenceStore: WidgetSnapshotPreferenceStore
+    private let widgetSyncEventBus: WidgetSyncEventBus
 
     init(
         store: UserDefaultsStore,
         themeStore: ThemeStore,
-        widgetSnapshotPreferenceStore: WidgetSnapshotPreferenceStore
+        widgetSnapshotPreferenceStore: WidgetSnapshotPreferenceStore,
+        widgetSyncEventBus: WidgetSyncEventBus
     ) {
         self.store = store
         self.themeStore = themeStore
         self.widgetSnapshotPreferenceStore = widgetSnapshotPreferenceStore
+        self.widgetSyncEventBus = widgetSyncEventBus
         themeStore.send(systemTheme())
     }
 
@@ -92,6 +95,7 @@ final class UserPreferencesRepositoryImpl: UserPreferencesRepository {
 
     func setHeatmapActivityTypes(_ activityTypes: [String]) {
         widgetSnapshotPreferenceStore.setHeatmapActivityTypes(activityTypes)
+        widgetSyncEventBus.publish(.syncRequested)
     }
 
     func todayDisplayOptions() -> TodayDisplayOptions {
@@ -100,5 +104,6 @@ final class UserPreferencesRepositoryImpl: UserPreferencesRepository {
 
     func setTodayDisplayOptions(_ options: TodayDisplayOptions) {
         widgetSnapshotPreferenceStore.setTodayDisplayOptions(options)
+        widgetSyncEventBus.publish(.syncRequested)
     }
 }

--- a/Application/DevLogData/Tests/Repository/TodoRepositoryImplTests.swift
+++ b/Application/DevLogData/Tests/Repository/TodoRepositoryImplTests.swift
@@ -1,0 +1,165 @@
+//
+//  TodoRepositoryImplTests.swift
+//  DevLogDataTests
+//
+//  Created by opfic on 6/1/26.
+//
+
+import Combine
+import Foundation
+import Testing
+import DevLogCore
+import DevLogDomain
+@testable import DevLogData
+
+struct TodoRepositoryImplTests {
+    @Test("Todo 변경 성공 시 위젯 동기화 이벤트를 발행한다")
+    func todo_변경_성공_시_위젯_동기화_이벤트를_발행한다() async throws {
+        let fixture = makeFixture()
+        let todo = makeTodo()
+
+        try await fixture.repository.upsertTodo(todo)
+        try await fixture.repository.deleteTodo(todo.id)
+        try await fixture.repository.undoDeleteTodo(todo.id)
+
+        let events = fixture.widgetSyncEventBus.events
+        #expect(events == [.syncRequested, .syncRequested, .syncRequested])
+    }
+
+    @Test("Todo 변경 실패 시 위젯 동기화 이벤트를 발행하지 않는다")
+    func todo_변경_실패_시_위젯_동기화_이벤트를_발행하지_않는다() async throws {
+        let fixture = makeFixture()
+        let todo = makeTodo()
+
+        await fixture.todoService.setShouldFail(true)
+
+        do {
+            try await fixture.repository.upsertTodo(todo)
+            Issue.record("upsertTodo should fail")
+        } catch {
+            #expect(error as? TodoRepositoryImplTestsError == .serviceFailed)
+        }
+        do {
+            try await fixture.repository.deleteTodo(todo.id)
+            Issue.record("deleteTodo should fail")
+        } catch {
+            #expect(error as? TodoRepositoryImplTestsError == .serviceFailed)
+        }
+        do {
+            try await fixture.repository.undoDeleteTodo(todo.id)
+            Issue.record("undoDeleteTodo should fail")
+        } catch {
+            #expect(error as? TodoRepositoryImplTestsError == .serviceFailed)
+        }
+
+        let events = fixture.widgetSyncEventBus.events
+        #expect(events.isEmpty)
+    }
+
+    private func makeFixture() -> Fixture {
+        let todoService = TodoServiceSpy()
+        let todoCategoryService = TodoCategoryServiceSpy()
+        let widgetSyncEventBus = WidgetSyncEventBusSpy()
+        let repository = TodoRepositoryImpl(
+            todoService: todoService,
+            todoCategoryService: todoCategoryService,
+            widgetSyncEventBus: widgetSyncEventBus
+        )
+
+        return Fixture(
+            repository: repository,
+            todoService: todoService,
+            widgetSyncEventBus: widgetSyncEventBus
+        )
+    }
+
+    private func makeTodo() -> Todo {
+        Todo(
+            id: "todo-id",
+            isPinned: false,
+            isCompleted: false,
+            isChecked: false,
+            number: 1,
+            title: "title",
+            content: "content",
+            createdAt: .now,
+            updatedAt: .now,
+            completedAt: nil,
+            deletedAt: nil,
+            dueDate: nil,
+            tags: [],
+            category: .system(.feature)
+        )
+    }
+}
+
+private struct Fixture {
+    let repository: TodoRepositoryImpl
+    let todoService: TodoServiceSpy
+    let widgetSyncEventBus: WidgetSyncEventBusSpy
+}
+
+private actor TodoServiceSpy: TodoService {
+    private var shouldFail = false
+
+    func setShouldFail(_ shouldFail: Bool) {
+        self.shouldFail = shouldFail
+    }
+
+    func fetchTodos(_ query: TodoQuery, cursor: TodoCursorDTO?) async throws -> TodoPageResponse {
+        throw TodoRepositoryImplTestsError.unexpectedCall
+    }
+
+    func upsertTodo(request: TodoRequest) async throws {
+        guard shouldFail == false else {
+            throw TodoRepositoryImplTestsError.serviceFailed
+        }
+    }
+
+    func deleteTodo(todoId: String) async throws {
+        guard shouldFail == false else {
+            throw TodoRepositoryImplTestsError.serviceFailed
+        }
+    }
+
+    func undoDeleteTodo(todoId: String) async throws {
+        guard shouldFail == false else {
+            throw TodoRepositoryImplTestsError.serviceFailed
+        }
+    }
+
+    func fetchTodo(todoId: String) async throws -> TodoResponse {
+        throw TodoRepositoryImplTestsError.unexpectedCall
+    }
+
+    func fetchReferences(_ numbers: [Int]) async throws -> [Int: TodoReferenceResponse] {
+        throw TodoRepositoryImplTestsError.unexpectedCall
+    }
+}
+
+private struct TodoCategoryServiceSpy: TodoCategoryService {
+    func fetchPreferences() async throws -> [TodoCategoryPreferenceResponse] {
+        []
+    }
+
+    func updatePreferences(_ preferences: [TodoCategoryPreferenceResponse]) async throws {
+        throw TodoRepositoryImplTestsError.unexpectedCall
+    }
+}
+
+private final class WidgetSyncEventBusSpy: WidgetSyncEventBus {
+    private(set) var events = [WidgetSyncEvent]()
+
+    func observe() -> AnyPublisher<WidgetSyncEvent, Never> {
+        Empty().eraseToAnyPublisher()
+    }
+
+    func publish(_ event: WidgetSyncEvent) {
+        events.append(event)
+    }
+}
+
+private enum TodoRepositoryImplTestsError: Error, Equatable {
+    case serviceFailed
+    case unexpectedCall
+}

--- a/Application/DevLogData/Tests/Repository/UserPreferencesRepositoryImplTests.swift
+++ b/Application/DevLogData/Tests/Repository/UserPreferencesRepositoryImplTests.swift
@@ -1,0 +1,110 @@
+//
+//  UserPreferencesRepositoryImplTests.swift
+//  DevLogDataTests
+//
+//  Created by opfic on 6/1/26.
+//
+
+import Combine
+import Foundation
+import Testing
+import DevLogCore
+@testable import DevLogData
+
+struct UserPreferencesRepositoryImplTests {
+    @Test("위젯 설정 변경 시 위젯 동기화 이벤트를 발행한다")
+    func 위젯_설정_변경_시_위젯_동기화_이벤트를_발행한다() {
+        let widgetSnapshotPreferenceStore = WidgetSnapshotPreferenceStoreSpy()
+        let widgetSyncEventBus = WidgetSyncEventBusSpy()
+        let repository = UserPreferencesRepositoryImpl(
+            store: UserDefaultsStoreSpy(),
+            themeStore: ThemeStoreSpy(),
+            widgetSnapshotPreferenceStore: widgetSnapshotPreferenceStore,
+            widgetSyncEventBus: widgetSyncEventBus
+        )
+
+        repository.setHeatmapActivityTypes(["created", "deleted"])
+        repository.setTodayDisplayOptions(
+            TodayDisplayOptions(
+                dueDateVisibility: .withDueDateOnly,
+                focusVisibility: .focusedOnly
+            )
+        )
+
+        #expect(widgetSnapshotPreferenceStore.heatmapActivityTypesValue == ["created", "deleted"])
+        #expect(
+            widgetSnapshotPreferenceStore.todayDisplayOptionsValue == TodayDisplayOptions(
+                dueDateVisibility: .withDueDateOnly,
+                focusVisibility: .focusedOnly
+            )
+        )
+        #expect(widgetSyncEventBus.events == [.syncRequested, .syncRequested])
+    }
+}
+
+private final class UserDefaultsStoreSpy: UserDefaultsStore {
+    func string(forKey key: String) -> String? {
+        nil
+    }
+
+    func setString(_ value: String?, forKey key: String) { }
+
+    func stringArray(forKey key: String) -> [String] {
+        []
+    }
+
+    func setStringArray(_ value: [String], forKey key: String) { }
+
+    func bool(forKey key: String) -> Bool {
+        false
+    }
+
+    func setBool(_ value: Bool, forKey key: String) { }
+}
+
+private final class ThemeStoreSpy: ThemeStore {
+    func observeTheme() -> AnyPublisher<SystemTheme, Never> {
+        Empty().eraseToAnyPublisher()
+    }
+
+    func send(_ theme: SystemTheme) { }
+}
+
+private final class WidgetSnapshotPreferenceStoreSpy: WidgetSnapshotPreferenceStore {
+    private(set) var heatmapActivityTypesValue = [String]()
+    private(set) var todayDisplayOptionsValue = TodayDisplayOptions.default
+
+    func heatmapActivityTypes() -> [String] {
+        heatmapActivityTypesValue
+    }
+
+    func setHeatmapActivityTypes(_ activityTypes: [String]) {
+        heatmapActivityTypesValue = activityTypes
+    }
+
+    func selectedActivityKinds() -> Set<ActivityKind> {
+        []
+    }
+
+    func todayDisplayOptions() -> TodayDisplayOptions {
+        todayDisplayOptionsValue
+    }
+
+    func setTodayDisplayOptions(_ options: TodayDisplayOptions) {
+        todayDisplayOptionsValue = options
+    }
+
+    func clear() { }
+}
+
+private final class WidgetSyncEventBusSpy: WidgetSyncEventBus {
+    private(set) var events = [WidgetSyncEvent]()
+
+    func publish(_ event: WidgetSyncEvent) {
+        events.append(event)
+    }
+
+    func observe() -> AnyPublisher<WidgetSyncEvent, Never> {
+        Empty().eraseToAnyPublisher()
+    }
+}


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #415

## 🎯 의도

- 앱/위젯 데이터 변경 경로에서 위젯 스냅샷 갱신 요청이 누락되지 않도록 동기화 트리거 보강

## 📝 작업 내용

### 📌 요약

- Todo 추가, 수정, 삭제, 삭제 취소 성공 시 위젯 동기화 요청 추가
- 위젯 표시 설정 변경 시 위젯 동기화 요청 추가
- 인증 세션 복구 시 1회 위젯 동기화 요청 추가
- App handler 의존성을 service 중심으로 정리

### 🔍 상세

- `TodoRepositoryImpl`에서 `upsertTodo`, `deleteTodo`, `undoDeleteTodo` 성공 이후 `WidgetSyncEventBus`로 `.syncRequested` 발행
- `UserPreferencesRepositoryImpl`에서 `setHeatmapActivityTypes`, `setTodayDisplayOptions` 성공 이후 위젯 동기화 요청 발행
- `WidgetSessionSyncHandler` 추가로 로그인 세션 `true` 첫 진입 시 위젯 동기화 요청 처리
- 로그아웃 후 재로그인 시 세션 동기화 요청이 다시 발생하도록 상태 초기화 처리
- `PushNotificationOpenHandler`의 analytics 기록 의존성을 `TrackAnalyticsEventUseCase`에서 `AnalyticsService`로 변경
- 변경된 동기화 트리거 동작을 검증하는 repository 및 handler 테스트 추가

## 📸 영상 / 이미지 (Optional)