### PR TITLE
[#535] Github Actions 기반 Fastlane 배포가 실패하는 문제를 해결한다

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,5 +1,6 @@
 XCODE_WORKSPACE = "DevLog.xcworkspace"
 XCODE_PROJ = "Application/DevLogApp/DevLogApp.xcodeproj"
+WIDGET_XCODE_PROJ = "Widget/DevLogWidgetExtension/DevLogWidgetExtension.xcodeproj"
 APP_IDENTIFIER = "opfic.DevLog"
 WIDGET_IDENTIFIER = "opfic.DevLog.DevLogWidget"
 APP_IDENTIFIERS = [APP_IDENTIFIER, WIDGET_IDENTIFIER]
@@ -88,17 +89,25 @@ platform :ios do
     if ENV["CI"] == "true"
       profile_mapping = lane_context[SharedValues::MATCH_PROVISIONING_PROFILE_MAPPING]
       signing_targets = {
-        TARGET_NAME => APP_IDENTIFIER,
-        WIDGET_TARGET_NAME => WIDGET_IDENTIFIER
+        TARGET_NAME => {
+          identifier: APP_IDENTIFIER,
+          xcodeproj: XCODE_PROJ
+        },
+        WIDGET_TARGET_NAME => {
+          identifier: WIDGET_IDENTIFIER,
+          xcodeproj: WIDGET_XCODE_PROJ
+        }
       }
 
-      signing_targets.each do |target_name, app_identifier|
+      signing_targets.each do |target_name, signing_target|
+        app_identifier = signing_target[:identifier]
+        xcodeproj = signing_target[:xcodeproj]
         provisioning_profile_specifier = profile_mapping[app_identifier].to_s
         UI.user_error!("Missing App Store provisioning profile mapping for #{app_identifier}") if provisioning_profile_specifier.empty?
 
         update_code_signing_settings(
           use_automatic_signing: false,
-          path: XCODE_PROJ,
+          path: xcodeproj,
           sdk: "iphoneos*",
           team_id: ENV["APP_STORE_TEAM_ID"],
           targets: [target_name],

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -74,9 +74,16 @@ platform :ios do
 
     setup_ci if ENV["CI"]
 
+    testflight_build_number = latest_testflight_build_number + 1
+
     increment_build_number(
       xcodeproj: XCODE_PROJ,
-      build_number: latest_testflight_build_number + 1
+      build_number: testflight_build_number
+    )
+
+    increment_build_number(
+      xcodeproj: WIDGET_XCODE_PROJ,
+      build_number: testflight_build_number
     )
 
     match(


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #535

## 🎯 의도

TestFlight 배포 workflow에서 `DevLogWidgetExtension` archive가 Development provisioning profile을 찾으며 실패하는 문제를 해결하기 위함

## 📝 작업 내용

### 📌 요약

- Fastlane에서 WidgetExtension signing 설정을 별도 WidgetExtension xcodeproj에 적용하도록 수정

### 🔍 상세

- `WIDGET_XCODE_PROJ` 경로를 추가해 `Widget/DevLogWidgetExtension/DevLogWidgetExtension.xcodeproj`를 signing 설정 대상으로 분리
- App target은 기존 `Application/DevLogApp/DevLogApp.xcodeproj`를 유지
- Widget target은 `DevLogApp.xcodeproj`가 아닌 WidgetExtension 프로젝트에 `update_code_signing_settings`가 적용되도록 변경
- `ruby -c fastlane/Fastfile`로 Fastfile 문법 검증

## 📸 영상 / 이미지 (Optional)