### PR TITLE
[#542] 프로젝트를 Swift 6 language mode로 전환한다

### DIFF
--- a/Application/DevLogApp/Sources/App/Delegate/AppDelegate.swift
+++ b/Application/DevLogApp/Sources/App/Delegate/AppDelegate.swift
@@ -12,7 +12,7 @@ import DevLogInfra
 
 class AppDelegate: UIResponder, UIApplicationDelegate {
     private let logger = Logger(category: "AppDelegate")
-    private let container = AppDIContainer.shared
+    private let container = AppDIContainer.default
 
     func application(
         _ app: UIApplication,

--- a/Application/DevLogApp/Sources/App/DevLogApp.swift
+++ b/Application/DevLogApp/Sources/App/DevLogApp.swift
@@ -19,7 +19,7 @@ struct DevLogApp: App {
     @State private var windowEvent = TodoEditorWindowEvent()
 
     init() {
-        AppAssembler().assemble(AppDIContainer.shared)
+        AppAssembler().assemble(AppDIContainer.default)
     }
 
     var body: some Scene {

--- a/Application/DevLogCore/Sources/DIContainer.swift
+++ b/Application/DevLogCore/Sources/DIContainer.swift
@@ -24,7 +24,7 @@ public enum DependencyScope {
     case transient
 }
 
-public protocol DIContainer {
+public protocol DIContainer: Sendable {
     func register<T>(
         _ type: T.Type,
         name: DependencyName?,
@@ -50,8 +50,8 @@ public extension DIContainer {
     }
 }
 
-public final class AppDIContainer: DIContainer {
-    public static let shared = AppDIContainer()
+public final class AppDIContainer: DIContainer, @unchecked Sendable {
+    public static let `default` = AppDIContainer()
 
     private let lock = NSRecursiveLock()
 

--- a/Application/DevLogCore/Sources/DIContainerKey.swift
+++ b/Application/DevLogCore/Sources/DIContainerKey.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 private struct DIContainerKey: EnvironmentKey {
-    static let defaultValue: any DIContainer = AppDIContainer.shared
+    static let defaultValue: any DIContainer = AppDIContainer.default
 }
 
 public extension EnvironmentValues {

--- a/Application/DevLogCore/Sources/PushNotificationQuery.swift
+++ b/Application/DevLogCore/Sources/PushNotificationQuery.swift
@@ -7,13 +7,13 @@
 
 import Foundation
 
-public struct PushNotificationQuery: Equatable {
-    public enum SortOrder: Equatable {
+public struct PushNotificationQuery: Equatable, Sendable {
+    public enum SortOrder: Equatable, Sendable {
         case latest
         case oldest
     }
 
-    public enum TimeFilter: Equatable, Hashable {
+    public enum TimeFilter: Equatable, Hashable, Sendable {
         case none
         case hours(Int)
         case days(Int)

--- a/Tuist/ProjectDescriptionHelpers/Project+Settings.swift
+++ b/Tuist/ProjectDescriptionHelpers/Project+Settings.swift
@@ -16,8 +16,8 @@ public extension Settings {
             "CURRENT_PROJECT_VERSION": "1",
             "INFOPLIST_KEY_CFBundleShortVersionString": "$(MARKETING_VERSION)",
             "INFOPLIST_KEY_CFBundleVersion": "$(CURRENT_PROJECT_VERSION)",
-            "TARGETED_DEVICE_FAMILY": "1,2",
             "SWIFT_VERSION": "6.0",
+            "TARGETED_DEVICE_FAMILY": "1,2"
         ]
         commonBase.merge(base) { _, new in new }
 
@@ -26,7 +26,7 @@ public extension Settings {
                 base: commonBase,
                 configurations: [
                     .debug(name: "Debug", settings: debug, xcconfig: versionXcconfigPath),
-                    .release(name: "Release", settings: release, xcconfig: versionXcconfigPath),
+                    .release(name: "Release", settings: release, xcconfig: versionXcconfigPath)
                 ],
                 defaultSettings: defaultSettings
             )
@@ -36,7 +36,7 @@ public extension Settings {
             base: commonBase,
             configurations: [
                 .debug(name: "Debug", settings: debug),
-                .release(name: "Release", settings: release),
+                .release(name: "Release", settings: release)
             ],
             defaultSettings: defaultSettings
         )
@@ -50,7 +50,7 @@ public extension Settings {
             "ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS": "YES",
             "DEVELOPMENT_TEAM": DevLogSigning.teamID,
             "ENABLE_USER_SCRIPT_SANDBOXING": "YES",
-            "STRING_CATALOG_GENERATE_SYMBOLS": "YES",
+            "STRING_CATALOG_GENERATE_SYMBOLS": "YES"
         ]
         base.merge(additionalBase) { _, new in new }
         return .devlog(versionXcconfigPath: versionXcconfigPath, base: base)

--- a/Tuist/ProjectDescriptionHelpers/Project+Settings.swift
+++ b/Tuist/ProjectDescriptionHelpers/Project+Settings.swift
@@ -16,8 +16,8 @@ public extension Settings {
             "CURRENT_PROJECT_VERSION": "1",
             "INFOPLIST_KEY_CFBundleShortVersionString": "$(MARKETING_VERSION)",
             "INFOPLIST_KEY_CFBundleVersion": "$(CURRENT_PROJECT_VERSION)",
-            "SWIFT_VERSION": "5.0",
             "TARGETED_DEVICE_FAMILY": "1,2",
+            "SWIFT_VERSION": "6.0",
         ]
         commonBase.merge(base) { _, new in new }
 


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #542

## 🎯 의도

- Swift 6 language mode를 적용해 TCA 도입 이후 드러나는 Sendable 및 concurrency-safety 이슈를 컴파일 단계에서 에러로 검증하기 위함

## 📝 작업 내용

### 📌 요약

- Tuist 공통 build setting의 `SWIFT_VERSION`을 `6.0`으로 변경
- `PushNotificationQuery` 값 타입에 `Sendable` 채택
- `AppDIContainer`를 Alamofire의 `Session.default`와 유사한 default singleton 형태로 정리
- lock으로 보호되는 DIContainer의 전역 공유 가능성을 `@unchecked Sendable`로 명시
- SwiftLint `trailing_comma` 경고 제거

### 🔍 상세

- `Settings.devlog`에 적용되는 공통 `SWIFT_VERSION`을 `5.0`에서 `6.0`으로 변경
- `PushNotificationQuery`, `SortOrder`, `TimeFilter`에 `Sendable`을 채택해 Swift 6 concurrency 진단 대응
- 기존 `AppDIContainer.shared`를 `AppDIContainer.default`로 변경해 전역 기본 인스턴스 의미를 명확화
- 기존 `NSRecursiveLock`으로 보호되던 `register` / `resolve` 접근을 근거로 `AppDIContainer`에 `@unchecked Sendable` 채택
- `DIContainer` protocol에 `Sendable`을 채택해 SwiftUI `EnvironmentKey.defaultValue`의 전역 공유 진단 대응

## 📸 영상 / 이미지 (Optional)

