### PR TITLE
[#528] actor에서 Task.detached를 사용하지 않고 백그라운드 스레드로 작업을 할 수 있도록 개선한다

### DIFF
--- a/Application/DevLogData/Sources/Protocol/WebPageImageStore.swift
+++ b/Application/DevLogData/Sources/Protocol/WebPageImageStore.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public protocol WebPageImageStore {
+public protocol WebPageImageStore: Sendable {
     func cachedImageURL(for url: URL) async throws -> URL
     func saveImage(_ data: Data, for url: URL) async throws -> URL
     func dirSizeInBytes() async -> Int64

--- a/Application/DevLogPersistence/Sources/Persistence/WebPageImageStoreImpl.swift
+++ b/Application/DevLogPersistence/Sources/Persistence/WebPageImageStoreImpl.swift
@@ -9,43 +9,60 @@ import CryptoKit
 import Foundation
 import DevLogData
 
-actor WebPageImageStoreImpl: WebPageImageStore {
+final class WebPageImageStoreImpl: WebPageImageStore {
+    private let queue = DispatchQueue(
+        label: "devlog.web-page-image-store",
+        qos: .utility
+    )
+
     func cachedImageURL(for url: URL) async throws -> URL {
-        return try await Task.detached(priority: .utility) {
-            return try Self.cachedImageURL(for: url)
-        }.value
+        return try await perform {
+            try Self.cachedImageURL(for: url)
+        }
     }
 
     func saveImage(_ data: Data, for url: URL) async throws -> URL {
-        return try await Task.detached(priority: .utility) {
-            return try Self.saveImage(data, for: url)
-        }.value
+        return try await perform {
+            try Self.saveImage(data, for: url)
+        }
     }
 
     func dirSizeInBytes() async -> Int64 {
         do {
-            return try await Task.detached(priority: .utility) {
-                return try Self.dirSizeInBytes()
-            }.value
+            return try await perform {
+                try Self.dirSizeInBytes()
+            }
         } catch {
             return 0
         }
     }
 
     func clearDirectory() async throws {
-        try await Task.detached(priority: .utility) {
+        try await perform {
             try Self.clearDirectory()
-        }.value
+        }
     }
 
     func removeImage(for url: URL) async throws -> Bool {
-        return try await Task.detached(priority: .utility) {
-            return try Self.removeImage(for: url)
-        }.value
+        return try await perform {
+            try Self.removeImage(for: url)
+        }
     }
 }
 
 private extension WebPageImageStoreImpl {
+    func perform<T: Sendable>(_ operation: @escaping @Sendable () throws -> T) async throws -> T {
+        try await withCheckedThrowingContinuation { continuation in
+            queue.async {
+                do {
+                    continuation.resume(returning: try operation())
+                } catch {
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+
     static func hashedFileName(for url: URL) -> String {
         let hashValue = SHA256.hash(data: Data(url.absoluteString.utf8))
         return hashValue.map { String(format: "%02x", $0) }.joined()

--- a/Application/DevLogPersistence/Tests/Persistence/WebPageImageStoreImplTests.swift
+++ b/Application/DevLogPersistence/Tests/Persistence/WebPageImageStoreImplTests.swift
@@ -1,0 +1,79 @@
+//
+//  WebPageImageStoreImplTests.swift
+//  DevLogPersistenceTests
+//
+//  Created by opfic on 6/3/26.
+//
+
+import Foundation
+import Testing
+@testable import DevLogPersistence
+
+@Suite(.serialized)
+struct WebPageImageStoreImplTests {
+    @Test("웹페이지 이미지는 저장되고 삭제된다")
+    func 웹페이지_이미지는_저장되고_삭제된다() async throws {
+        let store = WebPageImageStoreImpl()
+        let fileManager = FileManager.default
+        try await store.clearDirectory()
+        let url = try #require(URL(string: "https://example.com/image"))
+        let data = Data("image-data".utf8)
+
+        let fileURL = try await store.saveImage(data, for: url)
+
+        let savedData = try #require(fileManager.contents(atPath: fileURL.path))
+        let directorySize = await store.dirSizeInBytes()
+        #expect(fileURL.deletingLastPathComponent().lastPathComponent == "webPageImages")
+        #expect(savedData == data)
+        #expect(0 < directorySize)
+
+        let removed = try await store.removeImage(for: url)
+        let removedAgain = try await store.removeImage(for: url)
+
+        #expect(removed)
+        #expect(!removedAgain)
+        #expect(!fileManager.fileExists(atPath: fileURL.path))
+
+        try await store.clearDirectory()
+    }
+
+    @Test("웹페이지 이미지 디렉터리 삭제는 저장된 이미지를 모두 제거한다")
+    func 웹페이지_이미지_디렉터리_삭제는_저장된_이미지를_모두_제거한다() async throws {
+        let store = WebPageImageStoreImpl()
+        try await store.clearDirectory()
+        let firstURL = try #require(URL(string: "https://example.com/first"))
+        let secondURL = try #require(URL(string: "https://example.com/second"))
+
+        _ = try await store.saveImage(Data("first".utf8), for: firstURL)
+        _ = try await store.saveImage(Data("second".utf8), for: secondURL)
+        try await store.clearDirectory()
+
+        let directorySize = await store.dirSizeInBytes()
+        #expect(directorySize == 0)
+    }
+
+    @Test("동시 저장 요청은 요청 순서대로 같은 파일을 갱신한다")
+    func 동시_저장_요청은_요청_순서대로_같은_파일을_갱신한다() async throws {
+        let store = WebPageImageStoreImpl()
+        try await store.clearDirectory()
+        let url = try #require(URL(string: "https://example.com/\(UUID().uuidString)"))
+        let firstData = Data(repeating: 1, count: 64 * 1024 * 1024)
+        let secondData = Data("latest".utf8)
+
+        let firstSaveTask = Task {
+            try await store.saveImage(firstData, for: url)
+        }
+        try await Task.sleep(nanoseconds: 10_000_000)
+        let secondSaveTask = Task {
+            try await store.saveImage(secondData, for: url)
+        }
+
+        _ = try await firstSaveTask.value
+        let fileURL = try await secondSaveTask.value
+        let savedData = try Data(contentsOf: fileURL)
+
+        #expect(savedData == secondData)
+
+        try await store.clearDirectory()
+    }
+}

--- a/Application/DevLogPersistence/Tests/Persistence/WebPageImageStoreImplTests.swift
+++ b/Application/DevLogPersistence/Tests/Persistence/WebPageImageStoreImplTests.swift
@@ -52,28 +52,74 @@ struct WebPageImageStoreImplTests {
         #expect(directorySize == 0)
     }
 
-    @Test("동시 저장 요청은 요청 순서대로 같은 파일을 갱신한다")
-    func 동시_저장_요청은_요청_순서대로_같은_파일을_갱신한다() async throws {
+    @Test("같은 store를 공유하는 객체의 저장은 트랜잭션 단위로 반영된다")
+    func 같은_store를_공유하는_객체의_저장은_트랜잭션_단위로_반영된다() async throws {
         let store = WebPageImageStoreImpl()
+        let firstClient = WebPageImageStoreClient(store: store)
+        let secondClient = WebPageImageStoreClient(store: store)
         try await store.clearDirectory()
         let url = try #require(URL(string: "https://example.com/\(UUID().uuidString)"))
-        let firstData = Data(repeating: 1, count: 64 * 1024 * 1024)
-        let secondData = Data("latest".utf8)
+        let largeData = Data(repeating: 1, count: 64 * 1024 * 1024)
+        let smallData = Data("latest".utf8)
+        let startedAt = ContinuousClock.now
 
-        let firstSaveTask = Task {
-            try await store.saveImage(firstData, for: url)
+        // 동일한 Impl 인스턴스를 공유하는 두 객체가 접근하는 형태의 결과 기반 테스트다.
+        // 첫 번째 큰 저장 작업이 먼저 큐에 들어갈 시간을 준 뒤 두 번째 작은 저장을 요청하고,
+        // 최종 파일이 작은 데이터라면 앞 작업 전체가 끝난 뒤 뒤 작업이 반영된 것으로 본다.
+        // 각 작업의 완료 시점은 호출자 관점에서 saveImage await가 반환된 시점으로 기록한다.
+        let largeSaveTask = Task {
+            try await firstClient.saveImage(largeData, for: url, name: "large", since: startedAt)
         }
         try await Task.sleep(nanoseconds: 10_000_000)
-        let secondSaveTask = Task {
-            try await store.saveImage(secondData, for: url)
-        }
 
-        _ = try await firstSaveTask.value
-        let fileURL = try await secondSaveTask.value
-        let savedData = try Data(contentsOf: fileURL)
+        let smallSaveMeasurement = try await secondClient.saveImage(smallData, for: url, name: "small", since: startedAt)
+        let largeSaveMeasurement = try await largeSaveTask.value
+        let savedData = try Data(contentsOf: smallSaveMeasurement.fileURL)
 
-        #expect(savedData == secondData)
+        print(saveSummary(largeSaveMeasurement))
+        print(saveSummary(smallSaveMeasurement))
+
+        #expect(savedData == smallData)
 
         try await store.clearDirectory()
     }
+}
+
+private struct WebPageImageStoreClient {
+    let store: WebPageImageStoreImpl
+
+    func saveImage(
+        _ data: Data,
+        for url: URL,
+        name: String,
+        since startedAt: ContinuousClock.Instant
+    ) async throws -> WebPageImageStoreSaveMeasurement {
+        let requestedAt = startedAt.duration(to: .now)
+        let fileURL = try await store.saveImage(data, for: url)
+        let finishedAt = startedAt.duration(to: .now)
+
+        return WebPageImageStoreSaveMeasurement(
+            name: name,
+            fileURL: fileURL,
+            requestedAt: requestedAt,
+            finishedAt: finishedAt
+        )
+    }
+}
+
+private struct WebPageImageStoreSaveMeasurement {
+    let name: String
+    let fileURL: URL
+    let requestedAt: Duration
+    let finishedAt: Duration
+}
+
+private func saveSummary(_ measurement: WebPageImageStoreSaveMeasurement) -> String {
+    "\(measurement.name) save requested: \(millisecondsString(measurement.requestedAt))ms, finished: \(millisecondsString(measurement.finishedAt))ms"
+}
+
+private func millisecondsString(_ duration: Duration) -> String {
+    let components = duration.components
+    let milliseconds = Double(components.seconds) * 1_000 + Double(components.attoseconds) / 1_000_000_000_000_000
+    return String(format: "%.3f", milliseconds)
 }


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #528

## 🎯 의도

- 웹페이지 썸네일 이미지 저장 객체가 `actor` 내부에서 `Task.detached`로 파일 I/O를 수행하면서, 실제 저장 작업이 actor isolation 밖에서 실행되는 문제를 개선하기 위함
- 파일 시스템 작업을 전용 직렬 큐에서 처리해 저장, 삭제, 디렉터리 정리 작업이 트랜잭션 단위로 수행되도록 보장하기 위함

## 📝 작업 내용

### 📌 요약

- `WebPageImageStoreImpl`을 `actor`에서 `final class`로 변경
- 웹페이지 이미지 파일 I/O를 `.utility` QoS의 전용 `DispatchQueue`에서 실행하도록 변경
- `Task.detached` 제거
- 웹페이지 이미지 저장, 삭제, 디렉터리 정리 동작 테스트 추가
- 동일 store 인스턴스를 공유하는 객체 간 저장 요청이 트랜잭션 단위로 반영되는지 검증하는 테스트 추가

### 🔍 상세

- `Task.detached(priority: .utility)`로 분리되어 있던 파일 I/O 작업을 `perform {}` 내부로 모음
- `perform {}`은 전용 serial queue에 작업을 enqueue하고 `withCheckedThrowingContinuation`으로 async API와 연결
- `cachedImageURL`, `saveImage`, `dirSizeInBytes`, `clearDirectory`, `removeImage`가 모두 같은 serial queue를 통해 실행되도록 구성
- 같은 URL에 대해 큰 데이터 저장 후 작은 데이터 저장을 요청했을 때, 최종 파일이 작은 데이터로 반영되는지 테스트
- 테스트에서 각 저장 요청/완료 시점을 출력해 작업 완료 순서를 확인할 수 있도록 구성

## 📸 영상 / 이미지 (Optional)

<img width="575" height="66" alt="image" src="https://github.com/user-attachments/assets/8c0f21cb-ccf5-4c37-9591-909cd708c4e9" />
