### PR TITLE
[#534] TodoEditor에서 Todo를 수정하면 HomeView에서 최근 수정 섹션에 해당 Todo가 반영되지 않는 현상을 해결한다

### DIFF
--- a/Application/DevLogData/Sources/DataAssembler.swift
+++ b/Application/DevLogData/Sources/DataAssembler.swift
@@ -32,11 +32,16 @@ public final class DataAssembler: Assembler {
             )
         }
 
+        container.register(TodoMutationEventBus.self) {
+            TodoMutationEventBusImpl()
+        }
+
         container.register(TodoRepository.self) {
             TodoRepositoryImpl(
                 todoService: container.resolve(TodoService.self),
                 todoCategoryService: container.resolve(TodoCategoryService.self),
-                widgetSyncEventBus: container.resolve(WidgetSyncEventBus.self)
+                widgetSyncEventBus: container.resolve(WidgetSyncEventBus.self),
+                todoMutationEventBus: container.resolve(TodoMutationEventBus.self)
             )
         }
 

--- a/Application/DevLogData/Sources/Repository/TodoMutationEventBusImpl.swift
+++ b/Application/DevLogData/Sources/Repository/TodoMutationEventBusImpl.swift
@@ -1,0 +1,37 @@
+//
+//  TodoMutationEventBusImpl.swift
+//  DevLogData
+//
+//  Created by opfic on 6/6/26.
+//
+
+import Foundation
+import DevLogDomain
+
+actor TodoMutationEventBusImpl: TodoMutationEventBus {
+    private var continuations = [UUID: AsyncStream<TodoMutationEvent>.Continuation]()
+
+    func publish(_ event: TodoMutationEvent) async {
+        continuations.values.forEach { $0.yield(event) }
+    }
+
+    func events() -> AsyncStream<TodoMutationEvent> {
+        let id = UUID()
+        let (stream, continuation) = AsyncStream.makeStream(of: TodoMutationEvent.self)
+
+        continuations[id] = continuation
+        continuation.onTermination = { [weak self] _ in
+            Task {
+                await self?.removeContinuation(id: id)
+            }
+        }
+
+        return stream
+    }
+}
+
+private extension TodoMutationEventBusImpl {
+    func removeContinuation(id: UUID) {
+        continuations[id] = nil
+    }
+}

