### PR TITLE
[#522] 로그아웃 시 미등록 FCM 토큰 삭제 실패로 로그아웃이 중단되는 문제를 해결한다

### DIFF
--- a/Application/DevLogApp/DevLogApp.xcodeproj/project.pbxproj
+++ b/Application/DevLogApp/DevLogApp.xcodeproj/project.pbxproj
@@ -138,6 +138,7 @@
 		DCC05042BEB7C047BE4DB7E9 /* DevLogWidgetCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DevLogWidgetCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		ECA33E1403AF8BDB84D46C01 /* DevLogPresentation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DevLogPresentation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F078E79DE65AE8D92F556B27 /* DeletePushNotificationIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeletePushNotificationIntegrationTests.swift; sourceTree = "<group>"; };
+		FA3AC9C61067B0FBDE869711 /* App.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = App.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -206,6 +207,7 @@
 			children = (
 				6F190E03DDAFD11C50FF6510 /* App */,
 				514423F7A59AD057AC7310CA /* Resource */,
+				FA3AC9C61067B0FBDE869711 /* App.xcconfig */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -509,7 +511,7 @@
 /* Begin XCBuildConfiguration section */
 		31AC08F8A6DA3854B3A6B6AC /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4635BA36DE82C73A105E7157 /* Version.xcconfig */;
+			baseConfigurationReference = FA3AC9C61067B0FBDE869711 /* App.xcconfig */;
 			buildSettings = {
 				APS_ENVIRONMENT = production;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
@@ -618,7 +620,7 @@
 		};
 		8D758741AE117AED0462B9E4 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4635BA36DE82C73A105E7157 /* Version.xcconfig */;
+			baseConfigurationReference = FA3AC9C61067B0FBDE869711 /* App.xcconfig */;
 			buildSettings = {
 				APS_ENVIRONMENT = development;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;

--- a/Application/DevLogApp/DevLogApp.xcodeproj/project.pbxproj
+++ b/Application/DevLogApp/DevLogApp.xcodeproj/project.pbxproj
@@ -511,6 +511,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 4635BA36DE82C73A105E7157 /* Version.xcconfig */;
 			buildSettings = {
+				APS_ENVIRONMENT = production;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = Sources/Resource/DevLog.entitlements;
@@ -619,6 +620,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 4635BA36DE82C73A105E7157 /* Version.xcconfig */;
 			buildSettings = {
+				APS_ENVIRONMENT = development;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = Sources/Resource/DevLog.entitlements;

--- a/Application/DevLogApp/Project.swift
+++ b/Application/DevLogApp/Project.swift
@@ -41,6 +41,12 @@ let project = Project(
                     "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
                     "CODE_SIGN_STYLE": "Automatic",
                     "PRODUCT_MODULE_NAME": "DevLogApp",
+                ],
+                debug: [
+                    "APS_ENVIRONMENT": "development",
+                ],
+                release: [
+                    "APS_ENVIRONMENT": "production",
                 ]
             )
         ),

--- a/Application/DevLogApp/Project.swift
+++ b/Application/DevLogApp/Project.swift
@@ -36,7 +36,7 @@ let project = Project(
                 DevLogPackages.swiftLintPlugin,
             ],
             settings: .devlog(
-                versionXcconfigPath: "../Shared/Version.xcconfig",
+                versionXcconfigPath: "Sources/App.xcconfig",
                 base: [
                     "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
                     "CODE_SIGN_STYLE": "Automatic",

--- a/Application/DevLogApp/Sources/App.xcconfig
+++ b/Application/DevLogApp/Sources/App.xcconfig
@@ -1,0 +1,2 @@
+#include "../../Shared/Version.xcconfig"
+#include? "Resource/Config.xcconfig"

--- a/Application/DevLogPresentation/Sources/Common/Component/LoginButton.swift
+++ b/Application/DevLogPresentation/Sources/Common/Component/LoginButton.swift
@@ -31,6 +31,7 @@ struct LoginButton: View {
             Text(text)
                 .foregroundStyle(Color.primary)
                 .font(.system(.body))
+                .contentShape(.capsule)
                 .frame(width: 300, height: height + 16)
                 .overlay {
                     ZStack(alignment: .leading) {
@@ -46,6 +47,5 @@ struct LoginButton: View {
                     }
                 }
         }
-        .contentShape(.capsule)
     }
 }

--- a/Application/DevLogPresentation/Sources/Common/Component/LoginButton.swift
+++ b/Application/DevLogPresentation/Sources/Common/Component/LoginButton.swift
@@ -25,27 +25,27 @@ struct LoginButton: View {
     }
     
     var body: some View {
-        Button(action: {
+        Button {
             action()
-        }) {
+        } label: {
             Text(text)
                 .foregroundStyle(Color.primary)
                 .font(.system(.body))
-        }
-        .frame(width: 300, height: height + 16)
-        .contentShape(.capsule)
-        .overlay {
-            ZStack(alignment: .leading) {
-                Capsule()
-                    .stroke(Color.gray, lineWidth: 1)
-                if let logo = logo {
-                    logo
-                        .resizable()
-                        .scaledToFit()
-                        .frame(width: height, height: height)
-                        .padding(.leading)
+                .frame(width: 300, height: height + 16)
+                .overlay {
+                    ZStack(alignment: .leading) {
+                        Capsule()
+                            .stroke(Color.gray, lineWidth: 1)
+                        if let logo = logo {
+                            logo
+                                .resizable()
+                                .scaledToFit()
+                                .frame(width: height, height: height)
+                                .padding(.leading)
+                        }
+                    }
                 }
-            }
         }
+        .contentShape(.capsule)
     }
 }


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #522

## 🎯 의도
- GitHub 로그인/로그아웃 과정에서 FCM 토큰 등록과 OAuth redirect 설정이 정상 반영되지 않던 문제 해결

## 📝 작업 내용

### 📌 요약
- 앱 타깃에 APNs 환경 설정 추가
- 앱 전용 `App.xcconfig`를 추가해 로컬 `Config.xcconfig` 값을 Info.plist 치환에 사용
- 로그인 버튼의 탭 가능 영역이 텍스트에만 잡히던 문제 수정

### 🔍 상세
- `APS_ENVIRONMENT`를 Debug는 `development`, Release는 `production`으로 설정
- `Application/DevLogApp/Sources/App.xcconfig`에서 공통 version 설정과 로컬 config 설정을 함께 include
- `.gitignore` 대상인 `Config.xcconfig`는 optional include로 처리해 CI 환경에서 파일 누락으로 인한 설정 로드 실패 방지
- 빌드 산출물 기준으로 `APP_REDIRECT_URL`, `GITHUB_CLIENT_ID`, `GIDClientID`, URL scheme 치환 확인
- 빌드 산출물 기준으로 `aps-environment = development` 반영 확인
- `LoginButton`의 frame/overlay를 label 내부로 이동해 버튼 전체 영역이 탭되도록 수정

## 📸 영상 / 이미지 (Optional)