### PR TITLE
[#556] LoginVIew에서 signIn이 다 되기 전 LoadingView가 사라지는 현상을 해결한다

### DIFF
--- a/Application/DevLogApp/Sources/App/DevLogApp.swift
+++ b/Application/DevLogApp/Sources/App/DevLogApp.swift
@@ -30,7 +30,6 @@ struct DevLogApp: App {
                 networkConnectivityUseCase: container.resolve(ObserveNetworkConnectivityUseCase.self),
                 systemThemeUseCase: container.resolve(ObserveSystemThemeUseCase.self),
                 trackAnalyticsEventUseCase: container.resolve(TrackAnalyticsEventUseCase.self),
-                signInUseCase: container.resolve(SignInUseCase.self),
                 widgetURLTab: { MainTab(widgetURL: $0) },
                 windowEvent: windowEvent,
                 pushNotificationTodoIdPublisher: PushNotificationRoute.shared.observe(),

--- a/Application/DevLogPresentation/Sources/Login/LoginFeature.swift
+++ b/Application/DevLogPresentation/Sources/Login/LoginFeature.swift
@@ -20,8 +20,8 @@ struct LoginFeature {
         var alertMessage = ""
     }
 
-    enum Action {
-        case setAlert(Bool, AlertType? = nil)
+    enum Action: BindableAction {
+        case binding(BindingAction<State>)
         case tapSignInButton(AuthProvider)
         case signInSucceeded
         case signInFailed(AlertType)
@@ -36,10 +36,15 @@ struct LoginFeature {
     @Dependency(SignInUseCaseDependency.self) var signInUseCase
 
     var body: some ReducerOf<Self> {
+        BindingReducer()
         Reduce { state, action in
             switch action {
-            case .setAlert(let isPresented, let alertType):
-                setAlert(&state, isPresented: isPresented, alertType: alertType)
+            case .binding(\.showAlert):
+                if !state.showAlert {
+                    setAlert(&state, isPresented: false, alertType: nil)
+                }
+            case .binding:  // 다른 binding 액션들은 이쪽으로 처리됨
+                break       // 작성 필수
             case .tapSignInButton(let provider):
                 state.isLoading = true
                 return .run { [signInUseCase] send in

--- a/Application/DevLogPresentation/Sources/Login/LoginFeature.swift
+++ b/Application/DevLogPresentation/Sources/Login/LoginFeature.swift
@@ -13,15 +13,12 @@ import Foundation
 struct LoginFeature {
     @ObservableState
     struct State: Equatable {
+        @Presents var alert: AlertState<Never>?
         var isLoading = false
-        var showAlert = false
-        var alertType: AlertType?
-        var alertTitle = ""
-        var alertMessage = ""
     }
 
-    enum Action: BindableAction {
-        case binding(BindingAction<State>)
+    enum Action {
+        case alert(PresentationAction<Never>)
         case tapSignInButton(AuthProvider)
         case signInFailed(AlertType)
         case signInCancelled
@@ -35,15 +32,10 @@ struct LoginFeature {
     @Dependency(SignInUseCaseDependency.self) var signInUseCase
 
     var body: some ReducerOf<Self> {
-        BindingReducer()
         Reduce { state, action in
             switch action {
-            case .binding(\.showAlert):
-                if !state.showAlert {
-                    setAlert(&state, isPresented: false, alertType: nil)
-                }
-            case .binding:  // 다른 binding 액션들은 이쪽으로 처리됨
-                break       // 작성 필수
+            case .alert:
+                break
             case .tapSignInButton(let provider):
                 state.isLoading = true
                 return .run { [signInUseCase] send in
@@ -61,10 +53,11 @@ struct LoginFeature {
                 state.isLoading = false
             case .signInFailed(let alertType):
                 state.isLoading = false
-                setAlert(&state, isPresented: true, alertType: alertType)
+                state.alert = alertState(for: alertType)
             }
             return .none
         }
+        .ifLet(\.$alert, action: \.alert)
     }
 }
 
@@ -98,24 +91,28 @@ extension DependencyValues {
 }
 
 private extension LoginFeature {
-    func setAlert(
-        _ state: inout State,
-        isPresented: Bool,
-        alertType: AlertType?
-    ) {
+    func alertState(for alertType: AlertType) -> AlertState<Never> {
+        let title: String
+        let message: String
+
         switch alertType {
         case .emailUnavailable:
-            state.alertTitle = String(localized: "login_alert_email_unavailable_title")
-            state.alertMessage = String(localized: "login_alert_email_unavailable_message")
+            title = String(localized: "login_alert_email_unavailable_title")
+            message = String(localized: "login_alert_email_unavailable_message")
         case .error:
-            state.alertTitle = String(localized: "common_error_title")
-            state.alertMessage = String(localized: "common_error_message")
-        case .none:
-            state.alertTitle = ""
-            state.alertMessage = ""
+            title = String(localized: "common_error_title")
+            message = String(localized: "common_error_message")
         }
-        state.showAlert = isPresented
-        state.alertType = alertType
+
+        return AlertState {
+            TextState(title)
+        } actions: {
+            ButtonState(role: .cancel) {
+                TextState(String(localized: "common_close"))
+            }
+        } message: {
+            TextState(message)
+        }
     }
 
     func alertType(for error: Error) -> AlertType {

--- a/Application/DevLogPresentation/Sources/Login/LoginFeature.swift
+++ b/Application/DevLogPresentation/Sources/Login/LoginFeature.swift
@@ -23,7 +23,6 @@ struct LoginFeature {
     enum Action: BindableAction {
         case binding(BindingAction<State>)
         case tapSignInButton(AuthProvider)
-        case signInSucceeded
         case signInFailed(AlertType)
         case signInCancelled
     }
@@ -50,7 +49,6 @@ struct LoginFeature {
                 return .run { [signInUseCase] send in
                     do {
                         try await signInUseCase.execute(provider)
-                        await send(.signInSucceeded)
                     } catch {
                         if error.isSocialLoginCancelled {
                             await send(.signInCancelled)
@@ -59,7 +57,7 @@ struct LoginFeature {
                         await send(.signInFailed(alertType(for: error)))
                     }
                 }
-            case .signInSucceeded, .signInCancelled:
+            case .signInCancelled:
                 state.isLoading = false
             case .signInFailed(let alertType):
                 state.isLoading = false

--- a/Application/DevLogPresentation/Sources/Login/LoginView.swift
+++ b/Application/DevLogPresentation/Sources/Login/LoginView.swift
@@ -7,13 +7,26 @@
 
 import SwiftUI
 import ComposableArchitecture
+import DevLogDomain
 
 struct LoginView: View {
     @Environment(\.colorScheme) var colorScheme
     @Environment(\.sceneWidth) var sceneWidth
-    @Bindable var store: StoreOf<LoginFeature>
+    @State private var store: StoreOf<LoginFeature>
+
+    init(signInUseCase: SignInUseCase) {
+        self._store = State(initialValue: Store(
+            initialState: LoginFeature.State()
+        ) {
+            LoginFeature()
+        } withDependencies: {
+            $0.signInUseCase = .live(signInUseCase)
+        })
+    }
 
     var body: some View {
+        @Bindable var store = store
+
         ZStack {
             VStack {
                 Spacer()

--- a/Application/DevLogPresentation/Sources/Login/LoginView.swift
+++ b/Application/DevLogPresentation/Sources/Login/LoginView.swift
@@ -11,7 +11,7 @@ import ComposableArchitecture
 struct LoginView: View {
     @Environment(\.colorScheme) var colorScheme
     @Environment(\.sceneWidth) var sceneWidth
-    let store: StoreOf<LoginFeature>
+    @Bindable var store: StoreOf<LoginFeature>
 
     var body: some View {
         ZStack {
@@ -46,10 +46,7 @@ struct LoginView: View {
                 LoadingView()
             }
         }
-        .alert(store.alertTitle, isPresented: Binding(
-            get: { store.showAlert },
-            set: { store.send(.setAlert($0)) }
-        )) {
+        .alert(store.alertTitle, isPresented: $store.showAlert) {
             Button(String(localized: "common_close"), role: .cancel) { }
         } message: {
             Text(store.alertMessage)

--- a/Application/DevLogPresentation/Sources/Login/LoginView.swift
+++ b/Application/DevLogPresentation/Sources/Login/LoginView.swift
@@ -25,8 +25,6 @@ struct LoginView: View {
     }
 
     var body: some View {
-        @Bindable var store = store
-
         ZStack {
             VStack {
                 Spacer()

--- a/Application/DevLogPresentation/Sources/Login/LoginView.swift
+++ b/Application/DevLogPresentation/Sources/Login/LoginView.swift
@@ -57,10 +57,6 @@ struct LoginView: View {
                 LoadingView()
             }
         }
-        .alert(store.alertTitle, isPresented: $store.showAlert) {
-            Button(String(localized: "common_close"), role: .cancel) { }
-        } message: {
-            Text(store.alertMessage)
-        }
+        .alert($store.scope(state: \.alert, action: \.alert))
     }
 }

--- a/Application/DevLogPresentation/Sources/Root/RootView.swift
+++ b/Application/DevLogPresentation/Sources/Root/RootView.swift
@@ -16,7 +16,6 @@ public struct RootView: View {
     @State var viewModel: RootViewModel
     @State private var selectedRoute: Route?
     @State private var selectedMainTab = MainTab.home
-    private let loginStore: StoreOf<LoginFeature>
     private let widgetURLTab: (URL) -> MainTab?
     private let windowEvent: TodoEditorWindowEvent
     private let pushNotificationTodoIdPublisher: AnyPublisher<String, Never>
@@ -27,7 +26,6 @@ public struct RootView: View {
         networkConnectivityUseCase: ObserveNetworkConnectivityUseCase,
         systemThemeUseCase: ObserveSystemThemeUseCase,
         trackAnalyticsEventUseCase: TrackAnalyticsEventUseCase,
-        signInUseCase: SignInUseCase,
         widgetURLTab: @escaping (URL) -> MainTab?,
         windowEvent: TodoEditorWindowEvent,
         pushNotificationTodoIdPublisher: AnyPublisher<String, Never>,
@@ -39,13 +37,6 @@ public struct RootView: View {
             systemThemeUseCase: systemThemeUseCase,
             trackAnalyticsEventUseCase: trackAnalyticsEventUseCase
         ))
-        self.loginStore = Store(
-            initialState: LoginFeature.State()
-        ) {
-            LoginFeature()
-        } withDependencies: {
-            $0.signInUseCase = .live(signInUseCase)
-        }
         self.widgetURLTab = widgetURLTab
         self.windowEvent = windowEvent
         self.pushNotificationTodoIdPublisher = pushNotificationTodoIdPublisher
@@ -63,7 +54,7 @@ public struct RootView: View {
                         selectedTab: $selectedMainTab
                     )
                 } else {
-                    LoginView(store: loginStore)
+                    LoginView(signInUseCase: container.resolve(SignInUseCase.self))
                 }
             }
         }

--- a/Application/DevLogPresentation/Tests/Login/LoginFeatureTests.swift
+++ b/Application/DevLogPresentation/Tests/Login/LoginFeatureTests.swift
@@ -198,6 +198,6 @@ private struct LoginTestDriver {
     }
 
     func setAlert(_ isPresented: Bool) {
-        feature.send(.setAlert(isPresented))
+        feature.send(.binding(.set(\.showAlert, isPresented)))
     }
 }

--- a/Application/DevLogPresentation/Tests/Login/LoginFeatureTests.swift
+++ b/Application/DevLogPresentation/Tests/Login/LoginFeatureTests.swift
@@ -68,7 +68,7 @@ struct LoginFeatureTests {
         spy.resume()
 
         await waitUntil {
-            !driver.isLoading && driver.showAlert
+            !driver.isLoading && driver.hasAlert
         }
 
         #expect(!driver.isLoading)
@@ -83,12 +83,13 @@ struct LoginFeatureTests {
         driver.tapSignInButton(.google)
 
         await waitUntil {
-            driver.showAlert
+            driver.hasAlert
         }
 
-        #expect(driver.alertKind == .emailUnavailable)
-        #expect(driver.alertTitle == String(localized: "login_alert_email_unavailable_title"))
-        #expect(driver.alertMessage == String(localized: "login_alert_email_unavailable_message"))
+        #expect(driver.alert == expectedAlert(
+            title: String(localized: "login_alert_email_unavailable_title"),
+            message: String(localized: "login_alert_email_unavailable_message")
+        ))
     }
 
     @Test("일반 로그인 에러가 발생하면 공통 에러 알림을 표시한다")
@@ -100,12 +101,13 @@ struct LoginFeatureTests {
         driver.tapSignInButton(.apple)
 
         await waitUntil {
-            driver.showAlert
+            driver.hasAlert
         }
 
-        #expect(driver.alertKind == .error)
-        #expect(driver.alertTitle == String(localized: "common_error_title"))
-        #expect(driver.alertMessage == String(localized: "common_error_message"))
+        #expect(driver.alert == expectedAlert(
+            title: String(localized: "common_error_title"),
+            message: String(localized: "common_error_message")
+        ))
     }
 
     @Test("소셜 로그인 취소 에러가 발생하면 알림을 표시하지 않는다")
@@ -121,9 +123,7 @@ struct LoginFeatureTests {
         }
 
         #expect(!driver.showAlert)
-        #expect(driver.alertKind == nil)
-        #expect(driver.alertTitle.isEmpty)
-        #expect(driver.alertMessage.isEmpty)
+        #expect(driver.alert == nil)
     }
 
     @Test("알림을 닫으면 알림 상태와 문구가 초기화된다")
@@ -135,21 +135,14 @@ struct LoginFeatureTests {
         driver.tapSignInButton(.google)
 
         await waitUntil {
-            driver.showAlert
+            driver.hasAlert
         }
 
-        driver.setAlert(false)
+        driver.dismissAlert()
 
         #expect(!driver.showAlert)
-        #expect(driver.alertKind == nil)
-        #expect(driver.alertTitle.isEmpty)
-        #expect(driver.alertMessage.isEmpty)
+        #expect(driver.alert == nil)
     }
-}
-
-private enum LoginAlertKind: Equatable {
-    case emailUnavailable
-    case error
 }
 
 @MainActor
@@ -161,26 +154,15 @@ private struct LoginTestDriver {
     }
 
     var showAlert: Bool {
-        feature.state.showAlert
+        hasAlert
     }
 
-    var alertKind: LoginAlertKind? {
-        switch feature.state.alertType {
-        case .emailUnavailable:
-            return .emailUnavailable
-        case .error:
-            return .error
-        case .none:
-            return nil
-        }
+    var hasAlert: Bool {
+        alert != nil
     }
 
-    var alertTitle: String {
-        feature.state.alertTitle
-    }
-
-    var alertMessage: String {
-        feature.state.alertMessage
+    var alert: AlertState<Never>? {
+        feature.state.alert
     }
 
     init(useCase: SignInUseCase) {
@@ -197,7 +179,22 @@ private struct LoginTestDriver {
         feature.send(.tapSignInButton(provider))
     }
 
-    func setAlert(_ isPresented: Bool) {
-        feature.send(.binding(.set(\.showAlert, isPresented)))
+    func dismissAlert() {
+        feature.send(.alert(.dismiss))
+    }
+}
+
+private func expectedAlert(
+    title: String,
+    message: String
+) -> AlertState<Never> {
+    AlertState {
+        TextState(title)
+    } actions: {
+        ButtonState(role: .cancel) {
+            TextState(String(localized: "common_close"))
+        }
+    } message: {
+        TextState(message)
     }
 }

--- a/Application/DevLogPresentation/Tests/Login/LoginFeatureTests.swift
+++ b/Application/DevLogPresentation/Tests/Login/LoginFeatureTests.swift
@@ -27,8 +27,8 @@ struct LoginFeatureTests {
         #expect(spy.calledProviders == [.github])
     }
 
-    @Test("로그인 요청 중에는 로딩 상태가 켜지고 요청이 끝나면 꺼진다")
-    func 로그인_요청_중에는_로딩_상태가_켜지고_요청이_끝나면_꺼진다() async {
+    @Test("로그인 성공 후에도 메인 화면 전환 전까지 로딩 상태를 유지한다")
+    func 로그인_성공_후에도_메인_화면_전환_전까지_로딩_상태를_유지한다() async {
         let spy = SignInUseCaseSpy()
         spy.shouldSuspend = true
         let driver = LoginTestDriver(useCase: spy)
@@ -44,10 +44,10 @@ struct LoginFeatureTests {
         spy.resume()
 
         await waitUntil {
-            !driver.isLoading
+            spy.successfulProviders == [.google]
         }
 
-        #expect(!driver.isLoading)
+        #expect(driver.isLoading)
     }
 
     @Test("로그인 실패 후에도 로딩 상태가 꺼진다")

--- a/Application/DevLogPresentation/Tests/Support/TestSupport.swift
+++ b/Application/DevLogPresentation/Tests/Support/TestSupport.swift
@@ -54,6 +54,7 @@ final class SignInUseCaseSpy: SignInUseCase {
     var error: Error?
     var shouldSuspend = false
     private(set) var calledProviders: [AuthProvider] = []
+    private(set) var successfulProviders = [AuthProvider]()
     private var continuation: CheckedContinuation<Void, Never>?
     private var shouldResume = false
 
@@ -74,6 +75,8 @@ final class SignInUseCaseSpy: SignInUseCase {
         if let error {
             throw error
         }
+
+        successfulProviders.append(provider)
     }
 
     func resume() {


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #556

## 🎯 의도

OAuth 인증 얼럿 / 시트가 표시되는 동안 `LoginView`의 `Store`가 재생성되며 `isLoading`이 초기값으로 돌아가 `LoadingView`가 사라지는 문제 해결

## 📝 작업 내용

### 📌 요약

- `LoginView`가 `LoginFeature` store를 `@State`로 소유하도록 변경
- alert 표시 상태를 TCA binding action으로 처리하도록 `BindableAction` / `BindingReducer` 적용
- 로그인 성공 시 `LoginFeature`에서 로딩 상태를 끄지 않도록 성공 액션 제거
- `RootView`의 `loginStore` 보관과 `DevLogApp`의 `signInUseCase` 전달 제거

### 🔍 상세

- `LoginView` 생성 시 `SignInUseCase`를 받아 내부 `Store`를 구성해 OAuth sheet 표시 후 body 재평가에도 store lifetime 유지
- `showAlert` 닫힘 처리는 `$store.showAlert` 바인딩과 `case .binding(\.showAlert)`에서 alert 상태 초기화
- 로그인 실패와 취소에서만 `isLoading = false` 처리
- `RootView`는 로그인 화면 표시 시 `container.resolve(SignInUseCase.self)`로 `LoginView` 생성 책임만 수행

## 📸 영상 / 이미지 (Optional)

<table>
<tr>
<td align="center">

https://github.com/user-attachments/assets/12886b25-925c-4c11-8baa-4a9bbbbabfe4

<td align="center">

https://github.com/user-attachments/assets/019880c7-9b5f-4077-9a76-672c2ecd4929

<tr>
<tr>
<td align="center">개선 전
<td align="center">개선 후
<tr>
</table>