--- a/Application/DevLogData/Sources/Repository/TodoRepositoryImpl.swift
+++ b/Application/DevLogData/Sources/Repository/TodoRepositoryImpl.swift
@@ -13,15 +13,18 @@ final class TodoRepositoryImpl: TodoRepository {
     private let todoService: TodoService
     private let todoCategoryService: TodoCategoryService
     private let widgetSyncEventBus: WidgetSyncEventBus
+    private let todoMutationEventBus: TodoMutationEventBus
 
     init(
         todoService: TodoService,
         todoCategoryService: TodoCategoryService,
-        widgetSyncEventBus: WidgetSyncEventBus
+        widgetSyncEventBus: WidgetSyncEventBus,
+        todoMutationEventBus: TodoMutationEventBus
     ) {
         self.todoService = todoService
         self.todoCategoryService = todoCategoryService
         self.widgetSyncEventBus = widgetSyncEventBus
+        self.todoMutationEventBus = todoMutationEventBus
     }
 
     func fetchTodos(_ query: TodoQuery, cursor: TodoCursor?) async throws -> TodoPage {
@@ -107,6 +110,7 @@ final class TodoRepositoryImpl: TodoRepository {
     func upsertTodo(_ todo: Todo) async throws {
         let todoRequest = TodoRequest.fromDomain(todo)
         try await upsertTodo(todoRequest)
+        await todoMutationEventBus.publish(.updated(todo.id))
     }
 
     func upsertTodo(_ todoDraft: TodoDraft) async throws {
@@ -127,6 +131,7 @@ final class TodoRepositoryImpl: TodoRepository {
         do {
             try await todoService.deleteTodo(todoId: todoId)
             widgetSyncEventBus.publish(.syncRequested)
+            await todoMutationEventBus.publish(.deleted(todoId))
         } catch {
             throw error.toDomain()
         }
@@ -136,6 +141,7 @@ final class TodoRepositoryImpl: TodoRepository {
         do {
             try await todoService.undoDeleteTodo(todoId: todoId)
             widgetSyncEventBus.publish(.syncRequested)
+            await todoMutationEventBus.publish(.restored(todoId))
         } catch {
             throw error.toDomain()
         }

--- a/Application/DevLogData/Tests/Repository/TodoMutationEventBusImplTests.swift
+++ b/Application/DevLogData/Tests/Repository/TodoMutationEventBusImplTests.swift
@@ -1,0 +1,27 @@
+//
+//  TodoMutationEventBusImplTests.swift
+//  DevLogDataTests
+//
+//  Created by opfic on 6/6/26.
+//
+
+import Testing
+import DevLogDomain
+@testable import DevLogData
+
+struct TodoMutationEventBusImplTests {
+    @Test("TodoMutationEventBus는 발행된 이벤트를 관찰자에게 전달한다")
+    func todoMutationEventBus는_발행된_이벤트를_관찰자에게_전달한다() async {
+        let bus = TodoMutationEventBusImpl()
+        let events = await bus.events()
+        let task = Task {
+            var iterator = events.makeAsyncIterator()
+            return await iterator.next()
+        }
+
+        await bus.publish(.updated("todo-id"))
+
+        let event = await task.value
+        #expect(event == .updated("todo-id"))
+    }
+}

--- a/Application/DevLogData/Tests/Repository/TodoRepositoryImplTests.swift
+++ b/Application/DevLogData/Tests/Repository/TodoRepositoryImplTests.swift
@@ -10,11 +10,11 @@ import Foundation
 import Testing
 import DevLogCore
 import DevLogDomain
-@testable import DevLogData
+@testable @preconcurrency import DevLogData
 
 struct TodoRepositoryImplTests {
-    @Test("Todo 변경 성공 시 위젯 동기화 이벤트를 발행한다")
-    func todo_변경_성공_시_위젯_동기화_이벤트를_발행한다() async throws {
+    @Test("Todo 변경 성공 시 위젯 동기화와 mutation 이벤트를 발행한다")
+    func todo_변경_성공_시_위젯_동기화와_mutation_이벤트를_발행한다() async throws {
         let fixture = makeFixture()
         let todo = makeTodo()
 
@@ -24,10 +24,13 @@ struct TodoRepositoryImplTests {
 
         let events = fixture.widgetSyncEventBus.events
         #expect(events == [.syncRequested, .syncRequested, .syncRequested])
+
+        let mutationEvents = await fixture.todoMutationEventBus.publishedEvents()
+        #expect(mutationEvents == [.updated(todo.id), .deleted(todo.id), .restored(todo.id)])
     }
 
-    @Test("Todo 변경 실패 시 위젯 동기화 이벤트를 발행하지 않는다")
-    func todo_변경_실패_시_위젯_동기화_이벤트를_발행하지_않는다() async throws {
+    @Test("Todo 변경 실패 시 위젯 동기화와 mutation 이벤트를 발행하지 않는다")
+    func todo_변경_실패_시_위젯_동기화와_mutation_이벤트를_발행하지_않는다() async throws {
         let fixture = makeFixture()
         let todo = makeTodo()
 
@@ -52,24 +55,30 @@ struct TodoRepositoryImplTests {
             #expect(error as? TodoRepositoryImplTestsError == .serviceFailed)
         }
 
-        let events = fixture.widgetSyncEventBus.events
-        #expect(events.isEmpty)
+        let syncEvents = fixture.widgetSyncEventBus.events
+        #expect(syncEvents.isEmpty)
+
+        let mutationEvents = await fixture.todoMutationEventBus.publishedEvents()
+        #expect(mutationEvents.isEmpty)
     }
 
     private func makeFixture() -> Fixture {
         let todoService = TodoServiceSpy()
         let todoCategoryService = TodoCategoryServiceSpy()
         let widgetSyncEventBus = WidgetSyncEventBusSpy()
+        let todoMutationEventBus = TodoMutationEventBusSpy()
         let repository = TodoRepositoryImpl(
             todoService: todoService,
             todoCategoryService: todoCategoryService,
-            widgetSyncEventBus: widgetSyncEventBus
+            widgetSyncEventBus: widgetSyncEventBus,
+            todoMutationEventBus: todoMutationEventBus
         )
 
         return Fixture(
             repository: repository,
             todoService: todoService,
-            widgetSyncEventBus: widgetSyncEventBus
+            widgetSyncEventBus: widgetSyncEventBus,
+            todoMutationEventBus: todoMutationEventBus
         )
     }
 
@@ -97,6 +106,7 @@ private struct Fixture {
     let repository: TodoRepositoryImpl
     let todoService: TodoServiceSpy
     let widgetSyncEventBus: WidgetSyncEventBusSpy
+    let todoMutationEventBus: TodoMutationEventBusSpy
 }
 
 private actor TodoServiceSpy: TodoService {
@@ -156,6 +166,24 @@ private final class WidgetSyncEventBusSpy: WidgetSyncEventBus {
 
     func publish(_ event: WidgetSyncEvent) {
         events.append(event)
+    }
+}
+
+private actor TodoMutationEventBusSpy: TodoMutationEventBus {
+    private var capturedEvents = [TodoMutationEvent]()
+
+    func publish(_ event: TodoMutationEvent) async {
+        capturedEvents.append(event)
+    }
+
+    func publishedEvents() -> [TodoMutationEvent] {
+        capturedEvents
+    }
+
+    func events() async -> AsyncStream<TodoMutationEvent> {
+        AsyncStream { continuation in
+            continuation.finish()
+        }
     }
 }
 

--- a/Application/DevLogDomain/Sources/Entity/TodoMutationEvent.swift
+++ b/Application/DevLogDomain/Sources/Entity/TodoMutationEvent.swift
@@ -1,0 +1,12 @@
+//
+//  TodoMutationEvent.swift
+//  DevLogDomain
+//
+//  Created by opfic on 6/6/26.
+//
+
+public enum TodoMutationEvent: Equatable, Sendable {
+    case updated(String)
+    case deleted(String)
+    case restored(String)
+}

--- a/Application/DevLogDomain/Sources/Protocol/TodoMutationEventBus.swift
+++ b/Application/DevLogDomain/Sources/Protocol/TodoMutationEventBus.swift
@@ -1,0 +1,11 @@
+//
+//  TodoMutationEventBus.swift
+//  DevLogDomain
+//
+//  Created by opfic on 6/6/26.
+//
+
+public protocol TodoMutationEventBus: Sendable {
+    func publish(_ event: TodoMutationEvent) async
+    func events() async -> AsyncStream<TodoMutationEvent>
+}

--- a/Application/DevLogPresentation/Sources/Home/Home/HomeViewCoordinator.swift
+++ b/Application/DevLogPresentation/Sources/Home/Home/HomeViewCoordinator.swift
@@ -18,6 +18,8 @@ final class HomeViewCoordinator {
     private let container: DIContainer
     @ObservationIgnored
     private var cancellable: AnyCancellable?
+    @ObservationIgnored
+    private var mutationTask: Task<Void, Never>?
 
     init(container: DIContainer) {
         self.container = container
@@ -34,8 +36,31 @@ final class HomeViewCoordinator {
         )
     }
 
+    deinit {
+        mutationTask?.cancel()
+    }
+
     func fetchData() {
         viewModel.send(.fetchData)
+    }
+
+    func refreshRecentTodos() {
+        viewModel.send(.refreshRecentTodos)
+    }
+
+    func bindTodoMutationEvent() {
+        guard mutationTask == nil else { return }
+
+        let bus = container.resolve(TodoMutationEventBus.self)
+        mutationTask = Task { [weak self] in
+            let events = await bus.events()
+            for await event in events {
+                switch event {
+                case .updated, .deleted, .restored:
+                    self?.refreshRecentTodos()
+                }
+            }
+        }
     }
 
     func bindWindowEvent(_ windowEvent: TodoEditorWindowEvent) {

--- a/Application/DevLogPresentation/Sources/Home/Home/HomeViewCoordinator.swift
+++ b/Application/DevLogPresentation/Sources/Home/Home/HomeViewCoordinator.swift
@@ -13,13 +13,17 @@ import DevLogDomain
 @MainActor
 @Observable
 final class HomeViewCoordinator {
+    private enum AsyncStreamTaskID {
+        case todoMutationEvent
+    }
+
     let viewModel: HomeViewModel
     let router = NavigationRouter<HomeRoute>()
     private let container: DIContainer
     @ObservationIgnored
     private var cancellable: AnyCancellable?
     @ObservationIgnored
-    private var mutationTask: Task<Void, Never>?
+    private var streamTasks = [AsyncStreamTaskID: Task<Void, Never>]()
 
     init(container: DIContainer) {
         self.container = container
@@ -37,7 +41,7 @@ final class HomeViewCoordinator {
     }
 
     deinit {
-        mutationTask?.cancel()
+        streamTasks.values.forEach { $0.cancel() }
     }
 
     func fetchData() {
@@ -49,10 +53,10 @@ final class HomeViewCoordinator {
     }
 
     func bindTodoMutationEvent() {
-        guard mutationTask == nil else { return }
+        guard streamTasks[.todoMutationEvent] == nil else { return }
 
         let bus = container.resolve(TodoMutationEventBus.self)
-        mutationTask = Task { [weak self] in
+        streamTasks[.todoMutationEvent] = Task { [weak self] in
             let events = await bus.events()
             for await event in events {
                 switch event {

--- a/Application/DevLogPresentation/Sources/Home/Home/HomeViewCoordinator.swift
+++ b/Application/DevLogPresentation/Sources/Home/Home/HomeViewCoordinator.swift
@@ -59,9 +59,10 @@ final class HomeViewCoordinator {
         streamTasks[.todoMutationEvent] = Task { [weak self] in
             let events = await bus.events()
             for await event in events {
+                guard let self else { break }
                 switch event {
                 case .updated, .deleted, .restored:
-                    self?.refreshRecentTodos()
+                    self.refreshRecentTodos()
                 }
             }
         }

--- a/Application/DevLogPresentation/Sources/Home/Home/HomeViewModel.swift
+++ b/Application/DevLogPresentation/Sources/Home/Home/HomeViewModel.swift
@@ -36,6 +36,7 @@ final class HomeViewModel: StorePattern {
 
     enum Action {
         case fetchData
+        case refreshRecentTodos
         case networkStatusChanged(Bool)
         case setPresentation(Presentation, Bool)
         case setAlert(isPresented: Bool, type: AlertType? = nil)
@@ -136,7 +137,7 @@ final class HomeViewModel: StorePattern {
         switch action {
         case .networkStatusChanged(let isConnected):
             state.isNetworkConnected = isConnected
-        case .fetchData, .setPresentation, .setAlert, .refreshWebPages,
+        case .fetchData, .refreshRecentTodos, .setPresentation, .setAlert, .refreshWebPages,
                 .tapTodoCategory, .orderTodoCategory, .updateWebPageURLInput,
                 .addWebPage, .deleteWebPage, .undoDeleteWebPage, .finishDeleteWebPageToast:
             effects = reduceByView(action, state: &state)
@@ -252,6 +253,8 @@ private extension HomeViewModel {
         switch action {
         case .fetchData:
             return [.fetchTodoCategoryPreferences, .fetchRecentTodos, .fetchWebPages]
+        case .refreshRecentTodos:
+            return [.fetchRecentTodos]
         case .refreshWebPages:
             return [.fetchWebPages]
         case .setPresentation(let presentation, let isPresented):

--- a/Application/DevLogPresentation/Sources/Main/MainView.swift
+++ b/Application/DevLogPresentation/Sources/Main/MainView.swift
@@ -48,6 +48,7 @@ struct MainView: View {
         .onAppear {
             coordinator.viewModel.send(.onAppear)
             homeViewCoordinator.bindWindowEvent(windowEvent)
+            homeViewCoordinator.bindTodoMutationEvent()
             todoWindowCoordinator.bindWindowEvent(windowEvent)
         }
         .onChange(of: selectedTab, initial: true) { _, newValue in


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #534

## 🎯 의도

- TodoEditor 또는 TodoList에서 Todo 수정, 삭제, 복원이 발생했을 때 Home 화면의 최근 Todo 목록이 갱신되지 않는 문제 해결
- 전체 Home 데이터를 다시 fetch하지 않고 Todo 변경 이벤트를 기준으로 최근 Todo 목록만 갱신하는 흐름 구성

## 📝 작업 내용

### 📌 요약

- `TodoMutationEventBus` 추가
- `TodoRepositoryImpl`의 Todo 수정, 삭제, 복원 성공 시 `TodoMutationEvent` 방출
- Home 화면에서 `TodoMutationEvent` 구독 후 최근 Todo 목록 갱신
- `HomeViewCoordinator`의 AsyncStream 구독 task 관리 구조 개선

### 🔍 상세

- `TodoMutationEvent`와 `TodoMutationEventBus`를 Domain 계약으로 추가
- Data 레이어에 `TodoMutationEventBusImpl` 구현
- `TodoRepositoryImpl`에서 `updated`, `deleted`, `restored` 이벤트 방출
- Todo 생성은 최근 Todo 갱신 대상이 아니므로 mutation event 방출 대상에서 제외
- `HomeViewModel`에 `refreshRecentTodos` 액션 추가
- `HomeViewCoordinator`에서 Todo mutation stream 구독 후 최근 Todo만 refresh
- 추후 다른 AsyncStream 구독 추가를 고려한 `streamTasks` 기반 task 관리 구조 적용
- `TodoMutationEventBusImplTests`, `TodoRepositoryImplTests`로 event bus 전달과 repository 방출 검증

## 📸 영상 / 이미지 (Optional)