### PR TITLE
[#611] 업데이트된 구조 개선에 따른 리드미를 수정한다

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,11 +144,13 @@ Todo, 저장 링크, 오늘 할 일, 받은 알림, 누적 활동을 하나의 �
 
 | 항목 | 버전 |
 | --- | --- |
-| Xcode | 26.3 |
+| Xcode | 26.5 |
 | iOS Deployment Target | 17.0 |
 | Swift | 5.0 |
 | Tuist | 4.194.4 |
-| Ruby | 3.2 |
+| SwiftLint | 0.63.3 |
+| Ruby | 3.4.7 |
+| Bundler | 2.7.2 |
 | Fastlane | 2.232.2 |
 | Node.js | 22 |
 | TypeScript | 4.9.5 |

--- a/README.md
+++ b/README.md
@@ -53,8 +53,7 @@ Todo, 저장 링크, 오늘 할 일, 받은 알림, 누적 활동을 하나의 �
 
 ## 아키텍처
 
-MVVM을 기반으로 하되, ViewModel 상태 관리에는 MVI 형태의 단방향 흐름을 차용한 구조  
-`DevLog.xcworkspace` 안에서 Application, Widget 모듈을 분리하고 화면, 상태, 비즈니스 로직, 외부 의존성 경계를 나눈 `MVVM + Clean Architecture` 기반 구성
+`DevLog.xcworkspace` 안에서 Application, Widget 모듈을 분리하고 화면, 상태, 비즈니스 로직, 외부 의존성 경계를 나눈 `Clean Architecture` 기반 구성
 
 <table>
   <tr>
@@ -64,14 +63,6 @@ MVVM을 기반으로 하되, ViewModel 상태 관리에는 MVI 형태의 단방�
   </tr>
   <tr>
     <td align="center">Tuist 모듈 의존성 그래프</td>
-  </tr>
-  <tr>
-    <td align="center">
-      <img alt="StorePattern Protocol" src="./docs/store-protocol.png" />
-    </td>
-  </tr>
-  <tr>
-    <td align="center">StorePattern 프로토콜</td>
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -32,8 +32,6 @@
 
 ## 앱 사용해보기
 
-iOS 17 이상 환경에서 App Store에서 다운로드 가능
-
 <a href="https://apps.apple.com/us/app/devlog/id6760288611">
   <img src="https://img.shields.io/badge/App%20Store-0D96F6?style=flat&logo=appstore&logoColor=white" />
 

--- a/README.md
+++ b/README.md
@@ -124,14 +124,16 @@ Todo, 저장 링크, 오늘 할 일, 받은 알림, 누적 활동을 하나의 �
 
 | 구분 | 스택 |
 | --- | --- |
-| Deployment Target | iOS 17+ |
-| Architecture | Modular Architecture, MVVM, MVI-inspired state flow, Clean Architecture |
-| UI | SwiftUI, Charts, MarkdownUI |
-| State & Async | Observable, Combine, async/await |
-| Backend | FirebaseAuth, FirebaseFirestore, Firebase Cloud Functions, FirebaseMessaging |
-| Apple Frameworks | AuthenticationServices, UserNotifications, LinkPresentation, Network |
-| Utility | GoogleSignIn, OrderedCollections |
-| Tooling | Xcode, Tuist, mise, Swift Package Manager, SwiftLint, Fastlane |
+| Deployment Target | iOS / iPadOS 17.0+ |
+| Platform Support | iPhone, iPad, Apple Silicon Mac (App Store, Designed for iPad) |
+| Architecture | Tuist Modular based Clean Architecture |
+| UI | SwiftUI, MarkdownUI, WidgetKit, AppIntents |
+| State & Async | Observable, Combine, async/await, The Composable Architecture |
+| Backend | Firebase Authentication, Firestore, Cloud Functions, Cloud Messaging, Analytics |
+| Apple Frameworks | AuthenticationServices, UserNotifications, LinkPresentation, Network, CryptoKit, os.log |
+| External Packages | ComposableArchitecture, MarkdownUI, OrderedCollections, GoogleSignIn, Nexa |
+| Testing | swift-testing, TCA TestStore |
+| Tooling | Xcode, Tuist, mise, Swift Package Manager, SwiftLint, Fastlane, Firebase CLI |
 
 ## 개발 환경 구성
 


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #611

## 🎯 의도
README의 기술 스택, 지원 플랫폼, 개발 환경 정보가 현재 Tuist manifest와 실제 사용 의존성을 충분히 반영하지 못하던 문제 개선

## 📝 작업 내용

### 📌 요약
- README 기술 스택 표를 현재 프로젝트 구성 기준으로 최신화
- iOS/iPadOS Deployment Target과 App Store 기준 Apple Silicon Mac 지원 정보 분리
- README 아키텍처 설명과 이미지 구성을 현재 문서 흐름에 맞게 정리
- 개발 환경 버전 정보 최신화

### 🔍 상세
- `Charts`처럼 현재 사용되지 않는 스택 제거
- `WidgetKit`, `AppIntents`, `The Composable Architecture`, `Firebase Analytics`, `Nexa`, `swift-testing`, `TCA TestStore` 항목 추가
- `Deployment Target`은 `iOS / iPadOS 17.0+`로 정리
- Apple Silicon Mac 지원은 `Platform Support`에서 `App Store, Designed for iPad` 기준으로 분리
- Xcode, SwiftLint, Ruby, Bundler 버전 정보 갱신
- 중복 설명이 있던 StorePattern 이미지와 문구 제거

## 📸 영상 / 이미지 (Optional)