### PR TITLE
[#601] 푸시 알림 설정이 자동으로 upsert되는 현상을 해결한다

### DIFF
--- a/Application/DevLogPresentation/Sources/Settings/PushNotificationSettingsFeature.swift
+++ b/Application/DevLogPresentation/Sources/Settings/PushNotificationSettingsFeature.swift
@@ -42,6 +42,7 @@ struct PushNotificationSettingsFeature {
         case binding(BindingAction<State>)
         case timePicker(PresentationAction<TimePicker>)
         case fetchSettings
+        case applyFetchedSettings(PushNotificationSettings)
         case setAlert
         case tapCustomTime
         case selectPresetTime(Date)
@@ -86,6 +87,13 @@ struct PushNotificationSettingsFeature {
                 break
             case .fetchSettings:
                 return fetchPushNotificationSettingsEffect()
+            case .applyFetchedSettings(let settings):
+                state.pushNotificationEnable = settings.isEnabled
+                if let hour = settings.scheduledTime.hour,
+                   let minute = settings.scheduledTime.minute,
+                   let date = Calendar.current.date(bySettingHour: hour, minute: minute, second: 0, of: Date()) {
+                    state.viewPushNotificationTime = date
+                }
             case .setAlert:
                 state.alert = Self.alertState()
             case .tapCustomTime:
@@ -154,12 +162,7 @@ private extension PushNotificationSettingsFeature {
             await send(.loading(.begin(target: .default, mode: .delayed)))
             do {
                 let settings = try await fetchPushSettingsUseCase.execute()
-                await send(.binding(.set(\.pushNotificationEnable, settings.isEnabled)))
-                if let hour = settings.scheduledTime.hour,
-                   let minute = settings.scheduledTime.minute,
-                   let date = Calendar.current.date(bySettingHour: hour, minute: minute, second: 0, of: Date()) {
-                    await send(.binding(.set(\.viewPushNotificationTime, date)))
-                }
+                await send(.applyFetchedSettings(settings))
                 await send(.loading(.end(target: .default, mode: .delayed)))
             } catch {
                 await send(.loading(.end(target: .default, mode: .delayed)))

--- a/Application/DevLogPresentation/Tests/Settings/PushNotificationSettingsFeatureTests.swift
+++ b/Application/DevLogPresentation/Tests/Settings/PushNotificationSettingsFeatureTests.swift
@@ -19,21 +19,31 @@ struct PushNotificationSettingsFeatureTests {
             settings: makePushNotificationSettings(isEnabled: true, hour: 9, minute: 0)
         )
         let adapter = PushNotificationSettingsStoreTestAdapter(fetchUseCase: fetchSpy)
-
         await adapter.fetchSettings()
-
         #expect(adapter.pushNotificationEnable)
         #expect(adapter.pushNotificationHour == 9)
         #expect(adapter.pushNotificationMinute == 0)
         #expect(adapter.sheetPushNotificationTime == adapter.viewPushNotificationTime)
     }
 
+    @Test("fetchSettings는 서버 상태 반영 중 설정 업데이트를 다시 호출하지 않는다")
+    func fetchSettings는_서버_상태_반영_중_설정_업데이트를_다시_호출하지_않는다() async {
+        let fetchSpy = FetchPushSettingsUseCaseSpy(
+            settings: makePushNotificationSettings(isEnabled: true, hour: 9, minute: 0)
+        )
+        let updateSpy = UpdatePushSettingsUseCaseSpy()
+        let adapter = PushNotificationSettingsStoreTestAdapter(
+            fetchUseCase: fetchSpy,
+            updateUseCase: updateSpy
+        )
+        await adapter.fetchSettings()
+        #expect(updateSpy.executeCallCount == 0)
+    }
+
     @Test("setPushNotificationEnable은 활성화 상태를 변경한다")
     func setPushNotificationEnable은_활성화_상태를_변경한다() async {
         let adapter = PushNotificationSettingsStoreTestAdapter()
-
         await adapter.setPushNotificationEnable(true)
-
         #expect(adapter.pushNotificationEnable)
     }
 
@@ -41,9 +51,7 @@ struct PushNotificationSettingsFeatureTests {
     func selectPresetTime은_화면과_시트_시간을_함께_변경한다() async {
         let adapter = PushNotificationSettingsStoreTestAdapter()
         let date = makeDate(hour: 15, minute: 0)
-
         await adapter.selectPresetTime(date)
-
         #expect(adapter.viewPushNotificationTime == date)
         #expect(adapter.sheetPushNotificationTime == date)
         #expect(adapter.pushNotificationHour == 15)
@@ -54,10 +62,8 @@ struct PushNotificationSettingsFeatureTests {
     func setShowTimePicker는_현재_화면_시간으로_시트를_연다() async {
         let adapter = PushNotificationSettingsStoreTestAdapter()
         let date = makeDate(hour: 18, minute: 0)
-
         await adapter.setPushNotificationTime(view: date)
         await adapter.setShowTimePicker(true)
-
         #expect(adapter.showTimePicker)
         #expect(adapter.sheetPushNotificationTime == date)
     }
@@ -111,10 +117,8 @@ struct PushNotificationSettingsFeatureTests {
     @Test("setSheetHeight는 시트 높이 상태를 변경한다")
     func setSheetHeight는_시트_높이_상태를_변경한다() async {
         let adapter = PushNotificationSettingsStoreTestAdapter()
-
         await adapter.setShowTimePicker(true)
         await adapter.setSheetHeight(240)
-
         #expect(adapter.sheetHeight == 240)
     }
 
@@ -345,8 +349,10 @@ private final class FetchPushSettingsUseCaseSpy: FetchPushSettingsUseCase {
 
 private final class UpdatePushSettingsUseCaseSpy: UpdatePushSettingsUseCase {
     var error: Error?
+    private(set) var executeCallCount = 0
 
     func execute(_: PushNotificationSettings) async throws {
+        executeCallCount += 1
         if let error {
             self.error = nil
             throw error
@@ -374,12 +380,7 @@ private func makeDate(
     minute: Int
 ) -> Date {
     let baseDate = Date(timeIntervalSince1970: 0)
-    return Calendar.current.date(
-        bySettingHour: hour,
-        minute: minute,
-        second: 0,
-        of: baseDate
-    ) ?? baseDate
+    return Calendar.current.date(bySettingHour: hour, minute: minute, second: 0, of: baseDate) ?? baseDate
 }
 
 private func expectedPushNotificationSettingsErrorAlert() -> AlertState<Never> {

--- a/Tuist/ProjectDescriptionHelpers/Project+Packages.swift
+++ b/Tuist/ProjectDescriptionHelpers/Project+Packages.swift
@@ -3,19 +3,19 @@ import ProjectDescription
 public enum DevLogPackages {
     public static let markdownUIPackage: Package = .package(
         url: "https://github.com/gonzalezreal/swift-markdown-ui.git",
-        .upToNextMajor(from: "2.4.1")
+        .exact("2.4.1")
     )
     public static let swiftCollectionsPackage: Package = .package(
         url: "https://github.com/apple/swift-collections.git",
-        .upToNextMajor(from: "1.3.0")
+        .exact("1.3.0")
     )
     public static let composableArchitecturePackage: Package = .package(
         url: "https://github.com/pointfreeco/swift-composable-architecture",
-        .upToNextMinor(from: "1.25.5")
+        .exact("1.25.5")
     )
     public static let firebasePackage: Package = .package(
         url: "https://github.com/firebase/firebase-ios-sdk",
-        .upToNextMajor(from: "11.15.0")
+        .exact("11.15.0")
     )
     public static let googleSignInPackage: Package = .package(
         url: "https://github.com/google/GoogleSignIn-iOS",


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #601

## 🎯 의도
- PushNotificationSettingsView 진입 시 fetch 결과가 `binding` 액션으로 다시 전달되면서 의도치 않게 푸시 알림 설정 업데이트가 발생하던 문제 해결

## 📝 작업 내용

### 📌 요약
- `fetchSettings` 결과 반영 경로를 `binding` 액션과 별도 액션으로 분리한 작업
- 화면 진입 중 자동 업데이트가 발생하지 않도록 수정한 작업
- fetch만 수행했을 때 update use case가 다시 호출되지 않는 회귀 테스트 추가 작업

### 🔍 상세
- `PushNotificationSettingsFeature`에 `applyFetchedSettings` 액션 추가
- fetch 결과를 `.binding(.set(...))` 대신 `applyFetchedSettings`로 반영하도록 변경
- 사용자 토글 입력 경로와 서버 응답 반영 경로를 분리하여 `binding(\.pushNotificationEnable)`에서만 업데이트 effect가 실행되도록 수정
- `PushNotificationSettingsFeatureTests`에 fetch 결과 반영 중 update use case 재호출이 발생하지 않는 테스트 추가
- 테스트 spy에 update 호출 횟수 추적 로직 추가

## 📸 영상 / 이미지 (Optional)