### PR TITLE
[#508] regular ui일 때는 뷰 배경색을 통일하도록 수정한다

### DIFF
--- a/Application/DevLogPresentation/Sources/Common/NavigationBarConfigurator.swift
+++ b/Application/DevLogPresentation/Sources/Common/NavigationBarConfigurator.swift
@@ -10,7 +10,7 @@ import DevLogDomain
 
 /// NavigationBar의 배경색을 지정하고 shadowColor를 제거하는 구조체
 ///
-/// 기본적으로 ``UIColor/systemBackground``를 배경색으로 사용하며,
+/// 기본적으로 ``UIColor/systemGroupedBackground``를 배경색으로 사용하며,
 /// 자체 `NavigationStack`을 가진 뷰에서는 `alwaysVisible`을 `true`로 설정하여
 /// 스크롤 위치와 관계없이 배경색이 항상 표시되도록 할 수 있다.
 struct NavigationBarConfigurator: UIViewControllerRepresentable {
@@ -20,7 +20,7 @@ struct NavigationBarConfigurator: UIViewControllerRepresentable {
     /// 지정된 배경색으로 Configurator를 생성한다.
     ///
     /// - Parameter backgroundColor: NavigationBar에 적용할 배경색.
-    init(_ backgroundColor: UIColor = .systemBackground) {
+    init(_ backgroundColor: UIColor = .systemGroupedBackground) {
         self.backgroundColor = backgroundColor
         self.alwaysVisible = false
     }
@@ -32,7 +32,7 @@ struct NavigationBarConfigurator: UIViewControllerRepresentable {
     ///   - alwaysVisible: `true`이면 스크롤 위치와 관계없이 배경색이 항상 표시된다.
     ///     자체 `NavigationStack`을 가진 뷰에서 사용한다.
     @available(iOS, deprecated: 18, message: "iOS 18 이상에서는 alwaysVisible 파라미터가 없는 생성자를 사용한다.")
-    init(_ backgroundColor: UIColor = .systemBackground, alwaysVisible: Bool) {
+    init(_ backgroundColor: UIColor = .systemGroupedBackground, alwaysVisible: Bool) {
         self.backgroundColor = backgroundColor
         if #available(iOS 18.0, *) {
             self.alwaysVisible = false

--- a/Application/DevLogPresentation/Sources/Common/TodoDetailContentView.swift
+++ b/Application/DevLogPresentation/Sources/Common/TodoDetailContentView.swift
@@ -18,7 +18,7 @@ struct TodoDetailContentView: View {
 
     var body: some View {
         ZStack {
-            Color(.secondarySystemBackground).ignoresSafeArea()
+            Color(.systemGroupedBackground).ignoresSafeArea()
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 10) {
                     HStack(alignment: .firstTextBaseline, spacing: 8) {

--- a/Application/DevLogPresentation/Sources/Home/TodoDetailView.swift
+++ b/Application/DevLogPresentation/Sources/Home/TodoDetailView.swift
@@ -17,7 +17,7 @@ struct TodoDetailView: View {
 
     var body: some View {
         ZStack {
-            Color(.secondarySystemBackground).ignoresSafeArea()
+            Color(.systemGroupedBackground).ignoresSafeArea()
             if let todo = viewModel.state.todo, let number = todo.number {
                 TodoDetailContentView(
                     title: todo.title,
@@ -55,7 +55,7 @@ struct TodoDetailView: View {
                     }
                 }
             }
-            .background(Color(.secondarySystemBackground))
+            .background(Color(.systemGroupedBackground))
             .presentationDragIndicator(.visible)
         }
         .fullScreenCover(isPresented: Binding(

--- a/Application/DevLogPresentation/Sources/Home/TodoEditorView.swift
+++ b/Application/DevLogPresentation/Sources/Home/TodoEditorView.swift
@@ -73,7 +73,7 @@ struct TodoEditorView: View {
                         }
                     }
                 }
-                .background(Color(.secondarySystemBackground))
+                .background(Color(.systemGroupedBackground))
                 .presentationDragIndicator(.visible)
             }
             .toolbar {

--- a/Application/DevLogPresentation/Sources/Home/TodoListView.swift
+++ b/Application/DevLogPresentation/Sources/Home/TodoListView.swift
@@ -201,7 +201,7 @@ struct TodoListView: View {
                     if #available(iOS 26.0, *) {
                         Color.clear
                     } else {
-                        Color(.systemBackground)
+                        Color(.systemGroupedBackground)
                     }
                 }
                 .offset(y: headerOffset)

--- a/Application/DevLogPresentation/Sources/Home/TodoListView.swift
+++ b/Application/DevLogPresentation/Sources/Home/TodoListView.swift
@@ -116,6 +116,7 @@ struct TodoListView: View {
             }
         }
         .background(NavigationBarConfigurator())
+        .background(Color(.systemGroupedBackground))
         .task { viewModel.send(.onAppear) }
     }
 

--- a/Application/DevLogPresentation/Sources/Main/MainView.swift
+++ b/Application/DevLogPresentation/Sources/Main/MainView.swift
@@ -152,7 +152,7 @@ struct MainView: View {
                     }
                 }
             }
-            .background(Color(.secondarySystemBackground).ignoresSafeArea())
+            .background(Color(.systemGroupedBackground).ignoresSafeArea())
         case .profile:
             NavigationSplitView {
                 mainSidebar
@@ -236,7 +236,7 @@ struct MainView: View {
                 homeDestinationView(homeRoute)
             }
         }
-        .background(Color(.secondarySystemBackground).ignoresSafeArea())
+        .background(Color(.systemGroupedBackground).ignoresSafeArea())
     }
 
     @ViewBuilder
@@ -304,7 +304,7 @@ struct MainView: View {
                 todayDestinationView(todayRoute)
             }
         }
-        .background(Color(.secondarySystemBackground).ignoresSafeArea())
+        .background(Color(.systemGroupedBackground).ignoresSafeArea())
     }
 
     @ViewBuilder
@@ -349,7 +349,7 @@ struct MainView: View {
                 profileRegularDestinationView(route)
             }
         }
-        .background(Color(.secondarySystemBackground).ignoresSafeArea())
+        .background(Color(.systemGroupedBackground).ignoresSafeArea())
     }
 
     @ViewBuilder

--- a/Application/DevLogPresentation/Sources/PushNotification/PushNotificationListView.swift
+++ b/Application/DevLogPresentation/Sources/PushNotification/PushNotificationListView.swift
@@ -25,7 +25,7 @@ struct PushNotificationListView: View {
     var body: some View {
         NavigationStack {
             notificationList
-                .background(NavigationBarConfigurator(.secondarySystemBackground, alwaysVisible: true))
+                .background(NavigationBarConfigurator(alwaysVisible: true))
                 .onScrollOffsetChange { offset in
                     guard isScrollTrackingEnabled else { return }
                     headerOffset = max(0, -offset)
@@ -35,7 +35,7 @@ struct PushNotificationListView: View {
                 .navigationTitle(String(localized: "nav_push_notifications"))
                 .listStyle(.plain)
         }
-        .background(Color(.secondarySystemBackground).ignoresSafeArea())
+        .background(Color(.systemGroupedBackground).ignoresSafeArea())
         .alert(
             "",
             isPresented: Binding(
@@ -75,7 +75,7 @@ struct PushNotificationListView: View {
                     }
                 }
             }
-            .background(Color(.secondarySystemBackground))
+            .background(Color(.systemGroupedBackground))
             .presentationDragIndicator(.visible)
         }
         .overlay {
@@ -167,7 +167,7 @@ struct PushNotificationListView: View {
             if #available(iOS 26.0, *) {
                 Color.clear
             } else {
-                Color(.secondarySystemBackground)
+                Color(.systemGroupedBackground)
             }
         }
         .offset(y: headerOffset)

--- a/Application/DevLogPresentation/Sources/PushNotification/PushNotificationListView.swift
+++ b/Application/DevLogPresentation/Sources/PushNotification/PushNotificationListView.swift
@@ -25,6 +25,7 @@ struct PushNotificationListView: View {
     var body: some View {
         NavigationStack {
             notificationList
+                .background(Color(.systemGroupedBackground))
                 .background(NavigationBarConfigurator(alwaysVisible: true))
                 .onScrollOffsetChange { offset in
                     guard isScrollTrackingEnabled else { return }

--- a/Application/DevLogPresentation/Sources/Root/RootView.swift
+++ b/Application/DevLogPresentation/Sources/Root/RootView.swift
@@ -104,7 +104,7 @@ public struct RootView: View {
                         }
                     }
                 }
-                .background(Color(.secondarySystemBackground))
+                .background(Color(.systemGroupedBackground))
                 .presentationDragIndicator(.visible)
             }
         }


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #508

## 🎯 의도

- NavigationSplitView의 regular UI와 일부 sheet/detail 화면에서 배경색이 다르게 보여 ux를 해칠 것 같다고 판단하여 통일함

## 📝 작업 내용

### 📌 요약

- 화면 배경색을 `systemGroupedBackground` 기준으로 통일
- NavigationBarConfigurator의 기본 배경색을 `systemGroupedBackground`로 변경
- iOS 18 이하에서 safeArea 영역 배경색이 다르게 보이는 케이스 수정

### 🔍 상세

- TodoDetail, TodoEditor, TodoList, PushNotificationList, RootView, MainView detail 영역의 배경색 정리
- PushNotificationListView의 NavigationBarConfigurator 호출에서 기본 배경 파라미터 제거
- plain List의 safeArea header 색상을 `systemGroupedBackground`로 변경

## 📸 영상 / 이미지 (Optional)
