### PR TITLE
[#553] compact ui에서 토스트가 탭바와 너무 가깝게 뜨는 현상을 해결한다

### DIFF
--- a/Application/DevLogPresentation/Sources/Common/Component/Toast.swift
+++ b/Application/DevLogPresentation/Sources/Common/Component/Toast.swift
@@ -310,20 +310,17 @@ private struct ToastCardView<Label: View>: View {
 @MainActor
 private extension UIViewController {
     var visibleTabBarHeight: CGFloat {
-        if let tabBarController = self as? UITabBarController {
+        var topViewController = self
+
+        while let presentedViewController = topViewController.presentedViewController {
+            topViewController = presentedViewController
+        }
+
+        if let tabBarController = (topViewController as? UITabBarController) ?? topViewController.tabBarController {
             return tabBarController.tabBar.isHidden ? .zero : tabBarController.tabBar.frame.height
         }
 
-        if let tabBarController {
-            return tabBarController.tabBar.isHidden ? .zero : tabBarController.tabBar.frame.height
-        }
-
-        if let presentedViewController,
-           0 < presentedViewController.visibleTabBarHeight {
-            return presentedViewController.visibleTabBarHeight
-        }
-
-        for child in children {
+        for child in topViewController.children {
             let childHeight = child.visibleTabBarHeight
             if 0 < childHeight {
                 return childHeight

--- a/Application/DevLogPresentation/Sources/Common/Component/Toast.swift
+++ b/Application/DevLogPresentation/Sources/Common/Component/Toast.swift
@@ -85,11 +85,19 @@ extension View {
 }
 
 private struct ToastHostModifier: ViewModifier {
+    @Environment(\.safeAreaInsets) private var safeAreaInsets
+    @State private var tabBarHeight = CGFloat.zero
     private let toastPresenter = ToastPresenter.presenter
 
     func body(content: Content) -> some View {
         content
             .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .onAppear {
+                updateTabBarHeight()
+            }
+            .onChange(of: toastPresenter.item?.id) { _, _ in
+                updateTabBarHeight()
+            }
             .overlay(alignment: .bottom) {
                 if let item = toastPresenter.item {
                     ToastOverlayView(
@@ -109,8 +117,27 @@ private struct ToastHostModifier: ViewModifier {
                     }
                     .id(item.id)
                     .padding(.horizontal, 12)
+                    .padding(.bottom, toastBottomInset)
                 }
             }
+    }
+
+    private var toastBottomInset: CGFloat {
+        max(0, tabBarHeight - safeAreaInsets.bottom)
+    }
+
+    @MainActor
+    private func updateTabBarHeight() {
+        let window = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap(\.windows)
+            .first { $0.isKeyWindow }
+
+        guard let window else {
+            tabBarHeight = .zero
+            return
+        }
+        tabBarHeight = window.rootViewController?.visibleTabBarHeight ?? .zero
     }
 }
 
@@ -277,5 +304,32 @@ private struct ToastCardView<Label: View>: View {
                 }
             }
             .shadow(color: Color(.systemGray2).opacity(0.4), radius: 18, x: 0, y: 10)
+    }
+}
+
+@MainActor
+private extension UIViewController {
+    var visibleTabBarHeight: CGFloat {
+        if let tabBarController = self as? UITabBarController {
+            return tabBarController.tabBar.isHidden ? .zero : tabBarController.tabBar.frame.height
+        }
+
+        if let tabBarController {
+            return tabBarController.tabBar.isHidden ? .zero : tabBarController.tabBar.frame.height
+        }
+
+        if let presentedViewController,
+           0 < presentedViewController.visibleTabBarHeight {
+            return presentedViewController.visibleTabBarHeight
+        }
+
+        for child in children {
+            let childHeight = child.visibleTabBarHeight
+            if 0 < childHeight {
+                return childHeight
+            }
+        }
+
+        return .zero
     }
 }


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #553

## 🎯 의도
- compact 레이아웃에서 토스트가 탭바 바로 위에 붙어 보이던 문제 해결 목적
- 기존 토스트 표시 구조는 유지하면서 하단 위치만 최소 범위로 보정 목적

## 📝 작업 내용

### 📌 요약
- `ToastHostModifier`에서 현재 key window 기준 tab bar 높이 계산 추가
- `safeAreaInsets.bottom`을 제외한 값을 토스트 하단 padding으로 반영
- `visibleTabBarHeight` helper 추가로 tab bar 높이 탐색 처리

### 🔍 상세
- `UIApplication.shared.connectedScenes`를 순회해 현재 `isKeyWindow`인 window 탐색
- 해당 window의 `rootViewController` 기준으로 visible tab bar 높이 계산
- 계산한 높이에서 `safeAreaInsets.bottom`을 제외한 값만 `padding(.bottom)`에 반영
- `ToastPresenter`, 토스트 애니메이션, dismiss 흐름은 기존 로직 유지

## 📸 영상 / 이미지 (Optional)