### PR TITLE
[#499] MainView의 selectedTab에서 옵셔널을 제거한다

### DIFF
--- a/Application/DevLogPresentation/Sources/Main/MainView.swift
+++ b/Application/DevLogPresentation/Sources/Main/MainView.swift
@@ -17,13 +17,13 @@ struct MainView: View {
     @State private var todayViewCoordinator: TodayViewCoordinator
     @State private var pushNotificationListViewCoordinator: PushNotificationListViewCoordinator
     @State private var profileViewCoordinator: ProfileViewCoordinator
-    @Binding var selectedTab: MainTab?
+    @Binding var selectedTab: MainTab
     private let windowEvent: TodoEditorWindowEvent
 
     init(
         container: DIContainer,
         windowEvent: TodoEditorWindowEvent,
-        selectedTab: Binding<MainTab?>
+        selectedTab: Binding<MainTab>
     ) {
         self._coordinator = State(initialValue: MainViewCoordinator(container: container))
         self._todoWindowCoordinator = State(initialValue: TodoWindowCoordinator(container: container))
@@ -39,12 +39,10 @@ struct MainView: View {
 
     var body: some View {
         Group {
-            if let selectedTab {
-                if isCompactLayout {
-                    tabView
-                } else {
-                    sidebarView(for: selectedTab)
-                }
+            if isCompactLayout {
+                tabView
+            } else {
+                sidebarView(for: selectedTab)
             }
         }
         .onAppear {
@@ -53,7 +51,6 @@ struct MainView: View {
             todoWindowCoordinator.bindWindowEvent(windowEvent)
         }
         .onChange(of: selectedTab, initial: true) { _, newValue in
-            guard let newValue else { return }
             coordinator.viewModel.send(.selectedTabChanged(newValue))
             if newValue == .home {
                 homeViewCoordinator.fetchData()
@@ -81,26 +78,26 @@ struct MainView: View {
                 .tabItem {
                     tabLabel(.home)
                 }
-                .tag(MainTab.home as MainTab?)
+                .tag(MainTab.home)
 
             todayView
                 .tabItem {
                     tabLabel(.today)
                 }
-                .tag(MainTab.today as MainTab?)
+                .tag(MainTab.today)
 
             notificationView
                 .tabItem {
                     tabLabel(.notification)
                 }
                 .badge(coordinator.viewModel.state.unreadPushCount)
-                .tag(MainTab.notification as MainTab?)
+                .tag(MainTab.notification)
 
             profileView
                 .tabItem {
                     tabLabel(.profile)
                 }
-                .tag(MainTab.profile as MainTab?)
+                .tag(MainTab.profile)
         }
     }
 

--- a/Application/DevLogPresentation/Sources/Root/RootView.swift
+++ b/Application/DevLogPresentation/Sources/Root/RootView.swift
@@ -14,7 +14,7 @@ public struct RootView: View {
     @Environment(\.diContainer) var container: DIContainer
     @State var viewModel: RootViewModel
     @State private var selectedRoute: Route?
-    @State private var selectedMainTab: MainTab?
+    @State private var selectedMainTab = MainTab.home
     private let widgetURLTab: (URL) -> MainTab?
     private let windowEvent: TodoEditorWindowEvent
     private let pushNotificationTodoIdPublisher: AnyPublisher<String, Never>
@@ -65,8 +65,6 @@ public struct RootView: View {
             guard let value else { return }
             if value {
                 selectedMainTab = .home
-            } else {
-                selectedMainTab = nil
             }
         }
         .onOpenURL { url in


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #499

## 🎯 의도

- MainView의 최초 선택 탭을 `.home`으로 고정하기 위한 탭 선택 상태 단순화

## 📝 작업 내용

### 📌 요약

- RootView의 `selectedMainTab` 기본값을 `.home`으로 설정
- MainView의 `selectedTab` 바인딩 타입을 non-optional `MainTab`으로 변경
- TabView tag와 탭 변경 처리에서 optional 분기 제거

### 🔍 상세

- compact layout에서는 non-optional `selectedTab` 기반으로 TabView 선택 처리
- regular layout에서는 동일한 `selectedTab` 값으로 sidebarView 구성
- 로그인 성공 시 `selectedMainTab`을 `.home`으로 재설정하여 재진입 시 초기 탭 보장

## 📸 영상 / 이미지 (Optional)