### PR TITLE
[#545] SignInUseCase의 Sendable 책임을 TCA Dependency로 분리한다

### DIFF
--- a/Application/DevLogCore/Sources/ActivityKind.swift
+++ b/Application/DevLogCore/Sources/ActivityKind.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public enum ActivityKind: String, Hashable, Sendable {
+public enum ActivityKind: String, Hashable {
     case created
     case completed
     case deleted

--- a/Application/DevLogCore/Sources/Logger.swift
+++ b/Application/DevLogCore/Sources/Logger.swift
@@ -8,7 +8,7 @@
 import Foundation
 import os.log
 
-public final class Logger: Sendable {
+public final class Logger {
     private let subsystem: String
     private let category: String
     private let osLog: OSLog

--- a/Application/DevLogCore/Sources/TodayDisplayOptions.swift
+++ b/Application/DevLogCore/Sources/TodayDisplayOptions.swift
@@ -7,14 +7,14 @@
 
 import Foundation
 
-public struct TodayDisplayOptions: Equatable, Sendable {
-    public enum DueDateVisibility: String, CaseIterable, Equatable, Sendable {
+public struct TodayDisplayOptions: Equatable {
+    public enum DueDateVisibility: String, CaseIterable, Equatable {
         case all
         case withDueDateOnly
         case withoutDueDateOnly
     }
 
-    public enum FocusVisibility: String, CaseIterable, Equatable, Sendable {
+    public enum FocusVisibility: String, CaseIterable, Equatable {
         case all
         case focusedOnly
     }

--- a/Application/DevLogCore/Sources/WidgetTodoSnapshot.swift
+++ b/Application/DevLogCore/Sources/WidgetTodoSnapshot.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct WidgetTodoSnapshot: Equatable, Sendable {
+public struct WidgetTodoSnapshot: Equatable {
     public let id: String
     public let number: Int?
     public let title: String

--- a/Application/DevLogData/Sources/Protocol/AuthService.swift
+++ b/Application/DevLogData/Sources/Protocol/AuthService.swift
@@ -8,7 +8,7 @@
 import Combine
 import Foundation
 
-public protocol AuthService: Sendable {
+public protocol AuthService {
     var uid: String? { get }
     var providerIDs: [String] { get }
     var currentUserEmail: String? { get }

--- a/Application/DevLogData/Sources/Protocol/AuthenticationService.swift
+++ b/Application/DevLogData/Sources/Protocol/AuthenticationService.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public protocol AuthenticationService: Sendable {
+public protocol AuthenticationService {
     func signIn() async throws -> AuthDataResponse
     func signOut(_ uid: String) async throws
     func deleteAuth(_ uid: String) async throws

--- a/Application/DevLogData/Sources/Protocol/UserService.swift
+++ b/Application/DevLogData/Sources/Protocol/UserService.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public protocol UserService: Sendable {
+public protocol UserService {
     func upsertUser(_ response: AuthDataResponse) async throws
     func fetchUserProfile() async throws -> UserProfileResponse
     func upsertStatusMessage(_ message: String) async throws

--- a/Application/DevLogData/Sources/Protocol/WebPageImageStore.swift
+++ b/Application/DevLogData/Sources/Protocol/WebPageImageStore.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public protocol WebPageImageStore: Sendable {
+public protocol WebPageImageStore {
     func cachedImageURL(for url: URL) async throws -> URL
     func saveImage(_ data: Data, for url: URL) async throws -> URL
     func dirSizeInBytes() async -> Int64

--- a/Application/DevLogData/Sources/Protocol/WidgetSnapshotPreferenceStore.swift
+++ b/Application/DevLogData/Sources/Protocol/WidgetSnapshotPreferenceStore.swift
@@ -8,7 +8,7 @@
 import Foundation
 import DevLogCore
 
-public protocol WidgetSnapshotPreferenceStore: Sendable {
+public protocol WidgetSnapshotPreferenceStore {
     func heatmapActivityTypes() -> [String]
     func setHeatmapActivityTypes(_ activityTypes: [String])
     func selectedActivityKinds() -> Set<ActivityKind>

--- a/Application/DevLogData/Sources/Protocol/WidgetSnapshotUpdater.swift
+++ b/Application/DevLogData/Sources/Protocol/WidgetSnapshotUpdater.swift
@@ -8,7 +8,7 @@
 import Foundation
 import DevLogCore
 
-public protocol WidgetSnapshotUpdater: Sendable {
+public protocol WidgetSnapshotUpdater {
     func updateTodaySnapshot(
         todos: [WidgetTodoSnapshot],
         now: Date

--- a/Application/DevLogDomain/Sources/Entity/AuthProvider.swift
+++ b/Application/DevLogDomain/Sources/Entity/AuthProvider.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public enum AuthProvider: String, CaseIterable {
+public enum AuthProvider: String, CaseIterable, Sendable {
     case apple = "apple.com"
     case google = "google.com"
     case github = "github.com"

--- a/Application/DevLogDomain/Sources/Protocol/AuthenticationRepository.swift
+++ b/Application/DevLogDomain/Sources/Protocol/AuthenticationRepository.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public protocol AuthenticationRepository: Sendable {
+public protocol AuthenticationRepository {
     func signIn(_ provider: AuthProvider) async throws
     func signOut() async throws
     func restore() -> Bool

--- a/Application/DevLogDomain/Sources/UseCase/Auth/SignIn/SignInUseCase.swift
+++ b/Application/DevLogDomain/Sources/UseCase/Auth/SignIn/SignInUseCase.swift
@@ -5,6 +5,6 @@
 //  Created by 최윤진 on 11/2/25.
 //
 
-public protocol SignInUseCase: Sendable {
+public protocol SignInUseCase {
     func execute(_ provider: AuthProvider) async throws
 }

--- a/Application/DevLogInfra/Sources/Common/FirebaseDependency.swift
+++ b/Application/DevLogInfra/Sources/Common/FirebaseDependency.swift
@@ -10,7 +10,7 @@ import FirebaseFirestore
 import FirebaseFunctions
 import FirebaseMessaging
 
-struct FirebaseDependency<Value>: @unchecked Sendable {
+struct FirebaseDependency<Value> {
     private let value: Value
 
     init(value: Value) {

--- a/Application/DevLogInfra/Sources/Common/TopViewControllerProvider.swift
+++ b/Application/DevLogInfra/Sources/Common/TopViewControllerProvider.swift
@@ -8,7 +8,7 @@
 import UIKit
 import DevLogData
 
-final class TopViewControllerProvider: Sendable {
+final class TopViewControllerProvider {
     @MainActor
     func topViewController() -> UIViewController? {
         guard let keyWindow = keyWindow() else {

--- a/Application/DevLogInfra/Sources/Service/AuthServiceImpl.swift
+++ b/Application/DevLogInfra/Sources/Service/AuthServiceImpl.swift
@@ -114,7 +114,7 @@ final class AuthServiceImpl: AuthService {
 
 }
 
-private final class AuthStatePublisher: @unchecked Sendable {
+private final class AuthStatePublisher {
     private let logger: Logger
     private let subject: CurrentValueSubject<Bool, Never>
     private let lock = NSLock()

--- a/Application/DevLogInfra/Sources/Service/SocialLogin/AppleAuthenticationServiceImpl.swift
+++ b/Application/DevLogInfra/Sources/Service/SocialLogin/AppleAuthenticationServiceImpl.swift
@@ -300,7 +300,7 @@ final class AppleAuthenticationServiceImpl: AuthenticationService {
     }
 }
 
-private final class AppleSignInSession: @unchecked Sendable {
+private final class AppleSignInSession {
     @MainActor
     private var delegate: AppleSignInDelegate?
     @MainActor

--- a/Application/DevLogPersistence/Sources/Persistence/WebPageImageStoreImpl.swift
+++ b/Application/DevLogPersistence/Sources/Persistence/WebPageImageStoreImpl.swift
@@ -51,7 +51,7 @@ final class WebPageImageStoreImpl: WebPageImageStore {
 }
 
 private extension WebPageImageStoreImpl {
-    func perform<T: Sendable>(_ operation: @escaping @Sendable () throws -> T) async throws -> T {
+    func perform<T>(_ operation: @escaping () throws -> T) async throws -> T {
         try await withCheckedThrowingContinuation { continuation in
             queue.async {
                 do {

--- a/Application/DevLogPersistence/Sources/Persistence/WebPageImageStoreImpl.swift
+++ b/Application/DevLogPersistence/Sources/Persistence/WebPageImageStoreImpl.swift
@@ -51,7 +51,7 @@ final class WebPageImageStoreImpl: WebPageImageStore {
 }
 
 private extension WebPageImageStoreImpl {
-    func perform<T>(_ operation: @escaping () throws -> T) async throws -> T {
+    func perform<T: Sendable>(_ operation: @escaping @Sendable () throws -> T) async throws -> T {
         try await withCheckedThrowingContinuation { continuation in
             queue.async {
                 do {

--- a/Application/DevLogPersistence/Sources/Widget/UserDefaultsDependency.swift
+++ b/Application/DevLogPersistence/Sources/Widget/UserDefaultsDependency.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct UserDefaultsDependency: @unchecked Sendable {
+struct UserDefaultsDependency {
     private let value: UserDefaults
 
     init(value: UserDefaults) {

--- a/Application/DevLogPresentation/Sources/Login/LoginFeature.swift
+++ b/Application/DevLogPresentation/Sources/Login/LoginFeature.swift
@@ -5,8 +5,8 @@
 //  Created by opfic on 6/5/26.
 //
 
-import ComposableArchitecture
-import DevLogDomain
+@preconcurrency import ComposableArchitecture
+@preconcurrency import DevLogDomain
 import Foundation
 
 @Reducer
@@ -20,7 +20,7 @@ struct LoginFeature {
         var alertMessage = ""
     }
 
-    enum Action {
+    enum Action: Sendable {
         case setAlert(Bool, AlertType? = nil)
         case tapSignInButton(AuthProvider)
         case signInSucceeded
@@ -28,7 +28,7 @@ struct LoginFeature {
         case signInCancelled
     }
 
-    enum AlertType: Equatable {
+    enum AlertType: Equatable, Sendable {
         case emailUnavailable
         case error
     }

--- a/Application/DevLogPresentation/Sources/Login/LoginFeature.swift
+++ b/Application/DevLogPresentation/Sources/Login/LoginFeature.swift
@@ -65,10 +65,10 @@ struct LoginFeature {
     }
 }
 
-struct SignInUseCaseDependency {
-    var execute: (AuthProvider) async throws -> Void
+struct SignInUseCaseDependency: Sendable {
+    var execute: @Sendable (AuthProvider) async throws -> Void
 
-    init(execute: @escaping (AuthProvider) async throws -> Void) {
+    init(execute: @escaping @Sendable (AuthProvider) async throws -> Void) {
         self.execute = execute
     }
 }

--- a/Application/DevLogPresentation/Sources/Login/LoginFeature.swift
+++ b/Application/DevLogPresentation/Sources/Login/LoginFeature.swift
@@ -65,10 +65,10 @@ struct LoginFeature {
     }
 }
 
-struct SignInUseCaseDependency: Sendable {
-    var execute: @Sendable (AuthProvider) async throws -> Void
+struct SignInUseCaseDependency {
+    var execute: (AuthProvider) async throws -> Void
 
-    init(execute: @escaping @Sendable (AuthProvider) async throws -> Void) {
+    init(execute: @escaping (AuthProvider) async throws -> Void) {
         self.execute = execute
     }
 }

--- a/Application/DevLogPresentation/Sources/Login/LoginFeature.swift
+++ b/Application/DevLogPresentation/Sources/Login/LoginFeature.swift
@@ -5,7 +5,7 @@
 //  Created by opfic on 6/5/26.
 //
 
-@preconcurrency import ComposableArchitecture
+import ComposableArchitecture
 @preconcurrency import DevLogDomain
 import Foundation
 
@@ -33,7 +33,7 @@ struct LoginFeature {
         case error
     }
 
-    @Dependency(\.signInUseCase) var signInUseCase
+    @Dependency(SignInUseCaseDependency.self) var signInUseCase
 
     var body: some ReducerOf<Self> {
         Reduce { state, action in

--- a/Widget/DevLogWidgetCore/Sources/Common/UserDefaultsDependency.swift
+++ b/Widget/DevLogWidgetCore/Sources/Common/UserDefaultsDependency.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct UserDefaultsDependency: @unchecked Sendable {
+struct UserDefaultsDependency {
     private let value: UserDefaults
 
     init(value: UserDefaults) {

--- a/Widget/DevLogWidgetCore/Sources/Common/WidgetSharedDefaultsStore.swift
+++ b/Widget/DevLogWidgetCore/Sources/Common/WidgetSharedDefaultsStore.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public final class WidgetSharedDefaultsStore: Sendable {
+public final class WidgetSharedDefaultsStore {
     private let userDefaults: UserDefaultsDependency
 
     public init(userDefaults: UserDefaults = UserDefaults(suiteName: WidgetAppGroup.identifier) ?? .standard) {

--- a/Widget/DevLogWidgetCore/Sources/Common/WidgetSnapshotStore.swift
+++ b/Widget/DevLogWidgetCore/Sources/Common/WidgetSnapshotStore.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public final class WidgetSnapshotStore: Sendable {
+public final class WidgetSnapshotStore {
     private let store: WidgetSharedDefaultsStore
     private let encoder = JSONEncoder()
     private let decoder = JSONDecoder()

--- a/Widget/DevLogWidgetCore/Sources/Heatmap/HeatmapWidgetSnapshotFactory.swift
+++ b/Widget/DevLogWidgetCore/Sources/Heatmap/HeatmapWidgetSnapshotFactory.swift
@@ -8,8 +8,8 @@
 import Foundation
 import DevLogCore
 
-public struct HeatmapWidgetSnapshotFactory: Sendable {
-    fileprivate struct DailyCounts: Sendable {
+public struct HeatmapWidgetSnapshotFactory {
+    fileprivate struct DailyCounts {
         var createdCount = 0
         var completedCount = 0
         var deletedCount = 0

--- a/Widget/DevLogWidgetCore/Sources/Today/TodayWidgetSnapshotFactory.swift
+++ b/Widget/DevLogWidgetCore/Sources/Today/TodayWidgetSnapshotFactory.swift
@@ -8,8 +8,8 @@
 import Foundation
 import DevLogCore
 
-public struct TodayWidgetSnapshotFactory: Sendable {
-    private enum SectionCategory: String, CaseIterable, Sendable {
+public struct TodayWidgetSnapshotFactory {
+    private enum SectionCategory: String, CaseIterable {
         case focused
         case overdue
         case dueSoon
@@ -17,7 +17,7 @@ public struct TodayWidgetSnapshotFactory: Sendable {
         case unscheduled
     }
 
-    private struct SectionCollection: Sendable {
+    private struct SectionCollection {
         var focused = [TodayWidgetTodoItem]()
         var overdue = [TodayWidgetTodoItem]()
         var dueSoon = [TodayWidgetTodoItem]()
@@ -40,7 +40,7 @@ public struct TodayWidgetSnapshotFactory: Sendable {
         }
     }
 
-    private struct TodayWidgetTodoItem: Sendable {
+    private struct TodayWidgetTodoItem {
         let id: String
         let number: Int
         let title: String


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #545

## 🎯 의도
- `SignInUseCase` 자체에 `Sendable` 책임을 두지 않고 로그인 feature의 TCA dependency 경계에서만 필요한 동시성 책임을 관리하기 위함
- Sendable 적합성을 무분별하게 확장하지 않고 실제로 필요한 범위만 남기도록 정리하기 위함

## 📝 작업 내용

### 📌 요약
- 공통 계층과 하위 계층에 넓게 추가됐던 `Sendable` 관련 선언 제거
- `SignInUseCase`를 plain protocol로 복구
- `AuthProvider`와 `SignInUseCaseDependency`만 로그인 feature 경계에 맞게 `Sendable` 적용
- `LoginFeature`의 dependency 접근을 key path 기반에서 key type 기반으로 변경

### 🔍 상세
- `SignInUseCase`, `AuthenticationRepository`, Data/Infra/Persistence/WidgetCore 일부 타입에 추가됐던 `Sendable`, `@Sendable`, `@unchecked Sendable` 선언 제거
- `AuthProvider`를 `Sendable`로 선언해 로그인 action payload의 값 타입 경계 명시
- `SignInUseCaseDependency`를 `Sendable` 래퍼로 두고 `execute` 클로저만 `@Sendable`로 유지
- `@Dependency(\.signInUseCase)`를 `@Dependency(SignInUseCaseDependency.self)`로 변경해 `DependencyValues` key path 기반 경고 제거
- `LoginFeature`의 `Action`, `AlertType`에 `Sendable` 적용
- `DevLogDomain` import에 `@preconcurrency` 적용해 로그인 경로의 모듈 경계 경고 축소

## 📸 영상 / 이미지 (Optional)