### PR TITLE
[#537] Fastlane에서 업로드가 안되는 문제를 해결한다

### DIFF
--- a/Widget/DevLogWidgetExtension/Resource/Info.plist
+++ b/Widget/DevLogWidgetExtension/Resource/Info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>DevLog</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #537

## 🎯 의도

TestFlight 업로드 단계에서 `DevLogWidgetExtension.appex`의 `CFBundleDisplayName` 누락으로 App Store Connect 검증이 실패하는 문제를 해결하기 위함

## 📝 작업 내용

### 📌 요약

- WidgetExtension `Info.plist`에 `CFBundleDisplayName` 추가

### 🔍 상세

- `Widget/DevLogWidgetExtension/Resource/Info.plist`에 `CFBundleDisplayName` 값을 `DevLog`로 추가
- App Store Connect 업로드 검증에서 요구하는 WidgetExtension 번들 표시 이름 누락 문제 해결
- `plutil -lint Widget/DevLogWidgetExtension/Resource/Info.plist`로 plist 구조 검증
- `xcodebuild -quiet -workspace DevLog.xcworkspace -scheme DevLogApp -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' build`로 빌드 검증

## 📸 영상 / 이미지 (Optional)