### PR TITLE
[#514] Tuist generated file 추적 정책을 정리한다

### DIFF
--- a/Application/DevLogApp/DevLogApp.xcodeproj/project.pbxproj
+++ b/Application/DevLogApp/DevLogApp.xcodeproj/project.pbxproj
@@ -111,6 +111,7 @@
 		2242DBABD8ABF11A23160669 /* DevLogPersistence.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DevLogPersistence.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		28ECC31B0B7F9C0A9BB4F55C /* DevLogInfra.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DevLogInfra.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2B937350A0682E6F1CD20536 /* DeleteWebPageIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteWebPageIntegrationTests.swift; sourceTree = "<group>"; };
+		2DA024CEC167F3E73260E675 /* UnitTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "UnitTests-Info.plist"; sourceTree = "<group>"; };
 		346173767E6ED68E9DFDA51C /* FCMTokenSyncHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FCMTokenSyncHandler.swift; sourceTree = "<group>"; };
 		3494F50D6E7BC9510DE43F65 /* DevLogDomain.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DevLogDomain.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3AC12B5E227050E4BAEF315D /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -131,7 +132,6 @@
 		B1F60100641A6FBC29ED402D /* DevLogCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DevLogCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B347482071F5035929CB7CFB /* TempView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TempView.swift; sourceTree = "<group>"; };
 		B967FCB16D2F91F183A858E7 /* DevLogAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DevLogAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		C362AF15094D8F5E93617B0E /* DevLogAppTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "DevLogAppTests-Info.plist"; sourceTree = "<group>"; };
 		C44AFCDB8890714D634C4536 /* DevLogApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DevLogApp.swift; sourceTree = "<group>"; };
 		CAEEC97A4EC302C6974E1A4E /* MainTab+WidgetDeepLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MainTab+WidgetDeepLink.swift"; sourceTree = "<group>"; };
 		D0044D9310C29492954FD1F7 /* DevLogWidgetExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = DevLogWidgetExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -230,17 +230,10 @@
 			path = Integration;
 			sourceTree = "<group>";
 		};
-		60097CE5D1DA42FC84930179 /* InfoPlists */ = {
-			isa = PBXGroup;
-			children = (
-				C362AF15094D8F5E93617B0E /* DevLogAppTests-Info.plist */,
-			);
-			path = InfoPlists;
-			sourceTree = "<group>";
-		};
 		627EA6CB7079FEF3EAA0919A /* Shared */ = {
 			isa = PBXGroup;
 			children = (
+				B83508A381C872901D29B6E9 /* InfoPlists */,
 				4635BA36DE82C73A105E7157 /* Version.xcconfig */,
 			);
 			name = Shared;
@@ -281,20 +274,11 @@
 		9E8EF4194ED8097ED76A15CB /* Project */ = {
 			isa = PBXGroup;
 			children = (
-				A921B89C54E83E78FB2AC773 /* Derived */,
 				627EA6CB7079FEF3EAA0919A /* Shared */,
 				486F3A456A292E22151A8E00 /* Sources */,
 				1A3B968711187139DE60604C /* Tests */,
 			);
 			name = Project;
-			sourceTree = "<group>";
-		};
-		A921B89C54E83E78FB2AC773 /* Derived */ = {
-			isa = PBXGroup;
-			children = (
-				60097CE5D1DA42FC84930179 /* InfoPlists */,
-			);
-			path = Derived;
 			sourceTree = "<group>";
 		};
 		B010DBB3FAA011D8422A374B /* PushNotification */ = {
@@ -320,6 +304,14 @@
 				1D8FB7D923F9E7606A3B8672 /* Products */,
 				9E8EF4194ED8097ED76A15CB /* Project */,
 			);
+			sourceTree = "<group>";
+		};
+		B83508A381C872901D29B6E9 /* InfoPlists */ = {
+			isa = PBXGroup;
+			children = (
+				2DA024CEC167F3E73260E675 /* UnitTests-Info.plist */,
+			);
+			path = InfoPlists;
 			sourceTree = "<group>";
 		};
 		BD7D139B00B80391043465AA /* Support */ = {
@@ -558,7 +550,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				INFOPLIST_FILE = "Derived/InfoPlists/DevLogAppTests-Info.plist";
+				INFOPLIST_FILE = "../Shared/InfoPlists/UnitTests-Info.plist";
 				INFOPLIST_KEY_CFBundleShortVersionString = "$(MARKETING_VERSION)";
 				INFOPLIST_KEY_CFBundleVersion = "$(CURRENT_PROJECT_VERSION)";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -596,7 +588,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				INFOPLIST_FILE = "Derived/InfoPlists/DevLogAppTests-Info.plist";
+				INFOPLIST_FILE = "../Shared/InfoPlists/UnitTests-Info.plist";
 				INFOPLIST_KEY_CFBundleShortVersionString = "$(MARKETING_VERSION)";
 				INFOPLIST_KEY_CFBundleVersion = "$(CURRENT_PROJECT_VERSION)";
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/Application/DevLogApp/Project.swift
+++ b/Application/DevLogApp/Project.swift
@@ -49,7 +49,7 @@ let project = Project(
             destinations: .iOS,
             product: .unitTests,
             bundleId: "opfic.DevLogAppTests",
-            infoPlist: .default,
+            infoPlist: .file(path: "../Shared/InfoPlists/UnitTests-Info.plist"),
             sources: ["Tests/**/*.swift"],
             dependencies: [
                 .target(name: "DevLogApp"),

--- a/Application/DevLogCore/DevLogCore.xcodeproj/project.pbxproj
+++ b/Application/DevLogCore/DevLogCore.xcodeproj/project.pbxproj
@@ -42,10 +42,10 @@
 		7E1439EDF75977AE379F076D /* PushNotificationQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationQuery.swift; sourceTree = "<group>"; };
 		858BAFA1A55F74A8B4F7347D /* ActivityKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityKind.swift; sourceTree = "<group>"; };
 		9BB8F354E9137D253A489F1A /* TodoQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoQuery.swift; sourceTree = "<group>"; };
+		A2FE45360391B5FC6507D122 /* Framework-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "Framework-Info.plist"; sourceTree = "<group>"; };
 		BED429545213969E5D9E8F0C /* WidgetTodoSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetTodoSnapshot.swift; sourceTree = "<group>"; };
 		C532C71BD62DF500DC86772E /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		C5C98D8733B9DAD3033E8EE4 /* DevLogCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DevLogCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		EAC049AFC1FF824FA25456CD /* DevLogCore-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "DevLogCore-Info.plist"; sourceTree = "<group>"; };
 		F8F6B8781A629983E05833E3 /* Assembler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Assembler.swift; sourceTree = "<group>"; };
 		FFC29B53B4EC380EB2FD9933 /* DIContainerKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DIContainerKey.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -90,32 +90,24 @@
 		4CA20564D210295B92BFAADE /* Project */ = {
 			isa = PBXGroup;
 			children = (
-				BFDBAB21C2E19AD1DD116F1D /* Derived */,
 				CB7BF94122488E7FFA8C3A60 /* Shared */,
 				407D1BC54FEA47F991D2CF92 /* Sources */,
 			);
 			name = Project;
 			sourceTree = "<group>";
 		};
-		8B7A85A075850DD8E25126DA /* InfoPlists */ = {
+		4F8D665D200FA33FCBCBBD56 /* InfoPlists */ = {
 			isa = PBXGroup;
 			children = (
-				EAC049AFC1FF824FA25456CD /* DevLogCore-Info.plist */,
+				A2FE45360391B5FC6507D122 /* Framework-Info.plist */,
 			);
 			path = InfoPlists;
-			sourceTree = "<group>";
-		};
-		BFDBAB21C2E19AD1DD116F1D /* Derived */ = {
-			isa = PBXGroup;
-			children = (
-				8B7A85A075850DD8E25126DA /* InfoPlists */,
-			);
-			path = Derived;
 			sourceTree = "<group>";
 		};
 		CB7BF94122488E7FFA8C3A60 /* Shared */ = {
 			isa = PBXGroup;
 			children = (
+				4F8D665D200FA33FCBCBBD56 /* InfoPlists */,
 				2250B6ED63E0398484C1E019 /* Version.xcconfig */,
 			);
 			name = Shared;
@@ -304,7 +296,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = "Derived/InfoPlists/DevLogCore-Info.plist";
+				INFOPLIST_FILE = "../Shared/InfoPlists/Framework-Info.plist";
 				INFOPLIST_KEY_CFBundleShortVersionString = "$(MARKETING_VERSION)";
 				INFOPLIST_KEY_CFBundleVersion = "$(CURRENT_PROJECT_VERSION)";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -406,7 +398,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = "Derived/InfoPlists/DevLogCore-Info.plist";
+				INFOPLIST_FILE = "../Shared/InfoPlists/Framework-Info.plist";
 				INFOPLIST_KEY_CFBundleShortVersionString = "$(MARKETING_VERSION)";
 				INFOPLIST_KEY_CFBundleVersion = "$(CURRENT_PROJECT_VERSION)";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";

--- a/Application/DevLogCore/Project.swift
+++ b/Application/DevLogCore/Project.swift
@@ -5,6 +5,8 @@ let project = Project.devlogFramework(
     name: "DevLogCore",
     bundleId: "com.opfic.DevLog.DevLogCore",
     versionXcconfigPath: "../Shared/Version.xcconfig",
+    frameworkInfoPlistPath: "../Shared/InfoPlists/Framework-Info.plist",
+    testsInfoPlistPath: "../Shared/InfoPlists/UnitTests-Info.plist",
     packages: DevLogPackages.lintOnlyPackages,
     hasTests: false
 )

--- a/Application/DevLogData/DevLogData.xcodeproj/project.pbxproj
+++ b/Application/DevLogData/DevLogData.xcodeproj/project.pbxproj
@@ -113,6 +113,7 @@
 		0DB0EF9420637563E4608D82 /* TodoReferenceResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoReferenceResponse.swift; sourceTree = "<group>"; };
 		0E5D3E31AD1E8B7CE04D4ACD /* UserPreferencesRepositoryImplTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserPreferencesRepositoryImplTests.swift; sourceTree = "<group>"; };
 		13196553E95A4457076017F7 /* TodoPageResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoPageResponse.swift; sourceTree = "<group>"; };
+		172ECD791E7439EF818A8B6C /* UnitTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "UnitTests-Info.plist"; sourceTree = "<group>"; };
 		1753CF1357FCECF1C08BF516 /* WidgetSyncEventHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetSyncEventHandler.swift; sourceTree = "<group>"; };
 		1CC4FAF80149828CE4DD965E /* PushNotificationResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationResponse.swift; sourceTree = "<group>"; };
 		1DCE41E91372D51D7ED06A1B /* WidgetSyncEventBusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetSyncEventBusTests.swift; sourceTree = "<group>"; };
@@ -129,6 +130,7 @@
 		44D8E28151D4ACD689D20CA4 /* TodoCategoryService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoCategoryService.swift; sourceTree = "<group>"; };
 		46CDEBB619995D2FAFE246DC /* TodoCategoryPreferenceResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoCategoryPreferenceResponse.swift; sourceTree = "<group>"; };
 		475F578F7B5D79DE12864D0F /* NetworkConnectivityRepositoryImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkConnectivityRepositoryImpl.swift; sourceTree = "<group>"; };
+		4B0C831B507031CCA7E97067 /* Framework-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "Framework-Info.plist"; sourceTree = "<group>"; };
 		4B0D536ED65FF0568D75B5A7 /* AuthDataResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthDataResponse.swift; sourceTree = "<group>"; };
 		5770DD42523D93F4AB839D66 /* TodoDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoDTO.swift; sourceTree = "<group>"; };
 		59CEE04ACC0B3172214095E2 /* UserProfileMapping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileMapping.swift; sourceTree = "<group>"; };
@@ -151,7 +153,6 @@
 		9B7B242B75300BEFE39185F7 /* TodoCategoryResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoCategoryResponse.swift; sourceTree = "<group>"; };
 		9CB48D91C8EF2DBC52476A36 /* AuthDataRepositoryImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthDataRepositoryImpl.swift; sourceTree = "<group>"; };
 		9E1C9616F8398F1C2A11B3E8 /* AuthenticationRepositoryImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationRepositoryImpl.swift; sourceTree = "<group>"; };
-		9FA7E683DA10F820DE3FEB02 /* DevLogData-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "DevLogData-Info.plist"; sourceTree = "<group>"; };
 		A24E7646031B3F49A361B271 /* TodoRepositoryImplTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoRepositoryImplTests.swift; sourceTree = "<group>"; };
 		A29C910FFD87F558526C0008 /* WidgetSyncEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetSyncEvent.swift; sourceTree = "<group>"; };
 		A460ED05FBC68418D31FF3E6 /* PushMessagingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushMessagingService.swift; sourceTree = "<group>"; };
@@ -171,7 +172,6 @@
 		F398BF7F2B4457A83FC9D853 /* TodoRepositoryImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoRepositoryImpl.swift; sourceTree = "<group>"; };
 		FAA5CCDA41641E01694E29C6 /* WidgetSyncEventBus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetSyncEventBus.swift; sourceTree = "<group>"; };
 		FB0152B2261416B944A9EB9D /* PushNotificationMapping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationMapping.swift; sourceTree = "<group>"; };
-		FBFBA0307CCB614F70F13A54 /* DevLogDataTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "DevLogDataTests-Info.plist"; sourceTree = "<group>"; };
 		FCEF33A1976C86AFE87F32DA /* UserDefaultsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsStore.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -227,18 +227,18 @@
 			path = Sources;
 			sourceTree = "<group>";
 		};
-		3009D76FFD9BC0F7216D873B /* Derived */ = {
+		2118E3A720544C3E7793C528 /* InfoPlists */ = {
 			isa = PBXGroup;
 			children = (
-				47D74BB51491EC04558C65E9 /* InfoPlists */,
+				4B0C831B507031CCA7E97067 /* Framework-Info.plist */,
+				172ECD791E7439EF818A8B6C /* UnitTests-Info.plist */,
 			);
-			path = Derived;
+			path = InfoPlists;
 			sourceTree = "<group>";
 		};
 		3DB77CA26B141A5930A6DAC8 /* Project */ = {
 			isa = PBXGroup;
 			children = (
-				3009D76FFD9BC0F7216D873B /* Derived */,
 				C8D902130F1B575C6B4A4F0F /* Shared */,
 				114A48F28014D99C30CA3B1C /* Sources */,
 				02B682D08AA4968B501E9987 /* Tests */,
@@ -254,15 +254,6 @@
 				2A24F41BA271A76492C7C784 /* WidgetSyncEventTests.swift */,
 			);
 			path = Widget;
-			sourceTree = "<group>";
-		};
-		47D74BB51491EC04558C65E9 /* InfoPlists */ = {
-			isa = PBXGroup;
-			children = (
-				9FA7E683DA10F820DE3FEB02 /* DevLogData-Info.plist */,
-				FBFBA0307CCB614F70F13A54 /* DevLogDataTests-Info.plist */,
-			);
-			path = InfoPlists;
 			sourceTree = "<group>";
 		};
 		4D310A185DAC92A76849442A /* Repository */ = {
@@ -384,6 +375,7 @@
 		C8D902130F1B575C6B4A4F0F /* Shared */ = {
 			isa = PBXGroup;
 			children = (
+				2118E3A720544C3E7793C528 /* InfoPlists */,
 				2726E65D4893C8BE8739FD9F /* Version.xcconfig */,
 			);
 			name = Shared;
@@ -584,7 +576,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
-				INFOPLIST_FILE = "Derived/InfoPlists/DevLogDataTests-Info.plist";
+				INFOPLIST_FILE = "../Shared/InfoPlists/UnitTests-Info.plist";
 				INFOPLIST_KEY_CFBundleShortVersionString = "$(MARKETING_VERSION)";
 				INFOPLIST_KEY_CFBundleVersion = "$(CURRENT_PROJECT_VERSION)";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -624,7 +616,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = "Derived/InfoPlists/DevLogData-Info.plist";
+				INFOPLIST_FILE = "../Shared/InfoPlists/Framework-Info.plist";
 				INFOPLIST_KEY_CFBundleShortVersionString = "$(MARKETING_VERSION)";
 				INFOPLIST_KEY_CFBundleVersion = "$(CURRENT_PROJECT_VERSION)";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -794,7 +786,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
-				INFOPLIST_FILE = "Derived/InfoPlists/DevLogDataTests-Info.plist";
+				INFOPLIST_FILE = "../Shared/InfoPlists/UnitTests-Info.plist";
 				INFOPLIST_KEY_CFBundleShortVersionString = "$(MARKETING_VERSION)";
 				INFOPLIST_KEY_CFBundleVersion = "$(CURRENT_PROJECT_VERSION)";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -830,7 +822,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = "Derived/InfoPlists/DevLogData-Info.plist";
+				INFOPLIST_FILE = "../Shared/InfoPlists/Framework-Info.plist";
 				INFOPLIST_KEY_CFBundleShortVersionString = "$(MARKETING_VERSION)";
 				INFOPLIST_KEY_CFBundleVersion = "$(CURRENT_PROJECT_VERSION)";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";

--- a/Application/DevLogData/Project.swift
+++ b/Application/DevLogData/Project.swift
@@ -5,6 +5,8 @@ let project = Project.devlogFramework(
     name: "DevLogData",
     bundleId: "com.opfic.DevLog.DevLogData",
     versionXcconfigPath: "../Shared/Version.xcconfig",
+    frameworkInfoPlistPath: "../Shared/InfoPlists/Framework-Info.plist",
+    testsInfoPlistPath: "../Shared/InfoPlists/UnitTests-Info.plist",
     packages: DevLogPackages.lintOnlyPackages,
     dependencies: [
         .project(target: "DevLogDomain", path: "../DevLogDomain"),

--- a/Application/DevLogDomain/DevLogDomain.xcodeproj/project.pbxproj
+++ b/Application/DevLogDomain/DevLogDomain.xcodeproj/project.pbxproj
@@ -201,7 +201,6 @@
 		44A5D2C52532BBF96FA7DE9E /* FetchTodoCategoryPreferencesUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchTodoCategoryPreferencesUseCase.swift; sourceTree = "<group>"; };
 		4AAB919C7D411DB4D9168030 /* FetchPushNotificationsUseCaseImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchPushNotificationsUseCaseImpl.swift; sourceTree = "<group>"; };
 		4BD81068EBC12ED007C0628B /* SignInUseCaseImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInUseCaseImpl.swift; sourceTree = "<group>"; };
-		4D463C567813611BB72A4EC9 /* DevLogDomainTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "DevLogDomainTests-Info.plist"; sourceTree = "<group>"; };
 		4D69B23BE0591EC3D2C53ECE /* UndoDeleteWebPageUseCaseImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UndoDeleteWebPageUseCaseImpl.swift; sourceTree = "<group>"; };
 		4E14DDEA178FA87971333C66 /* DevLogDomainTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DevLogDomainTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		4F95776CDBA91EA25EC51BFB /* FetchPushSettingsUseCaseImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchPushSettingsUseCaseImpl.swift; sourceTree = "<group>"; };
@@ -209,10 +208,10 @@
 		522C178061576861644B6132 /* DeleteWebPageUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteWebPageUseCase.swift; sourceTree = "<group>"; };
 		530D90EC4678D416E4DA12A6 /* TogglePushNotificationReadUseCaseImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TogglePushNotificationReadUseCaseImpl.swift; sourceTree = "<group>"; };
 		55586B5C4575D297A6002CB2 /* FetchTodayDisplayOptionsUseCaseImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchTodayDisplayOptionsUseCaseImpl.swift; sourceTree = "<group>"; };
+		55AF1857CC910D4088DA6B3E /* Framework-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "Framework-Info.plist"; sourceTree = "<group>"; };
 		592F6F6BAD2B4BD3FCF6B175 /* FetchReferenceItemsUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchReferenceItemsUseCase.swift; sourceTree = "<group>"; };
 		5EDF4F333067563A4532492E /* PushNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotification.swift; sourceTree = "<group>"; };
 		60E3EF9F9F9C0D36885541EA /* PushNotificationSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationSettings.swift; sourceTree = "<group>"; };
-		65FF7463114BB27247C51312 /* DevLogDomain-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "DevLogDomain-Info.plist"; sourceTree = "<group>"; };
 		66E6672A3D0D3FC90ABB30F9 /* UpsertStatusMessageUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpsertStatusMessageUseCase.swift; sourceTree = "<group>"; };
 		6807875AE32DB208EC71E260 /* FetchWebPageImageDirSizeUseCaseImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchWebPageImageDirSizeUseCaseImpl.swift; sourceTree = "<group>"; };
 		68E5E96CD62E6E20E6C3A997 /* AuthenticationRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationRepository.swift; sourceTree = "<group>"; };
@@ -251,6 +250,7 @@
 		B926AB07A3ACC2EEB0665894 /* FetchUserDataUseCaseImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchUserDataUseCaseImpl.swift; sourceTree = "<group>"; };
 		BB538664B894C03D937EF198 /* DeleteTodoUseCaseImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteTodoUseCaseImpl.swift; sourceTree = "<group>"; };
 		BB99E0C43BE484896C884DB8 /* DeleteWebPageUseCaseImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteWebPageUseCaseImpl.swift; sourceTree = "<group>"; };
+		BE450CA9209129AF09A303ED /* UnitTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "UnitTests-Info.plist"; sourceTree = "<group>"; };
 		BE77EC768C9439B6C6B526BC /* UndoDeleteTodoUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UndoDeleteTodoUseCase.swift; sourceTree = "<group>"; };
 		C3CE45675AC34DD30EFB1EB5 /* UndoDeletePushNotificationUseCaseImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UndoDeletePushNotificationUseCaseImpl.swift; sourceTree = "<group>"; };
 		C43411396CEB5611FD6DC065 /* UpdatePushSettingsUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatePushSettingsUseCase.swift; sourceTree = "<group>"; };
@@ -551,18 +551,11 @@
 		5FE6D25D759EF61CAAD56945 /* Shared */ = {
 			isa = PBXGroup;
 			children = (
+				9FDBA3D9E1189AF3BF863391 /* InfoPlists */,
 				2AE197125EA28CEE7B37D8E3 /* Version.xcconfig */,
 			);
 			name = Shared;
 			path = ../Shared;
-			sourceTree = "<group>";
-		};
-		6737A29084C4A59BC236B487 /* Derived */ = {
-			isa = PBXGroup;
-			children = (
-				823134EE39FA4E216D8C44B0 /* InfoPlists */,
-			);
-			path = Derived;
 			sourceTree = "<group>";
 		};
 		6C4D28FEC7126C7AC7D53DF2 /* Provider */ = {
@@ -605,15 +598,6 @@
 				50B005D0C1950A3234105EE6 /* UpdatePushNotificationQueryUseCaseImpl.swift */,
 			);
 			path = PushNotification;
-			sourceTree = "<group>";
-		};
-		823134EE39FA4E216D8C44B0 /* InfoPlists */ = {
-			isa = PBXGroup;
-			children = (
-				65FF7463114BB27247C51312 /* DevLogDomain-Info.plist */,
-				4D463C567813611BB72A4EC9 /* DevLogDomainTests-Info.plist */,
-			);
-			path = InfoPlists;
 			sourceTree = "<group>";
 		};
 		888D6BE893F4596CD7110B7C /* Fetch */ = {
@@ -690,6 +674,15 @@
 				0D3B93233F9D8A999C6325C6 /* Today */,
 			);
 			path = UserPreferences;
+			sourceTree = "<group>";
+		};
+		9FDBA3D9E1189AF3BF863391 /* InfoPlists */ = {
+			isa = PBXGroup;
+			children = (
+				55AF1857CC910D4088DA6B3E /* Framework-Info.plist */,
+				BE450CA9209129AF09A303ED /* UnitTests-Info.plist */,
+			);
+			path = InfoPlists;
 			sourceTree = "<group>";
 		};
 		A4390E54A4F3B6277AB6A1DF /* Connectivity */ = {
@@ -790,7 +783,6 @@
 		F5F384B25198A86F62B3D290 /* Project */ = {
 			isa = PBXGroup;
 			children = (
-				6737A29084C4A59BC236B487 /* Derived */,
 				5FE6D25D759EF61CAAD56945 /* Shared */,
 				1DA425AF9DD1931F0D7D7E7E /* Sources */,
 			);
@@ -1053,7 +1045,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = "Derived/InfoPlists/DevLogDomain-Info.plist";
+				INFOPLIST_FILE = "../Shared/InfoPlists/Framework-Info.plist";
 				INFOPLIST_KEY_CFBundleShortVersionString = "$(MARKETING_VERSION)";
 				INFOPLIST_KEY_CFBundleVersion = "$(CURRENT_PROJECT_VERSION)";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -1096,7 +1088,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = "Derived/InfoPlists/DevLogDomain-Info.plist";
+				INFOPLIST_FILE = "../Shared/InfoPlists/Framework-Info.plist";
 				INFOPLIST_KEY_CFBundleShortVersionString = "$(MARKETING_VERSION)";
 				INFOPLIST_KEY_CFBundleVersion = "$(CURRENT_PROJECT_VERSION)";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -1199,7 +1191,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
-				INFOPLIST_FILE = "Derived/InfoPlists/DevLogDomainTests-Info.plist";
+				INFOPLIST_FILE = "../Shared/InfoPlists/UnitTests-Info.plist";
 				INFOPLIST_KEY_CFBundleShortVersionString = "$(MARKETING_VERSION)";
 				INFOPLIST_KEY_CFBundleVersion = "$(CURRENT_PROJECT_VERSION)";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1293,7 +1285,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
-				INFOPLIST_FILE = "Derived/InfoPlists/DevLogDomainTests-Info.plist";
+				INFOPLIST_FILE = "../Shared/InfoPlists/UnitTests-Info.plist";
 				INFOPLIST_KEY_CFBundleShortVersionString = "$(MARKETING_VERSION)";
 				INFOPLIST_KEY_CFBundleVersion = "$(CURRENT_PROJECT_VERSION)";
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/Application/DevLogDomain/Project.swift
+++ b/Application/DevLogDomain/Project.swift
@@ -5,6 +5,8 @@ let project = Project.devlogFramework(
     name: "DevLogDomain",
     bundleId: "com.opfic.DevLog.DevLogDomain",
     versionXcconfigPath: "../Shared/Version.xcconfig",
+    frameworkInfoPlistPath: "../Shared/InfoPlists/Framework-Info.plist",
+    testsInfoPlistPath: "../Shared/InfoPlists/UnitTests-Info.plist",
     packages: DevLogPackages.lintOnlyPackages,
     dependencies: [
         .project(target: "DevLogCore", path: "../DevLogCore"),

--- a/Application/DevLogInfra/DevLogInfra.xcodeproj/project.pbxproj
+++ b/Application/DevLogInfra/DevLogInfra.xcodeproj/project.pbxproj
@@ -89,10 +89,9 @@
 		391C037941B9566A1A06BD71 /* InfraLayerError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfraLayerError.swift; sourceTree = "<group>"; };
 		42C2266B98E4E0E4794D0FB6 /* GoogleAuthenticationServiceImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAuthenticationServiceImpl.swift; sourceTree = "<group>"; };
 		4F9DAE0DF4CFCCB45ED78C3B /* FirebaseAnalyticsServiceImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseAnalyticsServiceImpl.swift; sourceTree = "<group>"; };
+		509C78A2A30A17A92C4D4B52 /* Framework-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "Framework-Info.plist"; sourceTree = "<group>"; };
 		5287082C7DD223F75C2096AA /* FirebaseAuthUser+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FirebaseAuthUser+.swift"; sourceTree = "<group>"; };
-		5523A73C1408F0589CAD56E5 /* DevLogInfra-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "DevLogInfra-Info.plist"; sourceTree = "<group>"; };
 		60FACB11A58A248F2A8ACBFA /* AppleAuthResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleAuthResponse.swift; sourceTree = "<group>"; };
-		6767A842281FFB48E84E4477 /* DevLogInfraTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "DevLogInfraTests-Info.plist"; sourceTree = "<group>"; };
 		7397B6D565BFD4F478C9A0F1 /* PushNotificationServiceImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationServiceImpl.swift; sourceTree = "<group>"; };
 		8C19216926B23327988E800C /* AppleAuthenticationServiceImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleAuthenticationServiceImpl.swift; sourceTree = "<group>"; };
 		911C5B4FDB03FA96CF490F75 /* DevLogInfra.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DevLogInfra.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -102,6 +101,7 @@
 		B46C79C081261CD04F022CD3 /* AuthServiceImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthServiceImpl.swift; sourceTree = "<group>"; };
 		B58AF419649E8A0DA6FD4F1B /* WebPageServiceImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebPageServiceImpl.swift; sourceTree = "<group>"; };
 		C914173D4BA608F536B60E67 /* NWPathConnectivityProviderImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NWPathConnectivityProviderImpl.swift; sourceTree = "<group>"; };
+		D8929D3952D15EF92AA1A14C /* UnitTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "UnitTests-Info.plist"; sourceTree = "<group>"; };
 		DC5336AF5B66270AEA3DD14B /* FirebaseFunctions+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FirebaseFunctions+.swift"; sourceTree = "<group>"; };
 		E17E8E43BF39FC2AFC63EBD1 /* PushMessagingServiceImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushMessagingServiceImpl.swift; sourceTree = "<group>"; };
 		EF4875B9D9967FAA393674EA /* DevLogCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DevLogCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -150,19 +150,9 @@
 			path = Extension;
 			sourceTree = "<group>";
 		};
-		0E57DEFE359015144E7A6399 /* InfoPlists */ = {
-			isa = PBXGroup;
-			children = (
-				5523A73C1408F0589CAD56E5 /* DevLogInfra-Info.plist */,
-				6767A842281FFB48E84E4477 /* DevLogInfraTests-Info.plist */,
-			);
-			path = InfoPlists;
-			sourceTree = "<group>";
-		};
 		28E23892AA91FF8556788ED0 /* Project */ = {
 			isa = PBXGroup;
 			children = (
-				38B36204AD866BD829DF7B15 /* Derived */,
 				67934A4943C3545E22BFFDD6 /* Shared */,
 				7BD7A682F58CD1772921A25B /* Sources */,
 			);
@@ -177,17 +167,10 @@
 			);
 			sourceTree = "<group>";
 		};
-		38B36204AD866BD829DF7B15 /* Derived */ = {
-			isa = PBXGroup;
-			children = (
-				0E57DEFE359015144E7A6399 /* InfoPlists */,
-			);
-			path = Derived;
-			sourceTree = "<group>";
-		};
 		67934A4943C3545E22BFFDD6 /* Shared */ = {
 			isa = PBXGroup;
 			children = (
+				F4CA7CA990820D5928A5E011 /* InfoPlists */,
 				A2D88B6129964F1719A14917 /* Version.xcconfig */,
 			);
 			name = Shared;
@@ -245,6 +228,15 @@
 				B58AF419649E8A0DA6FD4F1B /* WebPageServiceImpl.swift */,
 			);
 			path = Service;
+			sourceTree = "<group>";
+		};
+		F4CA7CA990820D5928A5E011 /* InfoPlists */ = {
+			isa = PBXGroup;
+			children = (
+				509C78A2A30A17A92C4D4B52 /* Framework-Info.plist */,
+				D8929D3952D15EF92AA1A14C /* UnitTests-Info.plist */,
+			);
+			path = InfoPlists;
 			sourceTree = "<group>";
 		};
 		FBC6782C578B7835F9A0E0D2 /* Products */ = {
@@ -427,7 +419,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
-				INFOPLIST_FILE = "Derived/InfoPlists/DevLogInfraTests-Info.plist";
+				INFOPLIST_FILE = "../Shared/InfoPlists/UnitTests-Info.plist";
 				INFOPLIST_KEY_CFBundleShortVersionString = "$(MARKETING_VERSION)";
 				INFOPLIST_KEY_CFBundleVersion = "$(CURRENT_PROJECT_VERSION)";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -467,7 +459,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = "Derived/InfoPlists/DevLogInfra-Info.plist";
+				INFOPLIST_FILE = "../Shared/InfoPlists/Framework-Info.plist";
 				INFOPLIST_KEY_CFBundleShortVersionString = "$(MARKETING_VERSION)";
 				INFOPLIST_KEY_CFBundleVersion = "$(CURRENT_PROJECT_VERSION)";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -573,7 +565,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = "Derived/InfoPlists/DevLogInfra-Info.plist";
+				INFOPLIST_FILE = "../Shared/InfoPlists/Framework-Info.plist";
 				INFOPLIST_KEY_CFBundleShortVersionString = "$(MARKETING_VERSION)";
 				INFOPLIST_KEY_CFBundleVersion = "$(CURRENT_PROJECT_VERSION)";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -676,7 +668,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
-				INFOPLIST_FILE = "Derived/InfoPlists/DevLogInfraTests-Info.plist";
+				INFOPLIST_FILE = "../Shared/InfoPlists/UnitTests-Info.plist";
 				INFOPLIST_KEY_CFBundleShortVersionString = "$(MARKETING_VERSION)";
 				INFOPLIST_KEY_CFBundleVersion = "$(CURRENT_PROJECT_VERSION)";
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/Application/DevLogInfra/Project.swift
+++ b/Application/DevLogInfra/Project.swift
@@ -5,6 +5,8 @@ let project = Project.devlogFramework(
     name: "DevLogInfra",
     bundleId: "com.opfic.DevLog.DevLogInfra",
     versionXcconfigPath: "../Shared/Version.xcconfig",
+    frameworkInfoPlistPath: "../Shared/InfoPlists/Framework-Info.plist",
+    testsInfoPlistPath: "../Shared/InfoPlists/UnitTests-Info.plist",
     packages: DevLogPackages.infraPackages,
     dependencies: [
         .project(target: "DevLogData", path: "../DevLogData"),

--- a/Application/DevLogPersistence/DevLogPersistence.xcodeproj/project.pbxproj
+++ b/Application/DevLogPersistence/DevLogPersistence.xcodeproj/project.pbxproj
@@ -56,16 +56,16 @@
 
 /* Begin PBXFileReference section */
 		0864EAB48EFDCECD09BA9AFA /* DevLogData.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DevLogData.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		33C87ABA4DFD7BDFF54D9FBC /* UnitTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "UnitTests-Info.plist"; sourceTree = "<group>"; };
 		36E1B7DD130F0182BB92F551 /* DevLogPersistenceTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DevLogPersistenceTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3DCA6F3509EB1DBCB1DEB2FA /* DevLogPersistence.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DevLogPersistence.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		61609BCD51A06D5B6369EEFF /* WebPageImageStoreImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebPageImageStoreImpl.swift; sourceTree = "<group>"; };
 		67E63EE51A2809585706E7C8 /* UserDefaultsStoreImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsStoreImpl.swift; sourceTree = "<group>"; };
 		681B0BDCB9C473C2336AE4B7 /* ThemeStoreImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeStoreImpl.swift; sourceTree = "<group>"; };
-		6DA4FDF2D82CA9A9D5DD4A5D /* DevLogPersistence-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "DevLogPersistence-Info.plist"; sourceTree = "<group>"; };
 		73BB1CA638149B5B718B9AE4 /* WidgetSnapshotPreferenceStoreImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetSnapshotPreferenceStoreImpl.swift; sourceTree = "<group>"; };
 		83A8962496BF1CA78D4ABE2A /* Version.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Version.xcconfig; sourceTree = "<group>"; };
-		934C769B9A40787A8D555F86 /* DevLogPersistenceTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "DevLogPersistenceTests-Info.plist"; sourceTree = "<group>"; };
 		A4FBDCAD4BC18FBB17A64116 /* PersistenceAssembler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceAssembler.swift; sourceTree = "<group>"; };
+		AFBD36ED3CDDCF138DEBFDC2 /* Framework-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "Framework-Info.plist"; sourceTree = "<group>"; };
 		B41E73CA1D51BCBE701B60ED /* DevLogCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DevLogCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BC85B2119462F59387CFA027 /* WidgetSnapshotPreferenceStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetSnapshotPreferenceStoreTests.swift; sourceTree = "<group>"; };
 		CB91A62281A05241CCE70F0F /* WidgetSnapshotUpdaterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetSnapshotUpdaterTests.swift; sourceTree = "<group>"; };
@@ -95,11 +95,11 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		19D33E2832184C60B063D358 /* InfoPlists */ = {
+		0762FD8344B47602C2BD8302 /* InfoPlists */ = {
 			isa = PBXGroup;
 			children = (
-				6DA4FDF2D82CA9A9D5DD4A5D /* DevLogPersistence-Info.plist */,
-				934C769B9A40787A8D555F86 /* DevLogPersistenceTests-Info.plist */,
+				AFBD36ED3CDDCF138DEBFDC2 /* Framework-Info.plist */,
+				33C87ABA4DFD7BDFF54D9FBC /* UnitTests-Info.plist */,
 			);
 			path = InfoPlists;
 			sourceTree = "<group>";
@@ -123,18 +123,9 @@
 			path = Persistence;
 			sourceTree = "<group>";
 		};
-		438538490731340CEE8ADF07 /* Derived */ = {
-			isa = PBXGroup;
-			children = (
-				19D33E2832184C60B063D358 /* InfoPlists */,
-			);
-			path = Derived;
-			sourceTree = "<group>";
-		};
 		46CEBA7CE03919D86A1B7BF5 /* Project */ = {
 			isa = PBXGroup;
 			children = (
-				438538490731340CEE8ADF07 /* Derived */,
 				C0AA61EC9CD835C0115AFC98 /* Shared */,
 				971C392A1B5366C2448F0DE8 /* Sources */,
 				8952496A5234B356E0680EB5 /* Tests */,
@@ -192,6 +183,7 @@
 		C0AA61EC9CD835C0115AFC98 /* Shared */ = {
 			isa = PBXGroup;
 			children = (
+				0762FD8344B47602C2BD8302 /* InfoPlists */,
 				83A8962496BF1CA78D4ABE2A /* Version.xcconfig */,
 			);
 			name = Shared;
@@ -345,7 +337,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = "Derived/InfoPlists/DevLogPersistence-Info.plist";
+				INFOPLIST_FILE = "../Shared/InfoPlists/Framework-Info.plist";
 				INFOPLIST_KEY_CFBundleShortVersionString = "$(MARKETING_VERSION)";
 				INFOPLIST_KEY_CFBundleVersion = "$(CURRENT_PROJECT_VERSION)";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -379,7 +371,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
-				INFOPLIST_FILE = "Derived/InfoPlists/DevLogPersistenceTests-Info.plist";
+				INFOPLIST_FILE = "../Shared/InfoPlists/UnitTests-Info.plist";
 				INFOPLIST_KEY_CFBundleShortVersionString = "$(MARKETING_VERSION)";
 				INFOPLIST_KEY_CFBundleVersion = "$(CURRENT_PROJECT_VERSION)";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -551,7 +543,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = "Derived/InfoPlists/DevLogPersistence-Info.plist";
+				INFOPLIST_FILE = "../Shared/InfoPlists/Framework-Info.plist";
 				INFOPLIST_KEY_CFBundleShortVersionString = "$(MARKETING_VERSION)";
 				INFOPLIST_KEY_CFBundleVersion = "$(CURRENT_PROJECT_VERSION)";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -589,7 +581,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
-				INFOPLIST_FILE = "Derived/InfoPlists/DevLogPersistenceTests-Info.plist";
+				INFOPLIST_FILE = "../Shared/InfoPlists/UnitTests-Info.plist";
 				INFOPLIST_KEY_CFBundleShortVersionString = "$(MARKETING_VERSION)";
 				INFOPLIST_KEY_CFBundleVersion = "$(CURRENT_PROJECT_VERSION)";
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/Application/DevLogPersistence/Project.swift
+++ b/Application/DevLogPersistence/Project.swift
@@ -5,6 +5,8 @@ let project = Project.devlogFramework(
     name: "DevLogPersistence",
     bundleId: "com.opfic.DevLog.DevLogPersistence",
     versionXcconfigPath: "../Shared/Version.xcconfig",
+    frameworkInfoPlistPath: "../Shared/InfoPlists/Framework-Info.plist",
+    testsInfoPlistPath: "../Shared/InfoPlists/UnitTests-Info.plist",
     packages: DevLogPackages.lintOnlyPackages,
     dependencies: [
         .project(target: "DevLogData", path: "../DevLogData"),

--- a/Application/DevLogPresentation/DevLogPresentation.xcodeproj/project.pbxproj
+++ b/Application/DevLogPresentation/DevLogPresentation.xcodeproj/project.pbxproj
@@ -138,7 +138,6 @@
 		0EB658B8B1246F4399493FE3 /* TodoListItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoListItem.swift; sourceTree = "<group>"; };
 		10169ED43745C8286BAA560A /* UserTodoCategoryItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserTodoCategoryItem.swift; sourceTree = "<group>"; };
 		14DA5CF22287DA889A033F8E /* LoadingState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingState.swift; sourceTree = "<group>"; };
-		160AF2C6625745DEFB4DB23C /* DevLogPresentationTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "DevLogPresentationTests-Info.plist"; sourceTree = "<group>"; };
 		1B6F1C309AC57614AD630F79 /* Error+SocialLogin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Error+SocialLogin.swift"; sourceTree = "<group>"; };
 		2195BF2BC362FB4BD570C915 /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
 		252057C930A70DC1D5674EE5 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
@@ -174,6 +173,7 @@
 		70A888BE16FA57ED1309E014 /* DevLogCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DevLogCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		70B652BF58D45805A57ECCE0 /* HeatmapDay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeatmapDay.swift; sourceTree = "<group>"; };
 		7236EA0D4F011DB8D2922A65 /* HomeViewCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewCoordinator.swift; sourceTree = "<group>"; };
+		75082DF809488C7ACB3D75BD /* Framework-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "Framework-Info.plist"; sourceTree = "<group>"; };
 		79043B9D995BD5D987320FE6 /* EnvironmentValues+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EnvironmentValues+.swift"; sourceTree = "<group>"; };
 		7DDABB53271F38BCC892B6DD /* TodoListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoListViewModel.swift; sourceTree = "<group>"; };
 		7FA597F8A6C68F9460DE11FC /* TodoEditorWindowValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoEditorWindowValue.swift; sourceTree = "<group>"; };
@@ -196,7 +196,6 @@
 		B81F9AF1E3CEC36D194A916C /* SettingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingViewModel.swift; sourceTree = "<group>"; };
 		B8C462E5D83C6B639A66ED26 /* LoginButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginButton.swift; sourceTree = "<group>"; };
 		BA1D8AFC51309CDFB5962985 /* WebItemRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebItemRow.swift; sourceTree = "<group>"; };
-		BAD66EB3834CFD3D64831511 /* DevLogPresentation-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "DevLogPresentation-Info.plist"; sourceTree = "<group>"; };
 		BF0435F01417FE17DE757ADB /* TodoWindowCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoWindowCoordinator.swift; sourceTree = "<group>"; };
 		C0CBB0EEB3B15A4BE2EF9641 /* SystemTodoCategoryItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemTodoCategoryItem.swift; sourceTree = "<group>"; };
 		C25193961AAF03B736D8BA4D /* MainViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewModel.swift; sourceTree = "<group>"; };
@@ -219,6 +218,7 @@
 		F6D5BDBC6990696C3FA5B22A /* Toast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Toast.swift; sourceTree = "<group>"; };
 		FB82F4B31B49736F70F50EE7 /* SettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingView.swift; sourceTree = "<group>"; };
 		FCFF8EE1B8855BA6B7BC315F /* SearchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewModel.swift; sourceTree = "<group>"; };
+		FE61399BC82A4181913F8586 /* UnitTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "UnitTests-Info.plist"; sourceTree = "<group>"; };
 		FE62ED6DF757AF15ACBB2E07 /* PushNotificationListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationListView.swift; sourceTree = "<group>"; };
 		FF52D6EE30673D682147FAFE /* LoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -331,6 +331,15 @@
 			path = Todo;
 			sourceTree = "<group>";
 		};
+		498AD95ACEF0FEDDF6247FA2 /* InfoPlists */ = {
+			isa = PBXGroup;
+			children = (
+				75082DF809488C7ACB3D75BD /* Framework-Info.plist */,
+				FE61399BC82A4181913F8586 /* UnitTests-Info.plist */,
+			);
+			path = InfoPlists;
+			sourceTree = "<group>";
+		};
 		4D616118490727A8BF1F8245 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
@@ -380,14 +389,6 @@
 				BF0435F01417FE17DE757ADB /* TodoWindowCoordinator.swift */,
 			);
 			path = Home;
-			sourceTree = "<group>";
-		};
-		662F424B1BAF5366B2AE858C /* Derived */ = {
-			isa = PBXGroup;
-			children = (
-				9105D8FAAC29C3CC853C4FFB /* InfoPlists */,
-			);
-			path = Derived;
 			sourceTree = "<group>";
 		};
 		7530E5897034E53A8917ABEF /* Search */ = {
@@ -444,15 +445,6 @@
 			path = Profile;
 			sourceTree = "<group>";
 		};
-		9105D8FAAC29C3CC853C4FFB /* InfoPlists */ = {
-			isa = PBXGroup;
-			children = (
-				BAD66EB3834CFD3D64831511 /* DevLogPresentation-Info.plist */,
-				160AF2C6625745DEFB4DB23C /* DevLogPresentationTests-Info.plist */,
-			);
-			path = InfoPlists;
-			sourceTree = "<group>";
-		};
 		9304DF6054A93BFD4F17E794 /* Products */ = {
 			isa = PBXGroup;
 			children = (
@@ -504,7 +496,6 @@
 		D68750D8827585A7F938F99E /* Project */ = {
 			isa = PBXGroup;
 			children = (
-				662F424B1BAF5366B2AE858C /* Derived */,
 				FF7A52F8B2FCBBE98267FD8D /* Shared */,
 				4D616118490727A8BF1F8245 /* Sources */,
 				BF5F3862615F56298F9D9B7B /* Tests */,
@@ -561,6 +552,7 @@
 		FF7A52F8B2FCBBE98267FD8D /* Shared */ = {
 			isa = PBXGroup;
 			children = (
+				498AD95ACEF0FEDDF6247FA2 /* InfoPlists */,
 				ACA48428342FE3040FE708BE /* Version.xcconfig */,
 			);
 			name = Shared;
@@ -793,7 +785,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = "Derived/InfoPlists/DevLogPresentation-Info.plist";
+				INFOPLIST_FILE = "../Shared/InfoPlists/Framework-Info.plist";
 				INFOPLIST_KEY_CFBundleShortVersionString = "$(MARKETING_VERSION)";
 				INFOPLIST_KEY_CFBundleVersion = "$(CURRENT_PROJECT_VERSION)";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -896,7 +888,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
-				INFOPLIST_FILE = "Derived/InfoPlists/DevLogPresentationTests-Info.plist";
+				INFOPLIST_FILE = "../Shared/InfoPlists/UnitTests-Info.plist";
 				INFOPLIST_KEY_CFBundleShortVersionString = "$(MARKETING_VERSION)";
 				INFOPLIST_KEY_CFBundleVersion = "$(CURRENT_PROJECT_VERSION)";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -931,7 +923,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
-				INFOPLIST_FILE = "Derived/InfoPlists/DevLogPresentationTests-Info.plist";
+				INFOPLIST_FILE = "../Shared/InfoPlists/UnitTests-Info.plist";
 				INFOPLIST_KEY_CFBundleShortVersionString = "$(MARKETING_VERSION)";
 				INFOPLIST_KEY_CFBundleVersion = "$(CURRENT_PROJECT_VERSION)";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -967,7 +959,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = "Derived/InfoPlists/DevLogPresentation-Info.plist";
+				INFOPLIST_FILE = "../Shared/InfoPlists/Framework-Info.plist";
 				INFOPLIST_KEY_CFBundleShortVersionString = "$(MARKETING_VERSION)";
 				INFOPLIST_KEY_CFBundleVersion = "$(CURRENT_PROJECT_VERSION)";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";

--- a/Application/DevLogPresentation/Project.swift
+++ b/Application/DevLogPresentation/Project.swift
@@ -5,6 +5,8 @@ let project = Project.devlogFramework(
     name: "DevLogPresentation",
     bundleId: "com.opfic.DevLog.DevLogPresentation",
     versionXcconfigPath: "../Shared/Version.xcconfig",
+    frameworkInfoPlistPath: "../Shared/InfoPlists/Framework-Info.plist",
+    testsInfoPlistPath: "../Shared/InfoPlists/UnitTests-Info.plist",
     packages: DevLogPackages.presentationPackages,
     dependencies: [
         .project(target: "DevLogDomain", path: "../DevLogDomain"),

--- a/Application/Shared/InfoPlists/Framework-Info.plist
+++ b/Application/Shared/InfoPlists/Framework-Info.plist
@@ -13,15 +13,10 @@
 	<key>CFBundleName</key>
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>
-	<string>XPC!</string>
+	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
-	<key>NSExtension</key>
-	<dict>
-		<key>NSExtensionPointIdentifier</key>
-		<string>com.apple.widgetkit-extension</string>
-	</dict>
 </dict>
 </plist>

--- a/Application/Shared/InfoPlists/UnitTests-Info.plist
+++ b/Application/Shared/InfoPlists/UnitTests-Info.plist
@@ -13,15 +13,10 @@
 	<key>CFBundleName</key>
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>
-	<string>XPC!</string>
+	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
-	<key>NSExtension</key>
-	<dict>
-		<key>NSExtensionPointIdentifier</key>
-		<string>com.apple.widgetkit-extension</string>
-	</dict>
 </dict>
 </plist>

--- a/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
+++ b/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
@@ -5,6 +5,8 @@ public extension Project {
         name: String,
         bundleId: String,
         versionXcconfigPath: Path,
+        frameworkInfoPlistPath: Path,
+        testsInfoPlistPath: Path,
         packages: [Package] = DevLogPackages.lintOnlyPackages,
         dependencies: [TargetDependency] = [],
         hasTests: Bool
@@ -15,7 +17,7 @@ public extension Project {
                 destinations: .iOS,
                 product: .framework,
                 bundleId: bundleId,
-                infoPlist: .default,
+                infoPlist: .file(path: frameworkInfoPlistPath),
                 sources: ["Sources/**/*.swift"],
                 dependencies: dependencies + [DevLogPackages.swiftLintPlugin],
                 settings: .devlog(versionXcconfigPath: versionXcconfigPath)
@@ -29,7 +31,7 @@ public extension Project {
                     destinations: .iOS,
                     product: .unitTests,
                     bundleId: "\(bundleId)Tests",
-                    infoPlist: .default,
+                    infoPlist: .file(path: testsInfoPlistPath),
                     sources: ["Tests/**/*.swift"],
                     dependencies: [
                         .target(name: name),

--- a/Widget/DevLogWidgetCore/DevLogWidgetCore.xcodeproj/project.pbxproj
+++ b/Widget/DevLogWidgetCore/DevLogWidgetCore.xcodeproj/project.pbxproj
@@ -67,8 +67,8 @@
 		3A101EE8912071F11ADFA32A /* WidgetSharedConstantsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetSharedConstantsTests.swift; sourceTree = "<group>"; };
 		3F49912C26702885D7E28613 /* HeatmapWidgetSnapshotFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeatmapWidgetSnapshotFactory.swift; sourceTree = "<group>"; };
 		471664B4D33328062B8948E7 /* HeatmapWidgetSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeatmapWidgetSnapshot.swift; sourceTree = "<group>"; };
-		5B34B7D7E70F2E8D22CC0BE7 /* DevLogWidgetCore-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "DevLogWidgetCore-Info.plist"; sourceTree = "<group>"; };
 		6C06B13B7461FDA8764718D6 /* WidgetSnapshotStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetSnapshotStore.swift; sourceTree = "<group>"; };
+		7DC8D74C8FEEFA1CB95D0367 /* Framework-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "Framework-Info.plist"; sourceTree = "<group>"; };
 		A70B61E0BBE4E28AAB7EBC62 /* WidgetHeatmapPlaceholderShapeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetHeatmapPlaceholderShapeTests.swift; sourceTree = "<group>"; };
 		AD0F256C06042BBA3F4FD64B /* WidgetAppGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetAppGroup.swift; sourceTree = "<group>"; };
 		BB2502195815B7B0CDC41480 /* DevLogWidgetCoreTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DevLogWidgetCoreTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -76,9 +76,9 @@
 		C82279AEC65491588EF7A242 /* Version.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Version.xcconfig; sourceTree = "<group>"; };
 		CF17A8E7B670D7A07F12109E /* WidgetDeepLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetDeepLink.swift; sourceTree = "<group>"; };
 		D0B60A92D2D4AAF76EC22F9E /* TodayWidgetSnapshotFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayWidgetSnapshotFactory.swift; sourceTree = "<group>"; };
+		D20C1507A252483CC0EBEF06 /* UnitTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "UnitTests-Info.plist"; sourceTree = "<group>"; };
 		E0D4EA1FEF8ED7F84703C415 /* WidgetSharedDefaultsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetSharedDefaultsStore.swift; sourceTree = "<group>"; };
 		E75C91AA02459B09ABDEF0DA /* TodayWidgetSnapshotFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayWidgetSnapshotFactoryTests.swift; sourceTree = "<group>"; };
-		ED601024B9F454851B70EE57 /* DevLogWidgetCoreTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "DevLogWidgetCoreTests-Info.plist"; sourceTree = "<group>"; };
 		FC3C49608557879883A88CD2 /* DevLogWidgetCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DevLogWidgetCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FE857C3FD31F6C2B9C8D55B8 /* WidgetKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetKind.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -103,14 +103,6 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		0228F9ED62EF9ADAC02DF879 /* Derived */ = {
-			isa = PBXGroup;
-			children = (
-				3CF6BE6244E1E4AC9CCF4BEA /* InfoPlists */,
-			);
-			path = Derived;
-			sourceTree = "<group>";
-		};
 		0ADDCA70C655D8BC1A487A47 /* Common */ = {
 			isa = PBXGroup;
 			children = (
@@ -123,6 +115,7 @@
 		0BB0C4BC8344BA7713A2B04D /* Shared */ = {
 			isa = PBXGroup;
 			children = (
+				FCD7F0B11B6456D03AD71FFC /* InfoPlists */,
 				C82279AEC65491588EF7A242 /* Version.xcconfig */,
 			);
 			path = Shared;
@@ -132,7 +125,6 @@
 			isa = PBXGroup;
 			children = (
 				376E007556FB94677C40BDE8 /* Application */,
-				0228F9ED62EF9ADAC02DF879 /* Derived */,
 				59DEFD5120F166B9DB4DCBD5 /* Sources */,
 				318919BB7F4C0CB792446E05 /* Tests */,
 			);
@@ -175,15 +167,6 @@
 				3F49912C26702885D7E28613 /* HeatmapWidgetSnapshotFactory.swift */,
 			);
 			path = Heatmap;
-			sourceTree = "<group>";
-		};
-		3CF6BE6244E1E4AC9CCF4BEA /* InfoPlists */ = {
-			isa = PBXGroup;
-			children = (
-				5B34B7D7E70F2E8D22CC0BE7 /* DevLogWidgetCore-Info.plist */,
-				ED601024B9F454851B70EE57 /* DevLogWidgetCoreTests-Info.plist */,
-			);
-			path = InfoPlists;
 			sourceTree = "<group>";
 		};
 		4A911356A8BD59863C146BF8 /* Today */ = {
@@ -241,6 +224,15 @@
 				D0B60A92D2D4AAF76EC22F9E /* TodayWidgetSnapshotFactory.swift */,
 			);
 			path = Today;
+			sourceTree = "<group>";
+		};
+		FCD7F0B11B6456D03AD71FFC /* InfoPlists */ = {
+			isa = PBXGroup;
+			children = (
+				7DC8D74C8FEEFA1CB95D0367 /* Framework-Info.plist */,
+				D20C1507A252483CC0EBEF06 /* UnitTests-Info.plist */,
+			);
+			path = InfoPlists;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -392,7 +384,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
-				INFOPLIST_FILE = "Derived/InfoPlists/DevLogWidgetCoreTests-Info.plist";
+				INFOPLIST_FILE = "../../Application/Shared/InfoPlists/UnitTests-Info.plist";
 				INFOPLIST_KEY_CFBundleShortVersionString = "$(MARKETING_VERSION)";
 				INFOPLIST_KEY_CFBundleVersion = "$(CURRENT_PROJECT_VERSION)";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -497,7 +489,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = "Derived/InfoPlists/DevLogWidgetCore-Info.plist";
+				INFOPLIST_FILE = "../../Application/Shared/InfoPlists/Framework-Info.plist";
 				INFOPLIST_KEY_CFBundleShortVersionString = "$(MARKETING_VERSION)";
 				INFOPLIST_KEY_CFBundleVersion = "$(CURRENT_PROJECT_VERSION)";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -535,7 +527,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
-				INFOPLIST_FILE = "Derived/InfoPlists/DevLogWidgetCoreTests-Info.plist";
+				INFOPLIST_FILE = "../../Application/Shared/InfoPlists/UnitTests-Info.plist";
 				INFOPLIST_KEY_CFBundleShortVersionString = "$(MARKETING_VERSION)";
 				INFOPLIST_KEY_CFBundleVersion = "$(CURRENT_PROJECT_VERSION)";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -638,7 +630,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = "Derived/InfoPlists/DevLogWidgetCore-Info.plist";
+				INFOPLIST_FILE = "../../Application/Shared/InfoPlists/Framework-Info.plist";
 				INFOPLIST_KEY_CFBundleShortVersionString = "$(MARKETING_VERSION)";
 				INFOPLIST_KEY_CFBundleVersion = "$(CURRENT_PROJECT_VERSION)";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";

--- a/Widget/DevLogWidgetCore/Project.swift
+++ b/Widget/DevLogWidgetCore/Project.swift
@@ -5,6 +5,8 @@ let project = Project.devlogFramework(
     name: "DevLogWidgetCore",
     bundleId: "com.opfic.DevLog.DevLogWidgetCore",
     versionXcconfigPath: "../../Application/Shared/Version.xcconfig",
+    frameworkInfoPlistPath: "../../Application/Shared/InfoPlists/Framework-Info.plist",
+    testsInfoPlistPath: "../../Application/Shared/InfoPlists/UnitTests-Info.plist",
     packages: DevLogPackages.lintOnlyPackages,
     dependencies: [
         .project(target: "DevLogCore", path: "../../Application/DevLogCore"),

--- a/Widget/DevLogWidgetExtension/DevLogWidgetExtension.xcodeproj/project.pbxproj
+++ b/Widget/DevLogWidgetExtension/DevLogWidgetExtension.xcodeproj/project.pbxproj
@@ -15,12 +15,10 @@
 		37E3C6E74530428015955EF7 /* HeatmapWidgetEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C63EB0866E0F461576A797E /* HeatmapWidgetEntry.swift */; };
 		5F7E11ECDFC37228EC3439D7 /* HeatmapWidgetSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = C767D7ABD31D2292F579468C /* HeatmapWidgetSnapshot.swift */; };
 		6FAE62111C10881C9CE0BBDC /* HeatmapWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0315B1E52E66C3F64C76749 /* HeatmapWidget.swift */; };
-		832DD99138202C34E026F64E /* TuistBundle+DevLogWidgetExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7768B3FB60D3CFC62FB55046 /* TuistBundle+DevLogWidgetExtension.swift */; };
 		8B6FD2EED33A6F24C066E72C /* WidgetPlaceholderCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E2B50B274B1C22A4ABA8FCB /* WidgetPlaceholderCard.swift */; };
 		8E92F12CC884AD108747309F /* HeatmapWidgetConfigurationIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B39856A2E8750D45139C03C /* HeatmapWidgetConfigurationIntent.swift */; };
 		9CE95F0C72D62ADED106E45B /* TodayTodoWidgetEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7DAD785EC0C8A04516D292 /* TodayTodoWidgetEntry.swift */; };
 		A859CEEC1DEA45B114348C8A /* TodayWidgetSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = C486CDFEB8F12FDACAB34DF3 /* TodayWidgetSnapshot.swift */; };
-		B26C1DD779606C03CFE9165E /* TuistAssets+DevLogWidgetExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C75BF5BC326ECEB538079CC /* TuistAssets+DevLogWidgetExtension.swift */; };
 		B615669DA5B79B9E9B8C8E73 /* DevLogWidgetCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D9F255A8F63C0FA8A4B8BA4 /* DevLogWidgetCore.framework */; };
 		B9B04BF9C0C7CFFD32F0A01A /* TodayTodoWidgetEntryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44FF92DB8155A7AB1FB2208E /* TodayTodoWidgetEntryView.swift */; };
 		BBA8368E97685C969ACFB1C4 /* WidgetHeatmapGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 810827E0FF4659B548BA1189 /* WidgetHeatmapGrid.swift */; };
@@ -49,17 +47,16 @@
 		0C63EB0866E0F461576A797E /* HeatmapWidgetEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeatmapWidgetEntry.swift; sourceTree = "<group>"; };
 		13AC26AC485116B3F2A78F68 /* DevLogWidget.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = DevLogWidget.entitlements; sourceTree = "<group>"; };
 		14125274A6EB7399B87CCB63 /* WidgetSnapshotStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetSnapshotStore.swift; sourceTree = "<group>"; };
-		1C75BF5BC326ECEB538079CC /* TuistAssets+DevLogWidgetExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TuistAssets+DevLogWidgetExtension.swift"; sourceTree = "<group>"; };
 		1D9F255A8F63C0FA8A4B8BA4 /* DevLogWidgetCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DevLogWidgetCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		25FFDCC8525136F6CC7EC98F /* Version.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Version.xcconfig; sourceTree = "<group>"; };
 		32B7C10CE588EDB63FA1C59A /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		3BEE66D14A497723133C26B0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		3EAF4DC09E98176B9F89BB6A /* TodayTodoWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayTodoWidget.swift; sourceTree = "<group>"; };
 		40CEE9690896811CC43E9C71 /* TodayTodoWidgetConfigurationIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayTodoWidgetConfigurationIntent.swift; sourceTree = "<group>"; };
 		44FF92DB8155A7AB1FB2208E /* TodayTodoWidgetEntryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayTodoWidgetEntryView.swift; sourceTree = "<group>"; };
 		4E2B50B274B1C22A4ABA8FCB /* WidgetPlaceholderCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetPlaceholderCard.swift; sourceTree = "<group>"; };
 		5CFBD6E83B5166362F500A00 /* DevLogWidgetExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = DevLogWidgetExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		64C2CACF1270870F3D8BA217 /* DevLogWidgetBundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DevLogWidgetBundle.swift; sourceTree = "<group>"; };
-		7768B3FB60D3CFC62FB55046 /* TuistBundle+DevLogWidgetExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TuistBundle+DevLogWidgetExtension.swift"; sourceTree = "<group>"; };
 		810827E0FF4659B548BA1189 /* WidgetHeatmapGrid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetHeatmapGrid.swift; sourceTree = "<group>"; };
 		81EB573652A465C67708ECC2 /* Localizable.xcstrings */ = {isa = PBXFileReference; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		8B39856A2E8750D45139C03C /* HeatmapWidgetConfigurationIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeatmapWidgetConfigurationIntent.swift; sourceTree = "<group>"; };
@@ -71,7 +68,6 @@
 		C486CDFEB8F12FDACAB34DF3 /* TodayWidgetSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayWidgetSnapshot.swift; sourceTree = "<group>"; };
 		C767D7ABD31D2292F579468C /* HeatmapWidgetSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeatmapWidgetSnapshot.swift; sourceTree = "<group>"; };
 		CE7DAD785EC0C8A04516D292 /* TodayTodoWidgetEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayTodoWidgetEntry.swift; sourceTree = "<group>"; };
-		F2D76C2F7A06ADF85225D55E /* DevLogWidgetExtension-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "DevLogWidgetExtension-Info.plist"; sourceTree = "<group>"; };
 		FAB2D036D1E68DC1E6A61969 /* TodayTodoWidgetProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayTodoWidgetProvider.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -87,14 +83,6 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		14B95495A6E85FDF6536EF38 /* InfoPlists */ = {
-			isa = PBXGroup;
-			children = (
-				F2D76C2F7A06ADF85225D55E /* DevLogWidgetExtension-Info.plist */,
-			);
-			path = InfoPlists;
-			sourceTree = "<group>";
-		};
 		1838F0FDDD2C069B9F497092 /* Heatmap */ = {
 			isa = PBXGroup;
 			children = (
@@ -110,29 +98,12 @@
 			path = Heatmap;
 			sourceTree = "<group>";
 		};
-		2053AFEFA0975EB5B8AB483B /* Derived */ = {
-			isa = PBXGroup;
-			children = (
-				14B95495A6E85FDF6536EF38 /* InfoPlists */,
-				3C7E4F54283A2003E56E9694 /* Sources */,
-			);
-			path = Derived;
-			sourceTree = "<group>";
-		};
-		3C7E4F54283A2003E56E9694 /* Sources */ = {
-			isa = PBXGroup;
-			children = (
-				1C75BF5BC326ECEB538079CC /* TuistAssets+DevLogWidgetExtension.swift */,
-				7768B3FB60D3CFC62FB55046 /* TuistBundle+DevLogWidgetExtension.swift */,
-			);
-			path = Sources;
-			sourceTree = "<group>";
-		};
 		6E112C56584884031FD3D652 /* Resource */ = {
 			isa = PBXGroup;
 			children = (
 				32B7C10CE588EDB63FA1C59A /* Assets.xcassets */,
 				13AC26AC485116B3F2A78F68 /* DevLogWidget.entitlements */,
+				3BEE66D14A497723133C26B0 /* Info.plist */,
 				81EB573652A465C67708ECC2 /* Localizable.xcstrings */,
 			);
 			path = Resource;
@@ -143,7 +114,6 @@
 			children = (
 				C9A70630D3F4CC07D9F99F70 /* Application */,
 				C696BB6A953AA245F803F47D /* Common */,
-				2053AFEFA0975EB5B8AB483B /* Derived */,
 				1838F0FDDD2C069B9F497092 /* Heatmap */,
 				6E112C56584884031FD3D652 /* Resource */,
 				7D84E907853E8F89712C773E /* Today */,
@@ -281,8 +251,6 @@
 				8B6FD2EED33A6F24C066E72C /* WidgetPlaceholderCard.swift in Sources */,
 				E2711AB58FD4E477EF73BC65 /* WidgetSharedDefaultsStore.swift in Sources */,
 				DBDFD568B7756227C1310D28 /* WidgetSnapshotStore.swift in Sources */,
-				B26C1DD779606C03CFE9165E /* TuistAssets+DevLogWidgetExtension.swift in Sources */,
-				832DD99138202C34E026F64E /* TuistBundle+DevLogWidgetExtension.swift in Sources */,
 				020D76A320A0CAF1BC9AA506 /* DevLogWidgetBundle.swift in Sources */,
 				6FAE62111C10881C9CE0BBDC /* HeatmapWidget.swift in Sources */,
 				8E92F12CC884AD108747309F /* HeatmapWidgetConfigurationIntent.swift in Sources */,
@@ -312,7 +280,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				INFOPLIST_FILE = "Derived/InfoPlists/DevLogWidgetExtension-Info.plist";
+				INFOPLIST_FILE = Resource/Info.plist;
 				INFOPLIST_KEY_CFBundleShortVersionString = "$(MARKETING_VERSION)";
 				INFOPLIST_KEY_CFBundleVersion = "$(CURRENT_PROJECT_VERSION)";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -481,7 +449,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				INFOPLIST_FILE = "Derived/InfoPlists/DevLogWidgetExtension-Info.plist";
+				INFOPLIST_FILE = Resource/Info.plist;
 				INFOPLIST_KEY_CFBundleShortVersionString = "$(MARKETING_VERSION)";
 				INFOPLIST_KEY_CFBundleVersion = "$(CURRENT_PROJECT_VERSION)";
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/Widget/DevLogWidgetExtension/Project.swift
+++ b/Widget/DevLogWidgetExtension/Project.swift
@@ -4,8 +4,8 @@ import ProjectDescriptionHelpers
 let project = Project(
     name: "DevLogWidgetExtension",
     options: .options(
-        disableBundleAccessors: false,
-        disableSynthesizedResourceAccessors: false
+        disableBundleAccessors: true,
+        disableSynthesizedResourceAccessors: true
     ),
     settings: .devlogProject(versionXcconfigPath: "../../Application/Shared/Version.xcconfig"),
     targets: [
@@ -14,15 +14,7 @@ let project = Project(
             destinations: .iOS,
             product: .appExtension,
             bundleId: "opfic.DevLog.DevLogWidget",
-            infoPlist: .extendingDefault(
-                with: [
-                    "CFBundleShortVersionString": "$(MARKETING_VERSION)",
-                    "CFBundleVersion": "$(CURRENT_PROJECT_VERSION)",
-                    "NSExtension": [
-                        "NSExtensionPointIdentifier": "com.apple.widgetkit-extension",
-                    ],
-                ]
-            ),
+            infoPlist: .file(path: "Resource/Info.plist"),
             sources: [
                 .glob(
                     "**/*.swift",


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #514

## 🎯 의도

Tuist 기반 생성 산출물 중 리포지토리에 상시 추적할 대상과 재생성 가능한 generated file을 분리하고, `tuist generate --no-open` 이후에도 불필요한 `Derived` 산출물에 의존하지 않는 상태로 정리하기 위함

## 📝 작업 내용

### 📌 요약

- `infoPlist: .default` 사용 제거
- 공용 framework / unit test용 plist 추가
- Widget extension용 명시적 `Info.plist` 추가
- Widget extension의 synthesized resource / bundle accessor 생성 비활성화
- Tuist 재생성 결과에서 `Derived/InfoPlists`, `Derived/Sources` 참조 제거
- generated/cache 산출물 없이도 `tuist generate --no-open` 후 diff clean, build 성공 상태 확인

### 🔍 상세

- `Tuist/ProjectDescriptionHelpers/Project+Templates.swift`에서 framework / unit test 타깃이 공용 plist 파일을 직접 참조하도록 수정
- `Application/DevLogCore`, `DevLogDomain`, `DevLogData`, `DevLogInfra`, `DevLogPersistence`, `DevLogPresentation`, `Widget/DevLogWidgetCore`의 `Project.swift`에 공용 plist 경로 반영
- `Application/DevLogApp/Project.swift`의 test target도 `infoPlist: .default` 대신 공용 unit test plist 경로를 사용하도록 변경
- `Widget/DevLogWidgetExtension/Project.swift`는 `Resource/Info.plist`를 직접 사용하고, `disableBundleAccessors`, `disableSynthesizedResourceAccessors`를 `true`로 변경
- 위 변경에 맞춰 생성된 `.xcodeproj/project.pbxproj` 파일들을 재생성
- 검증:
  - `tuist generate --no-open`
  - `git diff --exit-code`
  - `DevLog.xcworkspace` `DevLogApp` simulator build 성공

## 📸 영상 / 이미지 (Optional)
