### PR TITLE
[#510] TCA 라이브러리 의존성을 추가한다

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,14 @@ jobs:
           install: true
           cache: true
 
+      - name: Install SwiftLint
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          brew list swiftlint >/dev/null 2>&1 || brew install swiftlint
+          swiftlint version
+
       - name: Cache SwiftPM
         uses: actions/cache@v5
         with:
@@ -254,6 +262,14 @@ jobs:
         with:
           install: true
           cache: true
+
+      - name: Install SwiftLint
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          brew list swiftlint >/dev/null 2>&1 || brew install swiftlint
+          swiftlint version
 
       - name: Cache SwiftPM
         uses: actions/cache@v5

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -90,6 +90,14 @@ jobs:
           install: true
           cache: true
 
+      - name: Install SwiftLint
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          brew list swiftlint >/dev/null 2>&1 || brew install swiftlint
+          swiftlint version
+
       - name: Generate Xcode workspace with Tuist
         shell: bash
         run: |

--- a/Application/DevLogApp/Project.swift
+++ b/Application/DevLogApp/Project.swift
@@ -25,7 +25,10 @@ let project = Project(
             ],
             entitlements: .file(path: "Sources/Resource/DevLog.entitlements"),
             scripts: [
-                DevLogScripts.swiftLint(sourcePath: "Sources"),
+                DevLogScripts.swiftLint(
+                    sourcePath: "Sources",
+                    configPath: "Sources/.swiftlint.yml"
+                ),
             ],
             dependencies: [
                 .project(target: "DevLogPresentation", path: "../DevLogPresentation"),
@@ -60,6 +63,12 @@ let project = Project(
             bundleId: "opfic.DevLogAppTests",
             infoPlist: .file(path: "../Shared/InfoPlists/UnitTests-Info.plist"),
             sources: ["Tests/**/*.swift"],
+            scripts: [
+                DevLogScripts.swiftLint(
+                    sourcePath: "Tests",
+                    configPath: "Tests/.swiftlint.yml"
+                ),
+            ],
             dependencies: [
                 .target(name: "DevLogApp"),
             ],
@@ -67,6 +76,7 @@ let project = Project(
                 base: [
                     "BUNDLE_LOADER": "$(TEST_HOST)",
                     "CODE_SIGN_STYLE": "Automatic",
+                    "ENABLE_USER_SCRIPT_SANDBOXING": "NO",
                     "TEST_HOST": "$(BUILT_PRODUCTS_DIR)/DevLog.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/DevLog",
                     "TEST_TARGET_NAME": "DevLogApp",
                 ]

--- a/Application/DevLogApp/Project.swift
+++ b/Application/DevLogApp/Project.swift
@@ -7,7 +7,7 @@ let project = Project(
         disableBundleAccessors: true,
         disableSynthesizedResourceAccessors: true
     ),
-    packages: DevLogPackages.lintOnlyPackages,
+    packages: DevLogPackages.defaultPackages,
     settings: .devlogProject(versionXcconfigPath: "../Shared/Version.xcconfig"),
     targets: [
         .target(
@@ -24,6 +24,9 @@ let project = Project(
                 "Sources/Resource/Localizable.xcstrings",
             ],
             entitlements: .file(path: "Sources/Resource/DevLog.entitlements"),
+            scripts: [
+                DevLogScripts.swiftLint(sourcePath: "Sources"),
+            ],
             dependencies: [
                 .project(target: "DevLogPresentation", path: "../DevLogPresentation"),
                 .project(target: "DevLogPersistence", path: "../DevLogPersistence"),
@@ -33,13 +36,13 @@ let project = Project(
                 .project(target: "DevLogCore", path: "../DevLogCore"),
                 .project(target: "DevLogWidgetCore", path: "../../Widget/DevLogWidgetCore"),
                 .project(target: "DevLogWidgetExtension", path: "../../Widget/DevLogWidgetExtension"),
-                DevLogPackages.swiftLintPlugin,
             ],
             settings: .devlog(
                 versionXcconfigPath: "Sources/Resource/App.xcconfig",
                 base: [
                     "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
                     "CODE_SIGN_STYLE": "Automatic",
+                    "ENABLE_USER_SCRIPT_SANDBOXING": "NO",
                     "PRODUCT_MODULE_NAME": "DevLogApp",
                 ],
                 debug: [

--- a/Application/DevLogCore/Project.swift
+++ b/Application/DevLogCore/Project.swift
@@ -7,6 +7,6 @@ let project = Project.devlogFramework(
     versionXcconfigPath: "../Shared/Version.xcconfig",
     frameworkInfoPlistPath: "../Shared/InfoPlists/Framework-Info.plist",
     testsInfoPlistPath: "../Shared/InfoPlists/UnitTests-Info.plist",
-    packages: DevLogPackages.lintOnlyPackages,
+    packages: DevLogPackages.defaultPackages,
     hasTests: false
 )

--- a/Application/DevLogData/Project.swift
+++ b/Application/DevLogData/Project.swift
@@ -7,7 +7,7 @@ let project = Project.devlogFramework(
     versionXcconfigPath: "../Shared/Version.xcconfig",
     frameworkInfoPlistPath: "../Shared/InfoPlists/Framework-Info.plist",
     testsInfoPlistPath: "../Shared/InfoPlists/UnitTests-Info.plist",
-    packages: DevLogPackages.lintOnlyPackages,
+    packages: DevLogPackages.defaultPackages,
     dependencies: [
         .project(target: "DevLogDomain", path: "../DevLogDomain"),
         .project(target: "DevLogCore", path: "../DevLogCore"),

--- a/Application/DevLogDomain/Project.swift
+++ b/Application/DevLogDomain/Project.swift
@@ -7,7 +7,7 @@ let project = Project.devlogFramework(
     versionXcconfigPath: "../Shared/Version.xcconfig",
     frameworkInfoPlistPath: "../Shared/InfoPlists/Framework-Info.plist",
     testsInfoPlistPath: "../Shared/InfoPlists/UnitTests-Info.plist",
-    packages: DevLogPackages.lintOnlyPackages,
+    packages: DevLogPackages.defaultPackages,
     dependencies: [
         .project(target: "DevLogCore", path: "../DevLogCore"),
     ],

--- a/Application/DevLogPersistence/Project.swift
+++ b/Application/DevLogPersistence/Project.swift
@@ -7,7 +7,7 @@ let project = Project.devlogFramework(
     versionXcconfigPath: "../Shared/Version.xcconfig",
     frameworkInfoPlistPath: "../Shared/InfoPlists/Framework-Info.plist",
     testsInfoPlistPath: "../Shared/InfoPlists/UnitTests-Info.plist",
-    packages: DevLogPackages.lintOnlyPackages,
+    packages: DevLogPackages.defaultPackages,
     dependencies: [
         .project(target: "DevLogData", path: "../DevLogData"),
         .project(target: "DevLogCore", path: "../DevLogCore"),

--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ MVVM을 기반으로 하되, ViewModel 상태 관리에는 MVI 형태의 단방�
 
 ```bash
 brew install mise
+brew install swiftlint
 mise install
 ```
 

--- a/Tuist/ProjectDescriptionHelpers/Project+Packages.swift
+++ b/Tuist/ProjectDescriptionHelpers/Project+Packages.swift
@@ -80,11 +80,16 @@ public enum DevLogScripts {
         if [ "$sourcePathName" != "." ]; then
             "$swiftLintPath" lint --config "$configPath" "$lintSourcePath"
         else
-            status=0
-            while IFS= read -r swiftFilePath; do
-                "$swiftLintPath" lint --config "$configPath" "$swiftFilePath" || status=$?
-            done < <(find "$lintSourcePath" -name "*.swift" -not -path "*/Derived/*" -not -name "Project.swift")
-            exit "$status"
+            swiftFilePaths=()
+            while IFS= read -r -d '' swiftFilePath; do
+                swiftFilePaths+=("$swiftFilePath")
+            done < <(find "$lintSourcePath" -name "*.swift" -not -path "*/Derived/*" -not -name "Project.swift" -print0)
+
+            if [ ${#swiftFilePaths[@]} -lt 1 ]; then
+                exit 0
+            fi
+
+            "$swiftLintPath" lint --config "$configPath" "${swiftFilePaths[@]}"
         fi
         """,
         name: "SwiftLint",

--- a/Tuist/ProjectDescriptionHelpers/Project+Packages.swift
+++ b/Tuist/ProjectDescriptionHelpers/Project+Packages.swift
@@ -59,7 +59,10 @@ public enum DevLogPackages {
 }
 
 public enum DevLogScripts {
-    public static func swiftLint(sourcePath: String) -> TargetScript {
+    public static func swiftLint(
+        sourcePath: String,
+        configPath: String = "../../.swiftlint.yml"
+    ) -> TargetScript {
         TargetScript.pre(
         script: """
         export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
@@ -70,7 +73,7 @@ public enum DevLogScripts {
             exit 1
         fi
 
-        configPath="${SRCROOT}/../../.swiftlint.yml"
+        configPath="${SRCROOT}/\(configPath)"
         sourcePathName="\(sourcePath)"
         lintSourcePath="${SRCROOT}/${sourcePathName}"
 
@@ -86,7 +89,7 @@ public enum DevLogScripts {
         """,
         name: "SwiftLint",
         inputPaths: [
-            "$(SRCROOT)/../../.swiftlint.yml",
+            "$(SRCROOT)/\(configPath)",
             "$(SRCROOT)/\(sourcePath)",
         ],
         basedOnDependencyAnalysis: false,

--- a/Tuist/ProjectDescriptionHelpers/Project+Packages.swift
+++ b/Tuist/ProjectDescriptionHelpers/Project+Packages.swift
@@ -9,6 +9,10 @@ public enum DevLogPackages {
         url: "https://github.com/apple/swift-collections.git",
         .upToNextMajor(from: "1.3.0")
     )
+    public static let composableArchitecturePackage: Package = .package(
+        url: "https://github.com/pointfreeco/swift-composable-architecture",
+        .upToNextMajor(from: "1.25.5")
+    )
     public static let firebasePackage: Package = .package(
         url: "https://github.com/firebase/firebase-ios-sdk",
         .upToNextMajor(from: "11.15.0")
@@ -23,6 +27,7 @@ public enum DevLogPackages {
     )
 
     public static let presentationPackageDependencies: [TargetDependency] = [
+        .package(product: "ComposableArchitecture"),
         .package(product: "MarkdownUI"),
         .package(product: "OrderedCollections"),
     ]
@@ -41,6 +46,7 @@ public enum DevLogPackages {
     public static let defaultPackages: [Package] = []
 
     public static let presentationPackages: [Package] = [
+        composableArchitecturePackage,
         markdownUIPackage,
         swiftCollectionsPackage,
     ]

--- a/Tuist/ProjectDescriptionHelpers/Project+Packages.swift
+++ b/Tuist/ProjectDescriptionHelpers/Project+Packages.swift
@@ -1,10 +1,6 @@
 import ProjectDescription
 
 public enum DevLogPackages {
-    public static let swiftLintPackage: Package = .package(
-        url: "https://github.com/realm/SwiftLint",
-        .upToNextMajor(from: "0.62.1")
-    )
     public static let markdownUIPackage: Package = .package(
         url: "https://github.com/gonzalezreal/swift-markdown-ui.git",
         .upToNextMajor(from: "2.4.1")
@@ -26,11 +22,6 @@ public enum DevLogPackages {
         .upToNextMajor(from: "1.1.0")
     )
 
-    public static let swiftLintPlugin: TargetDependency = .package(
-        product: "SwiftLintBuildToolPlugin",
-        type: .plugin
-    )
-
     public static let presentationPackageDependencies: [TargetDependency] = [
         .package(product: "MarkdownUI"),
         .package(product: "OrderedCollections"),
@@ -47,20 +38,53 @@ public enum DevLogPackages {
         .package(product: "Nexa"),
     ]
 
-    public static let lintOnlyPackages: [Package] = [
-        swiftLintPackage,
-    ]
+    public static let defaultPackages: [Package] = []
 
     public static let presentationPackages: [Package] = [
-        swiftLintPackage,
         markdownUIPackage,
         swiftCollectionsPackage,
     ]
 
     public static let infraPackages: [Package] = [
-        swiftLintPackage,
         firebasePackage,
         googleSignInPackage,
         nexaPackage,
     ]
+}
+
+public enum DevLogScripts {
+    public static func swiftLint(sourcePath: String) -> TargetScript {
+        TargetScript.pre(
+        script: """
+        export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
+
+        swiftLintPath="$(command -v swiftlint || true)"
+        if [ -z "$swiftLintPath" ]; then
+            echo "error: SwiftLint is not installed. Run 'brew install swiftlint'."
+            exit 1
+        fi
+
+        configPath="${SRCROOT}/../../.swiftlint.yml"
+        sourcePathName="\(sourcePath)"
+        lintSourcePath="${SRCROOT}/${sourcePathName}"
+
+        if [ "$sourcePathName" != "." ]; then
+            "$swiftLintPath" lint --config "$configPath" "$lintSourcePath"
+        else
+            status=0
+            while IFS= read -r swiftFilePath; do
+                "$swiftLintPath" lint --config "$configPath" "$swiftFilePath" || status=$?
+            done < <(find "$lintSourcePath" -name "*.swift" -not -path "*/Derived/*" -not -name "Project.swift")
+            exit "$status"
+        fi
+        """,
+        name: "SwiftLint",
+        inputPaths: [
+            "$(SRCROOT)/../../.swiftlint.yml",
+            "$(SRCROOT)/\(sourcePath)",
+        ],
+        basedOnDependencyAnalysis: false,
+        shellPath: "/bin/bash"
+        )
+    }
 }

--- a/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
+++ b/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
@@ -20,7 +20,10 @@ public extension Project {
                 infoPlist: .file(path: frameworkInfoPlistPath),
                 sources: ["Sources/**/*.swift"],
                 scripts: [
-                    DevLogScripts.swiftLint(sourcePath: "Sources"),
+                    DevLogScripts.swiftLint(
+                        sourcePath: "Sources",
+                        configPath: "Sources/.swiftlint.yml"
+                    ),
                 ],
                 dependencies: dependencies,
                 settings: .devlog(
@@ -41,11 +44,18 @@ public extension Project {
                     bundleId: "\(bundleId)Tests",
                     infoPlist: .file(path: testsInfoPlistPath),
                     sources: ["Tests/**/*.swift"],
+                    scripts: [
+                        DevLogScripts.swiftLint(
+                            sourcePath: "Tests",
+                            configPath: "Tests/.swiftlint.yml"
+                        ),
+                    ],
                     dependencies: [
                         .target(name: name),
                     ],
                     settings: .devlog(
                         base: [
+                            "ENABLE_USER_SCRIPT_SANDBOXING": "NO",
                             "TEST_TARGET_NAME": SettingValue(stringLiteral: name),
                         ]
                     )

--- a/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
+++ b/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
@@ -7,7 +7,7 @@ public extension Project {
         versionXcconfigPath: Path,
         frameworkInfoPlistPath: Path,
         testsInfoPlistPath: Path,
-        packages: [Package] = DevLogPackages.lintOnlyPackages,
+        packages: [Package] = DevLogPackages.defaultPackages,
         dependencies: [TargetDependency] = [],
         hasTests: Bool
     ) -> Project {
@@ -19,8 +19,16 @@ public extension Project {
                 bundleId: bundleId,
                 infoPlist: .file(path: frameworkInfoPlistPath),
                 sources: ["Sources/**/*.swift"],
-                dependencies: dependencies + [DevLogPackages.swiftLintPlugin],
-                settings: .devlog(versionXcconfigPath: versionXcconfigPath)
+                scripts: [
+                    DevLogScripts.swiftLint(sourcePath: "Sources"),
+                ],
+                dependencies: dependencies,
+                settings: .devlog(
+                    versionXcconfigPath: versionXcconfigPath,
+                    base: [
+                        "ENABLE_USER_SCRIPT_SANDBOXING": "NO",
+                    ]
+                )
             ),
         ]
 

--- a/Widget/DevLogWidgetCore/Project.swift
+++ b/Widget/DevLogWidgetCore/Project.swift
@@ -7,7 +7,7 @@ let project = Project.devlogFramework(
     versionXcconfigPath: "../../Application/Shared/Version.xcconfig",
     frameworkInfoPlistPath: "../../Application/Shared/InfoPlists/Framework-Info.plist",
     testsInfoPlistPath: "../../Application/Shared/InfoPlists/UnitTests-Info.plist",
-    packages: DevLogPackages.lintOnlyPackages,
+    packages: DevLogPackages.defaultPackages,
     dependencies: [
         .project(target: "DevLogCore", path: "../../Application/DevLogCore"),
     ],

--- a/Widget/DevLogWidgetExtension/Project.swift
+++ b/Widget/DevLogWidgetExtension/Project.swift
@@ -29,6 +29,9 @@ let project = Project(
                 "Resource/Localizable.xcstrings",
             ],
             entitlements: .file(path: "Resource/DevLogWidget.entitlements"),
+            scripts: [
+                DevLogScripts.swiftLint(sourcePath: "."),
+            ],
             dependencies: [
                 .project(target: "DevLogWidgetCore", path: "../DevLogWidgetCore"),
             ],
@@ -36,6 +39,7 @@ let project = Project(
                 versionXcconfigPath: "../../Application/Shared/Version.xcconfig",
                 base: [
                     "CODE_SIGN_STYLE": "Automatic",
+                    "ENABLE_USER_SCRIPT_SANDBOXING": "NO",
                 ]
             )
         ),


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #510

## 🎯 의도

- TCA를 DevLogPresentation 레이어에서 사용할 수 있도록 의존성 추가
- SwiftLint SPM BuildToolPlugin과 TCA macro 의존성의 swift-syntax 해석 충돌을 피하기 위한 SwiftLint 실행 방식 정리

## 📝 작업 내용

### 📌 요약

- DevLogPresentation package에 ComposableArchitecture 의존성 추가
- SwiftLint SPM package/plugin 제거
- Homebrew SwiftLint 기반 Tuist Run Script 추가
- Sources/Tests별 SwiftLint config 적용
- CI/TestFlight workflow에 SwiftLint 설치 단계 추가
- README 로컬 개발 환경 설치 명령에 SwiftLint 추가

### 🔍 상세

- SwiftLint를 SPM 의존성 그래프에서 제거하고 Homebrew binary 실행 방식으로 전환
- Xcode GUI 빌드 환경에서도 SwiftLint를 찾을 수 있도록 `/opt/homebrew/bin`, `/usr/local/bin` PATH 명시
- `Sources`는 각 target의 `Sources/.swiftlint.yml` 기반으로 lint 수행
- `Tests`는 각 test target의 `Tests/.swiftlint.yml` 기반으로 lint 수행
- `Tests/.swiftlint.yml`은 루트 `.swiftlint-tests.yml`을 parent config로 사용
- SwiftLint Run Script가 필요한 target의 `ENABLE_USER_SCRIPT_SANDBOXING` 비활성화
- TCA는 DevLogPresentation의 package/product 의존성으로만 추가

## 📸 영상 / 이미지 (Optional)