### PR TITLE
[#546] Tuist 설정에서 SwiftLint 범위와 TCA 링크 방식을 정리한다

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,3 +1,6 @@
+excluded:
+  - Tuist
+
 disabled_rules:
   - nesting
   - multiple_closures_with_trailing_closure

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,5 +1,16 @@
 excluded:
   - Tuist
+  - Tuist.swift
+  - Workspace.swift
+  - Application/DevLogApp/Project.swift
+  - Application/DevLogCore/Project.swift
+  - Application/DevLogData/Project.swift
+  - Application/DevLogDomain/Project.swift
+  - Application/DevLogInfra/Project.swift
+  - Application/DevLogPersistence/Project.swift
+  - Application/DevLogPresentation/Project.swift
+  - Widget/DevLogWidgetCore/Project.swift
+  - Widget/DevLogWidgetExtension/Project.swift
 
 disabled_rules:
   - nesting

--- a/Tuist/ProjectDescriptionHelpers/Project+Settings.swift
+++ b/Tuist/ProjectDescriptionHelpers/Project+Settings.swift
@@ -16,6 +16,7 @@ public extension Settings {
             "CURRENT_PROJECT_VERSION": "1",
             "INFOPLIST_KEY_CFBundleShortVersionString": "$(MARKETING_VERSION)",
             "INFOPLIST_KEY_CFBundleVersion": "$(CURRENT_PROJECT_VERSION)",
+            "SWIFT_STRICT_CONCURRENCY": "complete",
             "SWIFT_VERSION": "5.0",
             "TARGETED_DEVICE_FAMILY": "1,2",
         ]


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #546

## 🎯 의도
- Swift 5 language mode를 유지하면서 Swift 6 concurrency 이슈를 빌드 시점에 경고로 확인할 수 있도록 `SWIFT_STRICT_CONCURRENCY` 설정을 활성화하기 위함
- SwiftLint 목적을 앱/모듈 Swift 코드 품질 관리로 유지하기 위해 Tuist 설정 파일을 검사 범위에서 제외하기 위함

## 📝 작업 내용

### 📌 요약
- 공통 build setting에 `SWIFT_STRICT_CONCURRENCY = complete` 추가
- SwiftLint 검사 대상에서 `Tuist` 디렉터리 제외

### 🔍 상세
- Swift language version을 6으로 올리지 않고 strict concurrency 검사만 `complete`로 활성화
- Tuist 설정 파일의 formatting 규칙 충돌을 SwiftLint 대상 제외로 정리
- TCA 모듈 링크 방식 분리는 이번 PR 범위에서 제외

## 📸 영상 / 이미지 (Optional)
