### PR TITLE
[#519] List row들의 터치/탭 히트박스를 확장한다

### DIFF
--- a/Application/DevLogPresentation/Sources/Home/Home/HomeView.swift
+++ b/Application/DevLogPresentation/Sources/Home/Home/HomeView.swift
@@ -383,8 +383,8 @@ struct HomeView: View {
                 .foregroundStyle(Color.primary)
             Spacer()
         }
-        .padding(.vertical, -6)
         .contentShape(.rect)
+        .padding(.vertical, -6)
     }
 
     private func openTodoEditor(for todoCategory: TodoCategory) {

--- a/Application/DevLogPresentation/Sources/Home/Home/HomeView.swift
+++ b/Application/DevLogPresentation/Sources/Home/Home/HomeView.swift
@@ -124,6 +124,7 @@ struct HomeView: View {
                 let preferences = coordinator.viewModel.state.preferences
                 ForEach(preferences.filter { $0.isVisible }, id: \.id) { item in
                     todoCategoryRow(item)
+                        .listRowInsets((EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16)))
                 }
             }
         }, header: {
@@ -384,7 +385,6 @@ struct HomeView: View {
             Spacer()
         }
         .contentShape(.rect)
-        .padding(.vertical, -6)
     }
 
     private func openTodoEditor(for todoCategory: TodoCategory) {


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #519

## 🎯 의도

- Mac App에서 Home 화면의 List row에서 터치 가능 영역이 실제 표시 영역과 어긋나는 문제 개선

## 📝 작업 내용

### 📌 요약

- Home 화면의 Todo category row에서 `contentShape` 적용 위치를 조정

### 🔍 상세

- `labelImage`에서 vertical padding보다 먼저 `contentShape(.rect)`가 적용되도록 modifier 순서를 변경
- row label의 시각적 padding은 유지하면서, hit-test shape가 padding으로 줄어든 영역을 기준으로 잡히지 않도록 조정

## 📸 영상 / 이미지 (Optional)
