### PR TITLE
[#564] Fastlane 빌드가 실패하는 현상을 해결한다

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -20,7 +20,7 @@ on:
 env:
   SCHEME: DevLogApp
   RUBY_VERSION: "3.2"
-  XCODE_VERSION: latest
+  XCODE_VERSION: "26.5"
   APP_STORE_TEAM_ID: ${{ secrets.APP_STORE_TEAM_ID }}
   ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
   ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
@@ -36,7 +36,7 @@ permissions:
 jobs:
   testflight:
     if: github.event_name == 'workflow_dispatch' || (github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'develop' && (contains(github.event.pull_request.labels.*.name, 'qa') || contains(github.event.pull_request.labels.*.name, 'qa-local')))
-    runs-on: macos-latest
+    runs-on: macos-26
     timeout-minutes: 45
 
     steps:
@@ -113,6 +113,14 @@ jobs:
 
       - name: Build for TestFlight
         run: bundle exec fastlane testflight_build_only
+
+      - name: Upload TestFlight build log
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: testflight-build-log
+          path: ~/Library/Logs/gym/*.log
+          if-no-files-found: ignore
 
       - name: Skip TestFlight Upload
         if: (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'qa-local')) || (github.event_name == 'workflow_dispatch' && inputs.upload_to_app_store_connect != 'true')

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -20,7 +20,7 @@ on:
 env:
   SCHEME: DevLogApp
   RUBY_VERSION: "3.2"
-  XCODE_VERSION: "26.5"
+  XCODE_VERSION: latest
   APP_STORE_TEAM_ID: ${{ secrets.APP_STORE_TEAM_ID }}
   ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
   ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
@@ -36,7 +36,7 @@ permissions:
 jobs:
   testflight:
     if: github.event_name == 'workflow_dispatch' || (github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'develop' && (contains(github.event.pull_request.labels.*.name, 'qa') || contains(github.event.pull_request.labels.*.name, 'qa-local')))
-    runs-on: macos-26
+    runs-on: macos-latest
     timeout-minutes: 45
 
     steps:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -131,7 +131,7 @@ platform :ios do
       export_method: "app-store",
       output_directory: TESTFLIGHT_BUILD_OUTPUT_DIRECTORY,
       output_name: "#{APP_PRODUCT_NAME}.ipa",
-      xcargs: "-skipPackagePluginValidation"
+      xcargs: "-skipPackagePluginValidation -skipMacroValidation"
     )
 
     next api_key


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #564

## 🎯 의도

- TestFlight archive 단계에서 Swift macro validation으로 인해 `build_app`이 실패하는 현상 해결

## 📝 작업 내용

### 📌 요약

- Fastlane archive 명령에 `-skipMacroValidation` 옵션 추가
- TestFlight 실패 시 `gym` build log를 artifact로 업로드하도록 추가

### 🔍 상세

- `swift-composable-architecture`, `swift-case-paths`, `swift-dependencies`, `swift-perception`의 macro target validation 실패 대응
- 기존 CI build/test 경로와 동일하게 `-skipPackagePluginValidation -skipMacroValidation` 조합 적용
- `Build for TestFlight` 실패 후에도 `~/Library/Logs/gym/*.log`를 artifact로 남기도록 구성
- TestFlight workflow 재실행 성공 확인

## 📸 영상 / 이미지 (Optional