### PR TITLE
[#580] ProfileView에 TCA를 적용한다

### DIFF
--- a/Application/DevLogPresentation/Sources/Profile/ProfileFeature+Dependencies.swift
+++ b/Application/DevLogPresentation/Sources/Profile/ProfileFeature+Dependencies.swift
@@ -1,0 +1,101 @@
+//
+//  ProfileFeature+Dependencies.swift
+//  DevLogPresentation
+//
+//  Created by opfic on 6/15/26.
+//
+
+import ComposableArchitecture
+import DevLogDomain
+
+extension DependencyValues {
+    var profileFetchUserDataUseCase: FetchUserDataUseCase {
+        get { self[ProfileFetchUserDataKey.self] }
+        set { self[ProfileFetchUserDataKey.self] = newValue }
+    }
+
+    var profileFetchImageDataUseCase: FetchProfileImageDataUseCase {
+        get { self[ProfileFetchImageDataKey.self] }
+        set { self[ProfileFetchImageDataKey.self] = newValue }
+    }
+
+    var profileFetchTodosUseCase: FetchTodosUseCase {
+        get { self[ProfileFetchTodosKey.self] }
+        set { self[ProfileFetchTodosKey.self] = newValue }
+    }
+
+    var profileUpsertStatusMessageUseCase: UpsertStatusMessageUseCase {
+        get { self[ProfileUpsertStatusMessageKey.self] }
+        set { self[ProfileUpsertStatusMessageKey.self] = newValue }
+    }
+
+    var profileFetchHeatmapActivityTypesUseCase: FetchHeatmapActivityTypesUseCase {
+        get { self[ProfileFetchHeatmapTypesKey.self] }
+        set { self[ProfileFetchHeatmapTypesKey.self] = newValue }
+    }
+
+    var profileUpdateHeatmapActivityTypesUseCase: UpdateHeatmapActivityTypesUseCase {
+        get { self[ProfileUpdateHeatmapTypesKey.self] }
+        set { self[ProfileUpdateHeatmapTypesKey.self] = newValue }
+    }
+}
+
+private enum ProfileFetchUserDataKey: DependencyKey {
+    static var liveValue: FetchUserDataUseCase {
+        preconditionFailure("FetchUserDataUseCase must be provided.")
+    }
+
+    static var testValue: FetchUserDataUseCase {
+        liveValue
+    }
+}
+
+private enum ProfileFetchImageDataKey: DependencyKey {
+    static var liveValue: FetchProfileImageDataUseCase {
+        preconditionFailure("FetchProfileImageDataUseCase must be provided.")
+    }
+
+    static var testValue: FetchProfileImageDataUseCase {
+        liveValue
+    }
+}
+
+private enum ProfileFetchTodosKey: DependencyKey {
+    static var liveValue: FetchTodosUseCase {
+        preconditionFailure("FetchTodosUseCase must be provided.")
+    }
+
+    static var testValue: FetchTodosUseCase {
+        liveValue
+    }
+}
+
+private enum ProfileUpsertStatusMessageKey: DependencyKey {
+    static var liveValue: UpsertStatusMessageUseCase {
+        preconditionFailure("UpsertStatusMessageUseCase must be provided.")
+    }
+
+    static var testValue: UpsertStatusMessageUseCase {
+        liveValue
+    }
+}
+
+private enum ProfileFetchHeatmapTypesKey: DependencyKey {
+    static var liveValue: FetchHeatmapActivityTypesUseCase {
+        preconditionFailure("FetchHeatmapActivityTypesUseCase must be provided.")
+    }
+
+    static var testValue: FetchHeatmapActivityTypesUseCase {
+        liveValue
+    }
+}
+
+private enum ProfileUpdateHeatmapTypesKey: DependencyKey {
+    static var liveValue: UpdateHeatmapActivityTypesUseCase {
+        preconditionFailure("UpdateHeatmapActivityTypesUseCase must be provided.")
+    }
+
+    static var testValue: UpdateHeatmapActivityTypesUseCase {
+        liveValue
+    }
+}

--- a/Application/DevLogPresentation/Sources/Profile/ProfileFeature+Heatmap.swift
+++ b/Application/DevLogPresentation/Sources/Profile/ProfileFeature+Heatmap.swift
@@ -1,0 +1,280 @@
+//
+//  ProfileFeature+Heatmap.swift
+//  DevLogPresentation
+//
+//  Created by opfic on 6/15/26.
+//
+
+import DevLogCore
+import DevLogDomain
+import Foundation
+
+private struct ProfileHeatmapActivityCounts {
+    var createdCount = 0
+    var completedCount = 0
+    var deletedCount = 0
+
+    mutating func increment(_ activityKind: ActivityKind) {
+        switch activityKind {
+        case .created:
+            createdCount += 1
+        case .completed:
+            completedCount += 1
+        case .deleted:
+            deletedCount += 1
+        }
+    }
+}
+
+private struct ProfileHeatmapActivityEntry {
+    var todo: Todo
+    var activityKinds: Set<ActivityKind>
+}
+
+extension ProfileFeature {
+    static func quarterStart(for date: Date) -> Date? {
+        let month = Calendar.current.component(.month, from: date)
+        let startMonth = ((month - 1) / 3) * 3 + 1
+        var components = Calendar.current.dateComponents([.year], from: date)
+        components.month = startMonth
+        components.day = 1
+        return Calendar.current.date(from: components)
+    }
+
+    static func quarterStart(year: Int, quarter: Int) -> Date? {
+        guard (1...4).contains(quarter) else { return nil }
+        var components = DateComponents()
+        components.year = year
+        components.month = ((quarter - 1) * 3) + 1
+        components.day = 1
+        return Calendar.current.date(from: components)
+    }
+
+    static func canSelectQuarter(_ quarterStart: Date, state: State) -> Bool {
+        guard let earliestQuarterStart = state.earliestQuarterStart,
+              let currentQuarterStart = self.quarterStart(for: Date()) else { return false }
+        return earliestQuarterStart <= quarterStart && quarterStart <= currentQuarterStart
+    }
+
+    static func normalizeActivityKinds(_ rawValues: [String]) -> Set<ActivityKind> {
+        let selectableActivityKindRawValues = Set(ActivityKindItem.selectableItems.map(\.rawValue))
+
+        return Set(
+            rawValues
+                .compactMap(ActivityKind.init(rawValue:))
+                .filter { selectableActivityKindRawValues.contains($0.rawValue) }
+        )
+    }
+
+    static func canMoveToQuarter(offsetMonths: Int, state: State) -> Bool {
+        guard let selectedQuarterStart = state.selectedQuarterStart else { return false }
+        guard let targetQuarterStart = Calendar.current.date(
+            byAdding: .month,
+            value: offsetMonths,
+            to: selectedQuarterStart
+        ) else {
+            return false
+        }
+        return canSelectQuarter(targetQuarterStart, state: state)
+    }
+
+    static func fetchQuarterActivityData(
+        from quarterStart: Date,
+        fetchTodosUseCase: FetchTodosUseCase
+    ) async throws -> (quarter: HeatmapQuarter, dayActivitiesByDate: [Date: [HeatmapActivityItem]]) {
+        guard let nextQuarterStart = Calendar.current.date(byAdding: .month, value: 3, to: quarterStart) else {
+            return (HeatmapQuarter(quarterStart: quarterStart, months: []), [:])
+        }
+
+        async let createdTodoPage = fetchTodosUseCase.execute(
+            TodoQuery(
+                sortDateFrom: quarterStart,
+                sortDateTo: nextQuarterStart,
+                includesDeleted: true,
+                sortTarget: .createdAt,
+                pageSize: 100,
+                fetchAllPages: true
+            ),
+            cursor: nil
+        )
+        async let completedTodoPage = fetchTodosUseCase.execute(
+            TodoQuery(
+                sortDateFrom: quarterStart,
+                sortDateTo: nextQuarterStart,
+                includesDeleted: true,
+                sortTarget: .completedAt,
+                pageSize: 100,
+                fetchAllPages: true
+            ),
+            cursor: nil
+        )
+        async let deletedTodoPage = fetchTodosUseCase.execute(
+            TodoQuery(
+                sortDateFrom: quarterStart,
+                sortDateTo: nextQuarterStart,
+                includesDeleted: true,
+                sortTarget: .deletedAt,
+                pageSize: 100,
+                fetchAllPages: true
+            ),
+            cursor: nil
+        )
+
+        let (createdTodoPageResult, completedTodoPageResult, deletedTodoPageResult) = try await (
+            createdTodoPage,
+            completedTodoPage,
+            deletedTodoPage
+        )
+        return makeQuarterActivityData(
+            createdTodos: createdTodoPageResult.items,
+            completedTodos: completedTodoPageResult.items,
+            deletedTodos: deletedTodoPageResult.items,
+            quarterStart: quarterStart
+        )
+    }
+
+    static func makeQuarterActivityData(
+        createdTodos: [Todo],
+        completedTodos: [Todo],
+        deletedTodos: [Todo],
+        quarterStart: Date
+    ) -> (quarter: HeatmapQuarter, dayActivitiesByDate: [Date: [HeatmapActivityItem]]) {
+        var dailyCountsByDate: [Date: ProfileHeatmapActivityCounts] = [:]
+        var activityEntriesByDate: [Date: [String: ProfileHeatmapActivityEntry]] = [:]
+
+        for todo in createdTodos {
+            appendHeatmapActivity(
+                todo: todo,
+                kind: .created,
+                occurredAt: todo.createdAt,
+                dailyCountsByDate: &dailyCountsByDate,
+                activityEntriesByDate: &activityEntriesByDate
+            )
+        }
+
+        for todo in completedTodos {
+            guard let completedAt = todo.completedAt else { continue }
+            appendHeatmapActivity(
+                todo: todo,
+                kind: .completed,
+                occurredAt: completedAt,
+                dailyCountsByDate: &dailyCountsByDate,
+                activityEntriesByDate: &activityEntriesByDate
+            )
+        }
+
+        for todo in deletedTodos {
+            guard let deletedAt = todo.deletedAt else { continue }
+            appendHeatmapActivity(
+                todo: todo,
+                kind: .deleted,
+                occurredAt: deletedAt,
+                dailyCountsByDate: &dailyCountsByDate,
+                activityEntriesByDate: &activityEntriesByDate
+            )
+        }
+
+        let quarter = HeatmapQuarter(
+            quarterStart: quarterStart,
+            months: makeActivityMonths(dailyCountsByDate: dailyCountsByDate, quarterStart: quarterStart)
+        )
+        let dayActivitiesByDate = activityEntriesByDate.mapValues { activityEntries in
+            activityEntries.values.compactMap { activityEntry in
+                HeatmapActivityItem(
+                    todo: activityEntry.todo,
+                    activityKinds: orderedActivityKinds(from: activityEntry.activityKinds)
+                )
+            }
+            .sorted()
+        }
+        return (quarter, dayActivitiesByDate)
+    }
+
+    private static func makeActivityMonths(
+        dailyCountsByDate: [Date: ProfileHeatmapActivityCounts],
+        quarterStart: Date
+    ) -> [HeatmapMonth] {
+        let monthStarts = (0..<3).compactMap {
+            Calendar.current.date(byAdding: .month, value: $0, to: quarterStart)
+        }
+
+        return monthStarts.map { monthStart in
+            makeActivityMonth(
+                monthStart: monthStart,
+                dailyCountsByDate: dailyCountsByDate
+            )
+        }
+    }
+
+    private static func makeActivityMonth(
+        monthStart: Date,
+        dailyCountsByDate: [Date: ProfileHeatmapActivityCounts]
+    ) -> HeatmapMonth {
+        guard let monthInterval = Calendar.current.dateInterval(of: .month, for: monthStart),
+              let monthLastDay = Calendar.current.date(byAdding: .day, value: -1, to: monthInterval.end),
+              let firstWeekInterval = Calendar.current.dateInterval(of: .weekOfYear, for: monthInterval.start),
+              let lastWeekInterval = Calendar.current.dateInterval(of: .weekOfYear, for: monthLastDay) else {
+            return HeatmapMonth(monthStart: monthStart, weeks: [])
+        }
+
+        var days: [HeatmapDay] = []
+        var cursor = firstWeekInterval.start
+        while cursor < lastWeekInterval.end {
+            let normalizedDate = Calendar.current.startOfDay(for: cursor)
+            let isInMonth = Calendar.current.isDate(normalizedDate, equalTo: monthStart, toGranularity: .month)
+            let dailyCounts = dailyCountsByDate[normalizedDate] ?? ProfileHeatmapActivityCounts()
+            let createdCount = isInMonth ? dailyCounts.createdCount : 0
+            let completedCount = isInMonth ? dailyCounts.completedCount : 0
+            let deletedCount = isInMonth ? dailyCounts.deletedCount : 0
+            days.append(
+                HeatmapDay(
+                    date: normalizedDate,
+                    createdCount: createdCount,
+                    completedCount: completedCount,
+                    deletedCount: deletedCount,
+                    isVisible: isInMonth
+                )
+            )
+            guard let nextDay = Calendar.current.date(byAdding: .day, value: 1, to: cursor) else { break }
+            cursor = nextDay
+        }
+
+        var weeks: [[HeatmapDay]] = []
+        var index = 0
+        while index < days.count {
+            let endIndex = min(index + 7, days.count)
+            weeks.append(Array(days[index..<endIndex]))
+            index += 7
+        }
+
+        return HeatmapMonth(monthStart: monthStart, weeks: weeks)
+    }
+
+    private static func appendHeatmapActivity(
+        todo: Todo,
+        kind: ActivityKind,
+        occurredAt: Date,
+        dailyCountsByDate: inout [Date: ProfileHeatmapActivityCounts],
+        activityEntriesByDate: inout [Date: [String: ProfileHeatmapActivityEntry]]
+    ) {
+        let dayStart = Calendar.current.startOfDay(for: occurredAt)
+        var heatmapActivityCounts = dailyCountsByDate[dayStart] ?? ProfileHeatmapActivityCounts()
+        heatmapActivityCounts.increment(kind)
+        dailyCountsByDate[dayStart] = heatmapActivityCounts
+
+        var activityEntries = activityEntriesByDate[dayStart] ?? [:]
+        var heatmapActivityEntry = activityEntries[todo.id] ?? ProfileHeatmapActivityEntry(
+            todo: todo,
+            activityKinds: []
+        )
+        heatmapActivityEntry.todo = todo
+        heatmapActivityEntry.activityKinds.insert(kind)
+        activityEntries[todo.id] = heatmapActivityEntry
+        activityEntriesByDate[dayStart] = activityEntries
+    }
+
+    private static func orderedActivityKinds(from activityKinds: Set<ActivityKind>) -> [ActivityKind] {
+        let orderedActivityKinds: [ActivityKind] = [.created, .completed, .deleted]
+        return orderedActivityKinds.filter { activityKinds.contains($0) }
+    }
+}

--- a/Application/DevLogPresentation/Sources/Profile/ProfileFeature+State.swift
+++ b/Application/DevLogPresentation/Sources/Profile/ProfileFeature+State.swift
@@ -35,6 +35,33 @@ extension ProfileFeature.State {
         }
     }
 
+    var isCreatedActivitySelected: Bool {
+        get { selectedActivityKinds.contains(.created) }
+        set { setActivityKind(.created, isSelected: newValue) }
+    }
+
+    var isCompletedActivitySelected: Bool {
+        get { selectedActivityKinds.contains(.completed) }
+        set { setActivityKind(.completed, isSelected: newValue) }
+    }
+
+    var isDeletedActivitySelected: Bool {
+        get { selectedActivityKinds.contains(.deleted) }
+        set { setActivityKind(.deleted, isSelected: newValue) }
+    }
+
+    var isCreatedActivityToggleDisabled: Bool {
+        selectedActivityKinds == [.created]
+    }
+
+    var isCompletedActivityToggleDisabled: Bool {
+        selectedActivityKinds == [.completed]
+    }
+
+    var isDeletedActivityToggleDisabled: Bool {
+        selectedActivityKinds == [.deleted]
+    }
+
     var canMoveToPreviousQuarter: Bool {
         ProfileHeatmapBuilder.canMoveToQuarter(offsetMonths: -3, state: self)
     }
@@ -72,5 +99,13 @@ extension ProfileFeature.State {
 
     func isQuarterSelectedForPicker(_ quarter: Int) -> Bool {
         quarterStartForPicker(quarter: quarter) == selectedQuarterStart
+    }
+
+    private mutating func setActivityKind(_ activityKind: ActivityKind, isSelected: Bool) {
+        if isSelected {
+            selectedActivityKinds.insert(activityKind)
+        } else if 1 < selectedActivityKinds.count {
+            selectedActivityKinds.remove(activityKind)
+        }
     }
 }

--- a/Application/DevLogPresentation/Sources/Profile/ProfileFeature+State.swift
+++ b/Application/DevLogPresentation/Sources/Profile/ProfileFeature+State.swift
@@ -36,16 +36,16 @@ extension ProfileFeature.State {
     }
 
     var canMoveToPreviousQuarter: Bool {
-        ProfileFeature.canMoveToQuarter(offsetMonths: -3, state: self)
+        ProfileHeatmapBuilder.canMoveToQuarter(offsetMonths: -3, state: self)
     }
 
     var canMoveToNextQuarter: Bool {
-        ProfileFeature.canMoveToQuarter(offsetMonths: 3, state: self)
+        ProfileHeatmapBuilder.canMoveToQuarter(offsetMonths: 3, state: self)
     }
 
     var isViewingCurrentQuarter: Bool {
         guard let selectedQuarterStart,
-              let currentQuarterStart = ProfileFeature.quarterStart(for: Date()) else {
+              let currentQuarterStart = ProfileHeatmapBuilder.quarterStart(for: Date()) else {
             return false
         }
         return selectedQuarterStart == currentQuarterStart
@@ -53,7 +53,7 @@ extension ProfileFeature.State {
 
     var availableQuarterYears: [Int] {
         guard let earliestQuarterStart,
-              let currentQuarterStart = ProfileFeature.quarterStart(for: Date()) else {
+              let currentQuarterStart = ProfileHeatmapBuilder.quarterStart(for: Date()) else {
             return [selectedQuarterPickerYear]
         }
         let earliestYear = Calendar.current.component(.year, from: earliestQuarterStart)
@@ -62,12 +62,12 @@ extension ProfileFeature.State {
     }
 
     func quarterStartForPicker(quarter: Int) -> Date? {
-        ProfileFeature.quarterStart(year: selectedQuarterPickerYear, quarter: quarter)
+        ProfileHeatmapBuilder.quarterStart(year: selectedQuarterPickerYear, quarter: quarter)
     }
 
     func isQuarterSelectableForPicker(_ quarter: Int) -> Bool {
         guard let quarterStart = quarterStartForPicker(quarter: quarter) else { return false }
-        return ProfileFeature.canSelectQuarter(quarterStart, state: self)
+        return ProfileHeatmapBuilder.canSelectQuarter(quarterStart, state: self)
     }
 
     func isQuarterSelectedForPicker(_ quarter: Int) -> Bool {

--- a/Application/DevLogPresentation/Sources/Profile/ProfileFeature+State.swift
+++ b/Application/DevLogPresentation/Sources/Profile/ProfileFeature+State.swift
@@ -1,0 +1,76 @@
+//
+//  ProfileFeature+State.swift
+//  DevLogPresentation
+//
+//  Created by opfic on 6/15/26.
+//
+
+import DevLogCore
+import Foundation
+
+extension ProfileFeature.State {
+    var isLoading: Bool {
+        loading.isLoading
+    }
+
+    var quarterTitle: String {
+        guard let start = selectedQuarterStart else { return "" }
+        let year = Calendar.current.component(.year, from: start)
+        let month = Calendar.current.component(.month, from: start)
+        let quarter = ((month - 1) / 3) + 1
+        return String.localizedStringWithFormat(
+            String(localized: "profile_year_quarter_format"),
+            String(year),
+            String(quarter)
+        )
+    }
+
+    var selectedDayActivities: [HeatmapActivityItem] {
+        guard let selectedDay else { return [] }
+        let dayStart = Calendar.current.startOfDay(for: selectedDay.date)
+        let activities = dayActivitiesByDate[dayStart] ?? []
+
+        return activities.filter { activity in
+            !Set(activity.activityKinds).isDisjoint(with: selectedActivityKinds)
+        }
+    }
+
+    var canMoveToPreviousQuarter: Bool {
+        ProfileFeature.canMoveToQuarter(offsetMonths: -3, state: self)
+    }
+
+    var canMoveToNextQuarter: Bool {
+        ProfileFeature.canMoveToQuarter(offsetMonths: 3, state: self)
+    }
+
+    var isViewingCurrentQuarter: Bool {
+        guard let selectedQuarterStart,
+              let currentQuarterStart = ProfileFeature.quarterStart(for: Date()) else {
+            return false
+        }
+        return selectedQuarterStart == currentQuarterStart
+    }
+
+    var availableQuarterYears: [Int] {
+        guard let earliestQuarterStart,
+              let currentQuarterStart = ProfileFeature.quarterStart(for: Date()) else {
+            return [selectedQuarterPickerYear]
+        }
+        let earliestYear = Calendar.current.component(.year, from: earliestQuarterStart)
+        let currentYear = Calendar.current.component(.year, from: currentQuarterStart)
+        return Array(stride(from: currentYear, through: earliestYear, by: -1))
+    }
+
+    func quarterStartForPicker(quarter: Int) -> Date? {
+        ProfileFeature.quarterStart(year: selectedQuarterPickerYear, quarter: quarter)
+    }
+
+    func isQuarterSelectableForPicker(_ quarter: Int) -> Bool {
+        guard let quarterStart = quarterStartForPicker(quarter: quarter) else { return false }
+        return ProfileFeature.canSelectQuarter(quarterStart, state: self)
+    }
+
+    func isQuarterSelectedForPicker(_ quarter: Int) -> Bool {
+        quarterStartForPicker(quarter: quarter) == selectedQuarterStart
+    }
+}

--- a/Application/DevLogPresentation/Sources/Profile/ProfileFeature.swift
+++ b/Application/DevLogPresentation/Sources/Profile/ProfileFeature.swift
@@ -1,0 +1,303 @@
+//
+//  ProfileFeature.swift
+//  DevLogPresentation
+//
+//  Created by opfic on 6/15/26.
+//
+
+import Combine
+import ComposableArchitecture
+import DevLogCore
+import DevLogDomain
+import Foundation
+
+@Reducer
+struct ProfileFeature {
+    private enum CancelID: Hashable {
+        case networkConnectivity
+    }
+
+    @ObservableState
+    struct State: Equatable {
+        @Presents var alert: AlertState<Never>?
+        var name = ""
+        var email = ""
+        var isNetworkConnected = true
+        var statusMessage = ""
+        var avatarURL: URL?
+        var avatarImageData: ProfileAvatarImageData?
+        var earliestQuarterStart: Date?
+        var selectedQuarterStart: Date?
+        var showQuarterPicker = false
+        var selectedQuarterPickerYear = Calendar.current.component(.year, from: Date())
+        var activityQuarter: HeatmapQuarter?
+        var dayActivitiesByDate: [Date: [HeatmapActivityItem]] = [:]
+        var selectedActivityKinds: Set<ActivityKind> = [.created, .completed, .deleted]
+        var selectedDay: HeatmapDay?
+        var showDoneButton = false
+        var loading = LoadingFeature.State()
+    }
+
+    enum Action: BindableAction {
+        case alert(PresentationAction<Never>)
+        case binding(BindingAction<State>)
+        case startObserving
+        case fetchData
+        case refresh
+        case networkStatusChanged(Bool)
+        case setAlert(Bool)
+        case tapResetStatusMessageButton
+        case willUpdateStatusMessage
+        case setQuarterPickerPresented(Bool)
+        case openQuarterPicker
+        case selectQuarter(Date)
+        case moveToCurrentQuarter
+        case moveQuarter(Int)
+        case toggleActivityKind(ActivityKind)
+        case selectDay(HeatmapDay?)
+        case updateStatusTextFieldFocus(Bool)
+        case store(StoreAction)
+        case loading(LoadingFeature.Action)
+
+        enum StoreAction {
+            case fetchUserData(UserProfile)
+            case setAvatarImageData(URL, Data)
+            case setActivityQuarter(
+                quarterStart: Date,
+                quarter: HeatmapQuarter,
+                dayActivitiesByDate: [Date: [HeatmapActivityItem]]
+            )
+        }
+    }
+
+    @Dependency(\.profileFetchUserDataUseCase) var fetchUserDataUseCase
+    @Dependency(\.profileFetchImageDataUseCase) var fetchProfileImageDataUseCase
+    @Dependency(\.profileFetchTodosUseCase) var fetchTodosUseCase
+    @Dependency(\.profileUpsertStatusMessageUseCase) var upsertStatusMessageUseCase
+    @Dependency(\.networkConnectivityUseCase) var networkConnectivityUseCase
+    @Dependency(\.profileFetchHeatmapActivityTypesUseCase) var fetchHeatmapActivityTypesUseCase
+    @Dependency(\.profileUpdateHeatmapActivityTypesUseCase) var updateHeatmapActivityTypesUseCase
+
+    var body: some ReducerOf<Self> {
+        Scope(state: \.loading, action: \.loading) {
+            LoadingFeature()
+        }
+        BindingReducer()
+        Reduce { state, action in
+            switch action {
+            case .alert(.dismiss):
+                state.alert = nil
+            case .alert:
+                break
+            case .binding:
+                break
+            case .startObserving:
+                return observeNetworkConnectivityEffect()
+            case .fetchData, .refresh:
+                if state.selectedQuarterStart == nil,
+                   let quarterStart = Self.quarterStart(for: Date()) {
+                    state.selectedQuarterStart = quarterStart
+                }
+                let rawValues = fetchHeatmapActivityTypesUseCase.execute()
+                let settings = Self.normalizeActivityKinds(rawValues)
+                if !settings.isEmpty {
+                    state.selectedActivityKinds = settings
+                }
+                if let selectedQuarterStart = state.selectedQuarterStart {
+                    return .merge(
+                        fetchUserDataEffect(),
+                        fetchActivityQuarterEffect(selectedQuarterStart)
+                    )
+                }
+                return fetchUserDataEffect()
+            case .networkStatusChanged(let isConnected):
+                state.isNetworkConnected = isConnected
+            case .setAlert(let isPresented):
+                state.alert = isPresented ? Self.alertState() : nil
+            case .tapResetStatusMessageButton:
+                state.statusMessage = ""
+            case .willUpdateStatusMessage:
+                if !state.isNetworkConnected { break }
+                return updateStatusMessageEffect(state.statusMessage)
+            case .setQuarterPickerPresented(let isPresented):
+                state.showQuarterPicker = isPresented
+            case .openQuarterPicker:
+                if let selectedQuarterStart = state.selectedQuarterStart {
+                    state.selectedQuarterPickerYear = Calendar.current.component(.year, from: selectedQuarterStart)
+                }
+                state.showQuarterPicker = true
+            case .selectQuarter(let quarterStart):
+                guard Self.canSelectQuarter(quarterStart, state: state) else { break }
+                state.showQuarterPicker = false
+                return updateSelectedQuarter(to: quarterStart, state: &state)
+            case .moveToCurrentQuarter:
+                guard let currentQuarterStart = Self.quarterStart(for: Date()),
+                      state.selectedQuarterStart != currentQuarterStart else { break }
+                return updateSelectedQuarter(to: currentQuarterStart, state: &state)
+            case .moveQuarter(let delta):
+                guard let selectedQuarterStart = state.selectedQuarterStart else { break }
+                let monthDelta = 3 * delta
+                guard let nextQuarterStart = Calendar.current.date(
+                    byAdding: .month,
+                    value: monthDelta,
+                    to: selectedQuarterStart
+                ) else { break }
+                guard Self.canSelectQuarter(nextQuarterStart, state: state) else { break }
+                return updateSelectedQuarter(to: nextQuarterStart, state: &state)
+            case .toggleActivityKind(let activityKind):
+                if state.selectedActivityKinds.contains(activityKind),
+                   state.selectedActivityKinds.count == 1 {
+                    break
+                }
+
+                if state.selectedActivityKinds.contains(activityKind) {
+                    state.selectedActivityKinds.remove(activityKind)
+                } else {
+                    state.selectedActivityKinds.insert(activityKind)
+                }
+                return updateHeatmapActivityKindsEffect(state.selectedActivityKinds)
+            case .selectDay(let day):
+                if let day, state.selectedDay?.date == day.date {
+                    state.selectedDay = nil
+                } else {
+                    state.selectedDay = day
+                }
+            case .updateStatusTextFieldFocus(let focused):
+                state.showDoneButton = focused
+            case .store(.fetchUserData(let profile)):
+                let previousAvatarURL = state.avatarURL
+                state.name = profile.name
+                state.email = profile.email
+                state.statusMessage = profile.statusMessage
+                state.avatarURL = profile.avatarURL
+                if previousAvatarURL != profile.avatarURL {
+                    state.avatarImageData = nil
+                }
+                if state.earliestQuarterStart == nil {
+                    state.earliestQuarterStart = Self.quarterStart(for: profile.createdAt)
+                        ?? Calendar.current.startOfDay(for: profile.createdAt)
+                }
+                if let avatarURL = profile.avatarURL {
+                    return fetchAvatarImageDataEffect(avatarURL)
+                }
+            case .store(.setAvatarImageData(let url, let data)):
+                guard state.avatarURL == url else { break }
+                let id = (state.avatarImageData?.id ?? 0) + 1
+                state.avatarImageData = ProfileAvatarImageData(id: id, data: data)
+            case .store(.setActivityQuarter(let quarterStart, let quarter, let dayActivitiesByDate)):
+                guard state.selectedQuarterStart == quarterStart else { break }
+                state.activityQuarter = quarter
+                state.dayActivitiesByDate = dayActivitiesByDate
+            case .loading:
+                break
+            }
+
+            return .none
+        }
+        .ifLet(\.$alert, action: \.alert)
+    }
+}
+
+private extension ProfileFeature {
+    func observeNetworkConnectivityEffect() -> Effect<Action> {
+        .publisher { [networkConnectivityUseCase] in
+            networkConnectivityUseCase.observe()
+                .receive(on: DispatchQueue.main)
+                .map(Action.networkStatusChanged)
+        }
+        .cancellable(id: CancelID.networkConnectivity, cancelInFlight: true)
+    }
+
+    func fetchUserDataEffect() -> Effect<Action> {
+        .run { [fetchUserDataUseCase] send in
+            do {
+                let profile = try await fetchUserDataUseCase.execute()
+                await send(.store(.fetchUserData(profile)))
+            } catch {
+                await send(.setAlert(true))
+            }
+        }
+    }
+
+    func fetchAvatarImageDataEffect(_ url: URL) -> Effect<Action> {
+        .run { [fetchProfileImageDataUseCase] send in
+            do {
+                let data = try await fetchProfileImageDataUseCase.execute(from: url)
+                await send(.store(.setAvatarImageData(url, data)))
+            } catch { }
+        }
+    }
+
+    func fetchActivityQuarterEffect(_ quarterStart: Date) -> Effect<Action> {
+        .run { [fetchTodosUseCase] send in
+            await send(.loading(.begin(target: .default, mode: .delayed)))
+            do {
+                let data = try await Self.fetchQuarterActivityData(
+                    from: quarterStart,
+                    fetchTodosUseCase: fetchTodosUseCase
+                )
+                await send(
+                    .store(
+                        .setActivityQuarter(
+                            quarterStart: quarterStart,
+                            quarter: data.quarter,
+                            dayActivitiesByDate: data.dayActivitiesByDate
+                        )
+                    )
+                )
+                await send(.loading(.end(target: .default, mode: .delayed)))
+            } catch {
+                await send(.loading(.end(target: .default, mode: .delayed)))
+                await send(.setAlert(true))
+            }
+        }
+    }
+
+    func updateStatusMessageEffect(_ message: String) -> Effect<Action> {
+        .run { [upsertStatusMessageUseCase] send in
+            do {
+                try await upsertStatusMessageUseCase.execute(message)
+            } catch {
+                await send(.setAlert(true))
+            }
+        }
+    }
+
+    func updateHeatmapActivityKindsEffect(_ activityKinds: Set<ActivityKind>) -> Effect<Action> {
+        .run { [updateHeatmapActivityTypesUseCase] _ in
+            let rawValues = ActivityKindItem.selectableItems
+                .map(\.rawValue)
+                .filter { rawValue in
+                    guard let activityKind = ActivityKind(rawValue: rawValue) else {
+                        return false
+                    }
+                    return activityKinds.contains(activityKind)
+                }
+            updateHeatmapActivityTypesUseCase.execute(rawValues)
+        }
+    }
+
+    func updateSelectedQuarter(
+        to quarterStart: Date,
+        state: inout State
+    ) -> Effect<Action> {
+        guard state.selectedQuarterStart != quarterStart else { return .none }
+        state.selectedQuarterStart = quarterStart
+        state.activityQuarter = nil
+        state.dayActivitiesByDate = [:]
+        state.selectedDay = nil
+        return fetchActivityQuarterEffect(quarterStart)
+    }
+
+    static func alertState() -> AlertState<Never> {
+        AlertState {
+            TextState("")
+        } actions: {
+            ButtonState(role: .cancel) {
+                TextState(String(localized: "common_close"))
+            }
+        } message: {
+            TextState(String(localized: "common_error_message"))
+        }
+    }
+}

--- a/Application/DevLogPresentation/Sources/Profile/ProfileFeature.swift
+++ b/Application/DevLogPresentation/Sources/Profile/ProfileFeature.swift
@@ -53,7 +53,6 @@ struct ProfileFeature {
         case selectQuarter(Date)
         case moveToCurrentQuarter
         case moveQuarter(Int)
-        case toggleActivityKind(ActivityKind)
         case selectDay(HeatmapDay?)
         case updateStatusTextFieldFocus(Bool)
         case store(StoreAction)
@@ -89,6 +88,12 @@ struct ProfileFeature {
                 state.alert = nil
             case .alert:
                 break
+            case .binding(\.isCreatedActivitySelected):
+                return updateHeatmapActivityKindsEffectIfNeeded(.created, state: state)
+            case .binding(\.isCompletedActivitySelected):
+                return updateHeatmapActivityKindsEffectIfNeeded(.completed, state: state)
+            case .binding(\.isDeletedActivitySelected):
+                return updateHeatmapActivityKindsEffectIfNeeded(.deleted, state: state)
             case .binding:
                 break
             case .startObserving:
@@ -144,18 +149,6 @@ struct ProfileFeature {
                 ) else { break }
                 guard ProfileHeatmapBuilder.canSelectQuarter(nextQuarterStart, state: state) else { break }
                 return updateSelectedQuarter(to: nextQuarterStart, state: &state)
-            case .toggleActivityKind(let activityKind):
-                if state.selectedActivityKinds.contains(activityKind),
-                   state.selectedActivityKinds.count == 1 {
-                    break
-                }
-
-                if state.selectedActivityKinds.contains(activityKind) {
-                    state.selectedActivityKinds.remove(activityKind)
-                } else {
-                    state.selectedActivityKinds.insert(activityKind)
-                }
-                return updateHeatmapActivityKindsEffect(state.selectedActivityKinds)
             case .selectDay(let day):
                 if let day, state.selectedDay?.date == day.date {
                     state.selectedDay = nil
@@ -275,6 +268,14 @@ private extension ProfileFeature {
                 }
             updateHeatmapActivityTypesUseCase.execute(rawValues)
         }
+    }
+
+    func updateHeatmapActivityKindsEffectIfNeeded(
+        _ activityKind: ActivityKind,
+        state: State
+    ) -> Effect<Action> {
+        guard state.selectedActivityKinds != [activityKind] else { return .none }
+        return updateHeatmapActivityKindsEffect(state.selectedActivityKinds)
     }
 
     func updateSelectedQuarter(

--- a/Application/DevLogPresentation/Sources/Profile/ProfileFeature.swift
+++ b/Application/DevLogPresentation/Sources/Profile/ProfileFeature.swift
@@ -95,11 +95,11 @@ struct ProfileFeature {
                 return observeNetworkConnectivityEffect()
             case .fetchData, .refresh:
                 if state.selectedQuarterStart == nil,
-                   let quarterStart = Self.quarterStart(for: Date()) {
+                   let quarterStart = ProfileHeatmapBuilder.quarterStart(for: Date()) {
                     state.selectedQuarterStart = quarterStart
                 }
                 let rawValues = fetchHeatmapActivityTypesUseCase.execute()
-                let settings = Self.normalizeActivityKinds(rawValues)
+                let settings = ProfileHeatmapBuilder.normalizeActivityKinds(rawValues)
                 if !settings.isEmpty {
                     state.selectedActivityKinds = settings
                 }
@@ -127,11 +127,11 @@ struct ProfileFeature {
                 }
                 state.showQuarterPicker = true
             case .selectQuarter(let quarterStart):
-                guard Self.canSelectQuarter(quarterStart, state: state) else { break }
+                guard ProfileHeatmapBuilder.canSelectQuarter(quarterStart, state: state) else { break }
                 state.showQuarterPicker = false
                 return updateSelectedQuarter(to: quarterStart, state: &state)
             case .moveToCurrentQuarter:
-                guard let currentQuarterStart = Self.quarterStart(for: Date()),
+                guard let currentQuarterStart = ProfileHeatmapBuilder.quarterStart(for: Date()),
                       state.selectedQuarterStart != currentQuarterStart else { break }
                 return updateSelectedQuarter(to: currentQuarterStart, state: &state)
             case .moveQuarter(let delta):
@@ -142,7 +142,7 @@ struct ProfileFeature {
                     value: monthDelta,
                     to: selectedQuarterStart
                 ) else { break }
-                guard Self.canSelectQuarter(nextQuarterStart, state: state) else { break }
+                guard ProfileHeatmapBuilder.canSelectQuarter(nextQuarterStart, state: state) else { break }
                 return updateSelectedQuarter(to: nextQuarterStart, state: &state)
             case .toggleActivityKind(let activityKind):
                 if state.selectedActivityKinds.contains(activityKind),
@@ -174,7 +174,7 @@ struct ProfileFeature {
                     state.avatarImageData = nil
                 }
                 if state.earliestQuarterStart == nil {
-                    state.earliestQuarterStart = Self.quarterStart(for: profile.createdAt)
+                    state.earliestQuarterStart = ProfileHeatmapBuilder.quarterStart(for: profile.createdAt)
                         ?? Calendar.current.startOfDay(for: profile.createdAt)
                 }
                 if let avatarURL = profile.avatarURL {
@@ -232,7 +232,7 @@ private extension ProfileFeature {
         .run { [fetchTodosUseCase] send in
             await send(.loading(.begin(target: .default, mode: .delayed)))
             do {
-                let data = try await Self.fetchQuarterActivityData(
+                let data = try await ProfileHeatmapBuilder.fetchQuarterActivityData(
                     from: quarterStart,
                     fetchTodosUseCase: fetchTodosUseCase
                 )

--- a/Application/DevLogPresentation/Sources/Profile/ProfileHeatmapBuilder.swift
+++ b/Application/DevLogPresentation/Sources/Profile/ProfileHeatmapBuilder.swift
@@ -1,5 +1,5 @@
 //
-//  ProfileFeature+Heatmap.swift
+//  ProfileHeatmapBuilder.swift
 //  DevLogPresentation
 //
 //  Created by opfic on 6/15/26.
@@ -31,7 +31,7 @@ private struct ProfileHeatmapActivityEntry {
     var activityKinds: Set<ActivityKind>
 }
 
-extension ProfileFeature {
+enum ProfileHeatmapBuilder {
     static func quarterStart(for date: Date) -> Date? {
         let month = Calendar.current.component(.month, from: date)
         let startMonth = ((month - 1) / 3) * 3 + 1
@@ -50,9 +50,9 @@ extension ProfileFeature {
         return Calendar.current.date(from: components)
     }
 
-    static func canSelectQuarter(_ quarterStart: Date, state: State) -> Bool {
+    static func canSelectQuarter(_ quarterStart: Date, state: ProfileFeature.State) -> Bool {
         guard let earliestQuarterStart = state.earliestQuarterStart,
-              let currentQuarterStart = self.quarterStart(for: Date()) else { return false }
+              let currentQuarterStart = Self.quarterStart(for: Date()) else { return false }
         return earliestQuarterStart <= quarterStart && quarterStart <= currentQuarterStart
     }
 
@@ -66,7 +66,7 @@ extension ProfileFeature {
         )
     }
 
-    static func canMoveToQuarter(offsetMonths: Int, state: State) -> Bool {
+    static func canMoveToQuarter(offsetMonths: Int, state: ProfileFeature.State) -> Bool {
         guard let selectedQuarterStart = state.selectedQuarterStart else { return false }
         guard let targetQuarterStart = Calendar.current.date(
             byAdding: .month,

--- a/Application/DevLogPresentation/Sources/Profile/ProfileView.swift
+++ b/Application/DevLogPresentation/Sources/Profile/ProfileView.swift
@@ -5,14 +5,26 @@
 //  Created by opfic on 5/7/25.
 //
 
+// swiftlint:disable file_length
 import SwiftUI
+import ComposableArchitecture
 import DevLogCore
 import DevLogDomain
 
 struct ProfileView: View {
+    @Bindable var store: StoreOf<ProfileFeature>
+    @FocusState private var focused: Bool
     let coordinator: ProfileViewCoordinator
     let isCompactLayout: Bool
-    @FocusState private var focused: Bool
+
+    init(
+        coordinator: ProfileViewCoordinator,
+        isCompactLayout: Bool
+    ) {
+        self.store = coordinator.store
+        self.coordinator = coordinator
+        self.isCompactLayout = isCompactLayout
+    }
 
     var body: some View {
         Group {
@@ -29,118 +41,212 @@ struct ProfileView: View {
         }
         .onChange(of: focused) { _, newValue in
             withAnimation {
-                coordinator.viewModel.send(.updateStatusTextFieldFocus(newValue))
+                _ = store.send(.updateStatusTextFieldFocus(newValue))
             }
         }
-        .alert(
-            "",
-            isPresented: Binding(
-                get: { coordinator.viewModel.state.showAlert },
-                set: { coordinator.viewModel.send(.setAlert($0)) }
-            )
-        ) {
-            Button(String(localized: "common_close"), role: .cancel) { }
-        } message: {
-            Text(coordinator.viewModel.state.alertMessage)
-        }
-        .sheet(
-            isPresented: Binding(
-                get: { coordinator.viewModel.state.showQuarterPicker },
-                set: { coordinator.viewModel.send(.setQuarterPickerPresented($0)) }
-            )
-        ) {
+        .alert($store.scope(state: \.alert, action: \.alert))
+        .sheet(isPresented: $store.showQuarterPicker) {
             quarterPickerSheet
+        }
+        .overlay {
+            if store.isLoading {
+                LoadingView()
+            }
         }
     }
 
     private var profileContentView: some View {
         ScrollView {
             LazyVStack(alignment: .leading, spacing: 16) {
-                HStack {
-                    profileAvatarImage
-                    .frame(width: 60, height: 60)
-                    .cornerRadius(30)
-                    .foregroundStyle(Color.gray)
-
-                    VStack(alignment: .leading) {
-                        Text(coordinator.viewModel.state.name)
-                            .font(.title2)
-                            .bold()
-                        Text(coordinator.viewModel.state.email)
-                            .font(.caption2)
-                            .foregroundStyle(Color.gray)
-                    }
-                }
-                let connected = coordinator.viewModel.state.isNetworkConnected
-                HStack {
-                    HStack {
-                        Image(systemName: "face.smiling")
-                        TextField(
-                            text: Binding(
-                                get: { coordinator.viewModel.state.statusMessage },
-                                set: { coordinator.viewModel.send(.updateStatusMessage($0)) }
-                            )
-                        ) {
-                            Text(String(localized: "profile_status_placeholder"))
-                        }
-                        .frame(height: UIFont.preferredFont(forTextStyle: .body).lineHeight)
-                        .focused($focused)
-                        .disabled(!connected)
-
-                        if !coordinator.viewModel.state.statusMessage.isEmpty,
-                           coordinator.viewModel.state.showDoneButton {
-                            Button(action: {
-                                coordinator.viewModel.send(.tapResetStatusMessageButton)
-                            }) {
-                                Image(systemName: "xmark.circle.fill")
-                            }
-                            .transition(.move(edge: .trailing).combined(with: .opacity))
-                        }
-                    }
-                    .foregroundStyle(Color.gray)
-                    .padding(8)
-                    .background(
-                        RoundedRectangle(cornerRadius: 10)
-                            .fill(Color(.secondarySystemGroupedBackground))
-                    )
-                    if coordinator.viewModel.state.showDoneButton {
-                        Button(action: {
-                            focused = false
-                            coordinator.viewModel.send(.willUpdateStatusMessage)
-                        }) {
-                            Text(String(localized: "profile_done"))
-                        }
-                        .transition(.move(edge: .trailing).combined(with: .opacity))
-                    }
-                }
-                .opacity(connected ? 1 : 0.7)
+                profileHeader
+                statusMessageSection
                 activityHeatmapSection
             }
             .padding(.horizontal, 16)
         }
-        .refreshable { coordinator.viewModel.send(.refresh) }
+        .refreshable { store.send(.refresh) }
         .frame(maxWidth: .infinity)
         .background(Color(.systemGroupedBackground))
-        .toolbar { profileToolbarContent }
+        .toolbar { toolbar }
     }
 
-    @ViewBuilder
-    private var profileAvatarImage: some View {
-        if let data = coordinator.viewModel.state.avatarImageData?.data,
-           let uiImage = UIImage(data: data) {
-            Image(uiImage: uiImage)
-                .resizable()
-                .scaledToFill()
-        } else {
-            Image(systemName: "person.crop.circle.fill")
-                .resizable()
-                .scaledToFill()
-                .foregroundStyle(Color(.systemGray2))
+    private var profileHeader: some View {
+        HStack {
+            Group {
+                if let data = store.avatarImageData?.data,
+                   let uiImage = UIImage(data: data) {
+                    Image(uiImage: uiImage)
+                        .resizable()
+                        .scaledToFill()
+                } else {
+                    Image(systemName: "person.crop.circle.fill")
+                        .resizable()
+                        .scaledToFill()
+                        .foregroundStyle(Color(.systemGray2))
+                }
+            }
+            .frame(width: 60, height: 60)
+            .cornerRadius(30)
+
+            VStack(alignment: .leading) {
+                Text(store.name)
+                    .font(.title2)
+                    .bold()
+                Text(store.email)
+                    .font(.caption2)
+                    .foregroundStyle(Color.gray)
+            }
         }
     }
 
+    private var statusMessageSection: some View {
+        let connected = store.isNetworkConnected
+
+        return HStack {
+            HStack {
+                Image(systemName: "face.smiling")
+                TextField(
+                    text: $store.statusMessage
+                ) {
+                    Text(String(localized: "profile_status_placeholder"))
+                }
+                .frame(height: UIFont.preferredFont(forTextStyle: .body).lineHeight)
+                .focused($focused)
+                .disabled(!connected)
+
+                if !store.statusMessage.isEmpty,
+                   store.showDoneButton {
+                    Button(action: {
+                        store.send(.tapResetStatusMessageButton)
+                    }) {
+                        Image(systemName: "xmark.circle.fill")
+                    }
+                    .transition(.move(edge: .trailing).combined(with: .opacity))
+                }
+            }
+            .foregroundStyle(Color.gray)
+            .padding(8)
+            .background(
+                RoundedRectangle(cornerRadius: 10)
+                    .fill(Color(.secondarySystemGroupedBackground))
+            )
+            if store.showDoneButton {
+                Button(action: {
+                    focused = false
+                    store.send(.willUpdateStatusMessage)
+                }) {
+                    Text(String(localized: "profile_done"))
+                }
+                .transition(.move(edge: .trailing).combined(with: .opacity))
+            }
+        }
+        .opacity(connected ? 1 : 0.7)
+    }
+
+    private var activityHeatmapSection: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack {
+                Text(String(localized: "profile_quarterly_activity"))
+                    .font(.headline)
+                Spacer()
+                if !store.isViewingCurrentQuarter {
+                    Button {
+                        store.send(.moveToCurrentQuarter)
+                    } label: {
+                        Image(systemName: "arrow.uturn.backward")
+                            .bold()
+                            .foregroundStyle(.blue)
+                    }
+                    .buttonStyle(.plain)
+                }
+                Menu {
+                    ForEach(ActivityKindItem.selectableItems) { activityKindItem in
+                        Toggle(
+                            activityKindItem.title,
+                            isOn: Binding(
+                                get: {
+                                    guard let activityKind = ActivityKind(
+                                        rawValue: activityKindItem.rawValue
+                                    ) else {
+                                        return false
+                                    }
+                                    return store.selectedActivityKinds.contains(activityKind)
+                                },
+                                set: { _ in
+                                    guard let activityKind = ActivityKind(
+                                        rawValue: activityKindItem.rawValue
+                                    ) else {
+                                        return
+                                    }
+                                    store.send(.toggleActivityKind(activityKind))
+                                }
+                            )
+                        )
+                        .disabled({
+                            guard let activityKind = ActivityKind(rawValue: activityKindItem.rawValue) else {
+                                return false
+                            }
+                            return store.selectedActivityKinds.count == 1
+                                && store.selectedActivityKinds.contains(activityKind)
+                        }())
+                    }
+                } label: {
+                    Image(systemName: "line.3.horizontal.decrease")
+                        .bold()
+                        .foregroundStyle(.blue)
+                }
+            }
+
+            HStack {
+                Button {
+                    store.send(.moveQuarter(-1))
+                } label: {
+                    Image(systemName: "chevron.left")
+                }
+                .disabled(!store.canMoveToPreviousQuarter)
+                Spacer()
+                Button {
+                    store.send(.openQuarterPicker)
+                } label: {
+                    HStack(spacing: 4) {
+                        Text(store.quarterTitle)
+                            .font(.subheadline)
+                        Image(systemName: "chevron.up.chevron.down")
+                            .font(.caption2)
+                    }
+                    .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+                Spacer()
+                Button {
+                    store.send(.moveQuarter(1))
+                } label: {
+                    Image(systemName: "chevron.right")
+                }
+                .disabled(!store.canMoveToNextQuarter)
+            }
+
+            if let quarter = store.activityQuarter {
+                HeatmapView(
+                    quarter: quarter,
+                    selectedActivityKinds: store.selectedActivityKinds,
+                    selectedDay: store.selectedDay,
+                    onSelectDay: { store.send(.selectDay($0)) }
+                )
+                if let selectedDay = store.selectedDay {
+                    selectedDayDetailSection(for: selectedDay)
+                }
+            }
+        }
+        .padding(12)
+        .background(
+            RoundedRectangle(cornerRadius: 14)
+                .fill(Color(.secondarySystemGroupedBackground))
+        )
+    }
+
     @ToolbarContentBuilder
-    private var profileToolbarContent: some ToolbarContent {
+    private var toolbar: some ToolbarContent {
         ToolbarItem(placement: .topBarTrailing) {
             Button {
                 if isCompactLayout {
@@ -172,122 +278,6 @@ struct ProfileView: View {
         }
     }
 
-    private var activityHeatmapSection: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            HStack {
-                Text(String(localized: "profile_quarterly_activity"))
-                    .font(.headline)
-                Spacer()
-                quarterResetButton
-                activityTypeSelector
-            }
-
-            quarterNavigator
-
-            if let quarter = coordinator.viewModel.state.activityQuarter {
-                HeatmapView(
-                    quarter: quarter,
-                    selectedActivityKinds: coordinator.viewModel.state.selectedActivityKinds,
-                    selectedDay: coordinator.viewModel.state.selectedDay,
-                    onSelectDay: { coordinator.viewModel.send(.selectDay($0)) }
-                )
-                if let selectedDay = coordinator.viewModel.state.selectedDay {
-                    selectedDayDetailSection(for: selectedDay)
-                        .overlay {
-                            if coordinator.viewModel.state.isLoading {
-                                LoadingView()
-                            }
-                        }
-                }
-            }
-        }
-        .padding(12)
-        .background(
-            RoundedRectangle(cornerRadius: 14)
-                .fill(Color(.secondarySystemGroupedBackground))
-        )
-    }
-
-    @ViewBuilder
-    private var quarterResetButton: some View {
-        if !coordinator.viewModel.isViewingCurrentQuarter {
-            Button {
-                coordinator.viewModel.send(.moveToCurrentQuarter)
-            } label: {
-                Image(systemName: "arrow.uturn.backward")
-                    .bold()
-                    .foregroundStyle(.blue)
-            }
-            .buttonStyle(.plain)
-        }
-    }
-
-    private var activityTypeSelector: some View {
-        Menu {
-            ForEach(ActivityKindItem.selectableItems) { activityKindItem in
-                Toggle(
-                    activityKindItem.title,
-                    isOn: Binding(
-                        get: {
-                            guard let activityKind = ActivityKind(rawValue: activityKindItem.rawValue) else {
-                                return false
-                            }
-                            return coordinator.viewModel.state.selectedActivityKinds.contains(activityKind)
-                        },
-                        set: { _ in
-                            guard let activityKind = ActivityKind(rawValue: activityKindItem.rawValue) else {
-                                return
-                            }
-                            coordinator.viewModel.send(.toggleActivityKind(activityKind))
-                        }
-                    )
-                )
-                .disabled({
-                    guard let activityKind = ActivityKind(rawValue: activityKindItem.rawValue) else {
-                        return false
-                    }
-                    return coordinator.viewModel.state.selectedActivityKinds.count == 1
-                        && coordinator.viewModel.state.selectedActivityKinds.contains(activityKind)
-                }())
-            }
-        } label: {
-            Image(systemName: "line.3.horizontal.decrease")
-                .bold()
-                .foregroundStyle(.blue)
-        }
-    }
-
-    private var quarterNavigator: some View {
-        HStack {
-            Button {
-                coordinator.viewModel.send(.moveQuarter(-1))
-            } label: {
-                Image(systemName: "chevron.left")
-            }
-            .disabled(!coordinator.viewModel.canMoveToPreviousQuarter)
-            Spacer()
-            Button {
-                coordinator.viewModel.send(.openQuarterPicker)
-            } label: {
-                HStack(spacing: 4) {
-                    Text(coordinator.viewModel.quarterTitle)
-                        .font(.subheadline)
-                    Image(systemName: "chevron.up.chevron.down")
-                        .font(.caption2)
-                }
-                .foregroundStyle(.secondary)
-            }
-            .buttonStyle(.plain)
-            Spacer()
-            Button {
-                coordinator.viewModel.send(.moveQuarter(1))
-            } label: {
-                Image(systemName: "chevron.right")
-            }
-            .disabled(!coordinator.viewModel.canMoveToNextQuarter)
-        }
-    }
-
     private var quarterPickerSheet: some View {
         NavigationStack {
             VStack(alignment: .leading, spacing: 20) {
@@ -298,12 +288,9 @@ struct ProfileView: View {
                     Spacer()
                     Picker(
                         "",
-                        selection: Binding(
-                            get: { coordinator.viewModel.state.selectedQuarterPickerYear },
-                            set: { coordinator.viewModel.send(.setQuarterPickerYear($0)) }
-                        )
+                        selection: $store.selectedQuarterPickerYear
                     ) {
-                        ForEach(coordinator.viewModel.availableQuarterYears, id: \.self) { year in
+                        ForEach(store.availableQuarterYears, id: \.self) { year in
                             Text(verbatim: String(year))
                                 .tag(year)
                         }
@@ -325,7 +312,7 @@ struct ProfileView: View {
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarTrailingButton {
-                    coordinator.viewModel.send(.setQuarterPickerPresented(false))
+                    store.send(.setQuarterPickerPresented(false))
                 }
             }
         }
@@ -335,13 +322,13 @@ struct ProfileView: View {
 
     @ViewBuilder
     private func quarterSelectionButton(for quarter: Int) -> some View {
-        let quarterStart = coordinator.viewModel.quarterStartForPicker(quarter: quarter)
-        let isEnabled = coordinator.viewModel.isQuarterSelectableForPicker(quarter)
-        let isSelected = coordinator.viewModel.isQuarterSelectedForPicker(quarter)
+        let quarterStart = store.state.quarterStartForPicker(quarter: quarter)
+        let isEnabled = store.state.isQuarterSelectableForPicker(quarter)
+        let isSelected = store.state.isQuarterSelectedForPicker(quarter)
 
         Button {
             guard let quarterStart else { return }
-            coordinator.viewModel.send(.selectQuarter(quarterStart))
+            store.send(.selectQuarter(quarterStart))
         } label: {
             Text(
                 String.localizedStringWithFormat(
@@ -364,7 +351,7 @@ struct ProfileView: View {
 
     @ViewBuilder
     private func selectedDayDetailSection(for day: HeatmapDay) -> some View {
-        let activities = coordinator.viewModel.selectedDayActivities
+        let activities = store.selectedDayActivities
 
         VStack(alignment: .leading, spacing: 12) {
             Text(day.date.formatted(.dateTime.year().month(.wide).day()))
@@ -380,13 +367,7 @@ struct ProfileView: View {
             } else {
                 ForEach(activities) { activity in
                     Button {
-                        if !activity.isDeleted {
-                            if isCompactLayout {
-                                coordinator.router.push(.activity(activity.todoId))
-                            } else {
-                                coordinator.router.replace(with: .activity(activity.todoId))
-                            }
-                        }
+                        selectActivity(activity)
                     } label: {
                         let item = TodoCategoryItem(from: activity.category)
                         let rowColor = activity.isDeleted ? Color.secondary : .primary
@@ -401,15 +382,15 @@ struct ProfileView: View {
                             Text("#\(activity.number)")
                                 .font(.caption)
                                 .foregroundStyle(.secondary)
-                            ForEach(activity.activityKindItems) { activityKindItem in
-                                Text(activityKindItem.title)
+                            ForEach(activity.activityKindItems) { item in
+                                Text(item.title)
                                     .font(.caption2)
-                                    .foregroundStyle(activityKindItem.badgeColor)
+                                    .foregroundStyle(item.badgeColor)
                                     .padding(.horizontal, 6)
                                     .padding(.vertical, 2)
                                     .background(
                                         Capsule()
-                                            .fill(activityKindItem.badgeColor.opacity(0.14))
+                                            .fill(item.badgeColor.opacity(0.14))
                                     )
                             }
                             Spacer()
@@ -435,6 +416,16 @@ struct ProfileView: View {
             get: { coordinator.router.path },
             set: { coordinator.router.path = $0 }
         )
+    }
+
+    private func selectActivity(_ activity: HeatmapActivityItem) {
+        guard !activity.isDeleted else { return }
+
+        if isCompactLayout {
+            coordinator.router.push(.activity(activity.todoId))
+        } else {
+            coordinator.router.replace(with: .activity(activity.todoId))
+        }
     }
 }
 

--- a/Application/DevLogPresentation/Sources/Profile/ProfileView.swift
+++ b/Application/DevLogPresentation/Sources/Profile/ProfileView.swift
@@ -157,34 +157,19 @@ struct ProfileView: View {
                 }
                 Menu {
                     ForEach(ActivityKindItem.selectableItems) { activityKindItem in
-                        Toggle(
-                            activityKindItem.title,
-                            isOn: Binding(
-                                get: {
-                                    guard let activityKind = ActivityKind(
-                                        rawValue: activityKindItem.rawValue
-                                    ) else {
-                                        return false
-                                    }
-                                    return store.selectedActivityKinds.contains(activityKind)
-                                },
-                                set: { _ in
-                                    guard let activityKind = ActivityKind(
-                                        rawValue: activityKindItem.rawValue
-                                    ) else {
-                                        return
-                                    }
-                                    store.send(.toggleActivityKind(activityKind))
-                                }
-                            )
-                        )
-                        .disabled({
-                            guard let activityKind = ActivityKind(rawValue: activityKindItem.rawValue) else {
-                                return false
+                        if let activityKind = ActivityKind(rawValue: activityKindItem.rawValue) {
+                            switch activityKind {
+                            case .created:
+                                Toggle(activityKindItem.title, isOn: $store.isCreatedActivitySelected)
+                                    .disabled(store.isCreatedActivityToggleDisabled)
+                            case .completed:
+                                Toggle(activityKindItem.title, isOn: $store.isCompletedActivitySelected)
+                                    .disabled(store.isCompletedActivityToggleDisabled)
+                            case .deleted:
+                                Toggle(activityKindItem.title, isOn: $store.isDeletedActivitySelected)
+                                    .disabled(store.isDeletedActivityToggleDisabled)
                             }
-                            return store.selectedActivityKinds.count == 1
-                                && store.selectedActivityKinds.contains(activityKind)
-                        }())
+                        }
                     }
                 } label: {
                     Image(systemName: "line.3.horizontal.decrease")

--- a/Application/DevLogPresentation/Sources/Profile/ProfileView.swift
+++ b/Application/DevLogPresentation/Sources/Profile/ProfileView.swift
@@ -60,7 +60,7 @@ struct ProfileView: View {
             }
             .padding(.horizontal, 16)
         }
-        .refreshable { store.send(.refresh) }
+        .refreshable { await store.send(.refresh).finish() }
         .frame(maxWidth: .infinity)
         .background(Color(.systemGroupedBackground))
         .toolbar { toolbar }

--- a/Application/DevLogPresentation/Sources/Profile/ProfileView.swift
+++ b/Application/DevLogPresentation/Sources/Profile/ProfileView.swift
@@ -83,6 +83,7 @@ struct ProfileView: View {
             }
             .frame(width: 60, height: 60)
             .cornerRadius(30)
+            .transaction { $0.animation = nil }
 
             VStack(alignment: .leading) {
                 Text(store.name)

--- a/Application/DevLogPresentation/Sources/Profile/ProfileView.swift
+++ b/Application/DevLogPresentation/Sources/Profile/ProfileView.swift
@@ -112,9 +112,9 @@ struct ProfileView: View {
 
                 if !store.statusMessage.isEmpty,
                    store.showDoneButton {
-                    Button(action: {
+                    Button {
                         store.send(.tapResetStatusMessageButton)
-                    }) {
+                    } label: {
                         Image(systemName: "xmark.circle.fill")
                     }
                     .transition(.move(edge: .trailing).combined(with: .opacity))
@@ -127,10 +127,10 @@ struct ProfileView: View {
                     .fill(Color(.secondarySystemGroupedBackground))
             )
             if store.showDoneButton {
-                Button(action: {
+                Button {
                     focused = false
                     store.send(.willUpdateStatusMessage)
-                }) {
+                } label: {
                     Text(String(localized: "profile_done"))
                 }
                 .transition(.move(edge: .trailing).combined(with: .opacity))

--- a/Application/DevLogPresentation/Sources/Profile/ProfileView.swift
+++ b/Application/DevLogPresentation/Sources/Profile/ProfileView.swift
@@ -43,9 +43,7 @@ struct ProfileView: View {
             store.send(.updateStatusTextFieldFocus(newValue), animation: .default)
         }
         .alert($store.scope(state: \.alert, action: \.alert))
-        .sheet(isPresented: $store.showQuarterPicker) {
-            quarterPickerSheet
-        }
+        .sheet(isPresented: $store.showQuarterPicker) { quarterPickerSheet }
         .overlay {
             if store.isLoading {
                 LoadingView()

--- a/Application/DevLogPresentation/Sources/Profile/ProfileView.swift
+++ b/Application/DevLogPresentation/Sources/Profile/ProfileView.swift
@@ -40,9 +40,7 @@ struct ProfileView: View {
             }
         }
         .onChange(of: focused) { _, newValue in
-            withAnimation {
-                _ = store.send(.updateStatusTextFieldFocus(newValue))
-            }
+            store.send(.updateStatusTextFieldFocus(newValue), animation: .default)
         }
         .alert($store.scope(state: \.alert, action: \.alert))
         .sheet(isPresented: $store.showQuarterPicker) {

--- a/Application/DevLogPresentation/Sources/Profile/ProfileViewCoordinator.swift
+++ b/Application/DevLogPresentation/Sources/Profile/ProfileViewCoordinator.swift
@@ -13,22 +13,24 @@ import DevLogDomain
 @MainActor
 @Observable
 final class ProfileViewCoordinator {
-    let viewModel: ProfileViewModel
+    let store: StoreOf<ProfileFeature>
     let settingsStore: StoreOf<SettingsFeature>
     var router = NavigationRouter<ProfileRoute>()
     private let container: DIContainer
 
     init(container: DIContainer) {
         self.container = container
-        self.viewModel = ProfileViewModel(
-            fetchUserDataUseCase: container.resolve(FetchUserDataUseCase.self),
-            fetchProfileImageDataUseCase: container.resolve(FetchProfileImageDataUseCase.self),
-            fetchTodosUseCase: container.resolve(FetchTodosUseCase.self),
-            upsertStatusMessageUseCase: container.resolve(UpsertStatusMessageUseCase.self),
-            networkConnectivityUseCase: container.resolve(ObserveNetworkConnectivityUseCase.self),
-            fetchHeatmapActivityTypesUseCase: container.resolve(FetchHeatmapActivityTypesUseCase.self),
-            updateHeatmapActivityTypesUseCase: container.resolve(UpdateHeatmapActivityTypesUseCase.self)
-        )
+        self.store = Store(initialState: ProfileFeature.State()) {
+            ProfileFeature()
+        } withDependencies: {
+            $0.profileFetchUserDataUseCase = container.resolve(FetchUserDataUseCase.self)
+            $0.profileFetchImageDataUseCase = container.resolve(FetchProfileImageDataUseCase.self)
+            $0.profileFetchTodosUseCase = container.resolve(FetchTodosUseCase.self)
+            $0.profileUpsertStatusMessageUseCase = container.resolve(UpsertStatusMessageUseCase.self)
+            $0.networkConnectivityUseCase = container.resolve(ObserveNetworkConnectivityUseCase.self)
+            $0.profileFetchHeatmapActivityTypesUseCase = container.resolve(FetchHeatmapActivityTypesUseCase.self)
+            $0.profileUpdateHeatmapActivityTypesUseCase = container.resolve(UpdateHeatmapActivityTypesUseCase.self)
+        }
         self.settingsStore = Store(initialState: SettingsFeature.State()) {
             SettingsFeature()
         } withDependencies: {
@@ -40,11 +42,12 @@ final class ProfileViewCoordinator {
             $0.fetchWebPageImageDirSizeUseCase = container.resolve(FetchWebPageImageDirSizeUseCase.self)
             $0.clearWebPageImageDirectoryUseCase = container.resolve(ClearWebPageImageDirectoryUseCase.self)
         }
+        self.store.send(.startObserving)
         self.settingsStore.send(.startObserving)
     }
 
     func fetchData() {
-        viewModel.send(.fetchData)
+        store.send(.fetchData)
     }
 
     func makeAccountStore() -> StoreOf<AccountFeature> {

--- a/Application/DevLogPresentation/Tests/Profile/ProfileViewModelTests.swift
+++ b/Application/DevLogPresentation/Tests/Profile/ProfileViewModelTests.swift
@@ -207,7 +207,20 @@ private struct ProfileStoreTestAdapter {
     }
 
     func toggleActivityKind(_ activityKind: ActivityKind) async {
-        await store.send(.toggleActivityKind(activityKind))
+        switch activityKind {
+        case .created:
+            await store.send(.binding(.set(\.isCreatedActivitySelected, !store.state.isCreatedActivitySelected))) {
+                $0.isCreatedActivitySelected.toggle()
+            }
+        case .completed:
+            await store.send(.binding(.set(\.isCompletedActivitySelected, !store.state.isCompletedActivitySelected))) {
+                $0.isCompletedActivitySelected.toggle()
+            }
+        case .deleted:
+            await store.send(.binding(.set(\.isDeletedActivitySelected, !store.state.isDeletedActivitySelected))) {
+                $0.isDeletedActivitySelected.toggle()
+            }
+        }
         await drainReceivedActions()
     }
 

--- a/Application/DevLogPresentation/Tests/Profile/ProfileViewModelTests.swift
+++ b/Application/DevLogPresentation/Tests/Profile/ProfileViewModelTests.swift
@@ -6,7 +6,9 @@
 //
 
 import Testing
+import ComposableArchitecture
 import Foundation
+import DevLogCore
 import DevLogDomain
 @testable import DevLogPresentation
 
@@ -39,11 +41,94 @@ struct ProfileViewModelTests {
         #expect(spy.calledURLs == [avatarURL, avatarURL])
         #expect(viewModel.state.avatarImageData?.data == imageData)
     }
+
+    @Test("ProfileFeature는 같은 아바타 URL을 다시 받아도 프로필 이미지 데이터를 다시 요청한다")
+    func ProfileFeature는_같은_아바타_URL을_다시_받아도_프로필_이미지_데이터를_다시_요청한다() async {
+        let imageData = Data([1, 2, 3])
+        let spy = FetchProfileImageDataUseCaseSpy(data: imageData)
+        let adapter = ProfileStoreTestAdapter(fetchProfileImageDataUseCase: spy)
+        let avatarURL = URL(string: "https://example.com/avatar.png")!
+        let profile = UserProfile(
+            name: "opfic",
+            email: "opfic@example.com",
+            statusMessage: "status",
+            avatarURL: avatarURL,
+            createdAt: Date(timeIntervalSince1970: 0)
+        )
+
+        await adapter.fetchUserData(profile)
+        await adapter.fetchUserData(profile)
+
+        #expect(spy.calledURLs == [avatarURL, avatarURL])
+        #expect(adapter.avatarImageData?.data == imageData)
+    }
+
+    @Test("현재 ProfileViewModel은 연결 상태일 때 상태 메시지 저장을 요청한다")
+    func 현재_ProfileViewModel은_연결_상태일_때_상태_메시지_저장을_요청한다() async {
+        let spy = UpsertStatusMessageUseCaseSpy()
+        let viewModel = makeProfileViewModel(upsertStatusMessageUseCase: spy)
+
+        viewModel.send(.updateStatusMessage("working"))
+        viewModel.send(.willUpdateStatusMessage)
+        await waitUntil {
+            spy.messages == ["working"]
+        }
+
+        #expect(spy.messages == ["working"])
+    }
+
+    @Test("ProfileFeature는 연결 상태일 때 현재 ProfileViewModel처럼 상태 메시지 저장을 요청한다")
+    func ProfileFeature는_연결_상태일_때_현재_ProfileViewModel처럼_상태_메시지_저장을_요청한다() async {
+        let spy = UpsertStatusMessageUseCaseSpy()
+        let adapter = ProfileStoreTestAdapter(upsertStatusMessageUseCase: spy)
+
+        await adapter.updateStatusMessage("working")
+        await adapter.willUpdateStatusMessage()
+
+        #expect(spy.messages == ["working"])
+    }
+
+    @Test("현재 ProfileViewModel은 마지막 활동 종류를 해제하지 않는다")
+    func 현재_ProfileViewModel은_마지막_활동_종류를_해제하지_않는다() {
+        let spy = UpdateHeatmapActivityTypesUseCaseSpy()
+        let fetchSpy = FetchHeatmapActivityTypesUseCaseSpy()
+        fetchSpy.activityTypes = ["created"]
+        let viewModel = makeProfileViewModel(
+            fetchHeatmapActivityTypesUseCase: fetchSpy,
+            updateHeatmapActivityTypesUseCase: spy
+        )
+
+        viewModel.send(.fetchData)
+        viewModel.send(.toggleActivityKind(.created))
+
+        #expect(viewModel.state.selectedActivityKinds == [.created])
+        #expect(spy.activityTypes.isEmpty)
+    }
+
+    @Test("ProfileFeature는 현재 ProfileViewModel처럼 마지막 활동 종류를 해제하지 않는다")
+    func ProfileFeature는_현재_ProfileViewModel처럼_마지막_활동_종류를_해제하지_않는다() async {
+        let spy = UpdateHeatmapActivityTypesUseCaseSpy()
+        let fetchSpy = FetchHeatmapActivityTypesUseCaseSpy()
+        fetchSpy.activityTypes = ["created"]
+        let adapter = ProfileStoreTestAdapter(
+            fetchHeatmapActivityTypesUseCase: fetchSpy,
+            updateHeatmapActivityTypesUseCase: spy
+        )
+
+        await adapter.fetchData()
+        await adapter.toggleActivityKind(.created)
+
+        #expect(adapter.selectedActivityKinds == [.created])
+        #expect(spy.activityTypes.isEmpty)
+    }
 }
 
 @MainActor
 private func makeProfileViewModel(
-    fetchProfileImageDataUseCase: FetchProfileImageDataUseCase
+    fetchProfileImageDataUseCase: FetchProfileImageDataUseCase = FetchProfileImageDataUseCaseSpy(data: Data()),
+    upsertStatusMessageUseCase: UpsertStatusMessageUseCase = UpsertStatusMessageUseCaseSpy(),
+    fetchHeatmapActivityTypesUseCase: FetchHeatmapActivityTypesUseCase = FetchHeatmapActivityTypesUseCaseSpy(),
+    updateHeatmapActivityTypesUseCase: UpdateHeatmapActivityTypesUseCase = UpdateHeatmapActivityTypesUseCaseSpy()
 ) -> ProfileViewModel {
     ProfileViewModel(
         fetchUserDataUseCase: FetchUserDataUseCaseSpy(
@@ -57,9 +142,78 @@ private func makeProfileViewModel(
         ),
         fetchProfileImageDataUseCase: fetchProfileImageDataUseCase,
         fetchTodosUseCase: FetchTodosUseCaseSpy(),
-        upsertStatusMessageUseCase: UpsertStatusMessageUseCaseSpy(),
+        upsertStatusMessageUseCase: upsertStatusMessageUseCase,
         networkConnectivityUseCase: ObserveNetworkConnectivityUseCaseSpy(),
-        fetchHeatmapActivityTypesUseCase: FetchHeatmapActivityTypesUseCaseSpy(),
-        updateHeatmapActivityTypesUseCase: UpdateHeatmapActivityTypesUseCaseSpy()
+        fetchHeatmapActivityTypesUseCase: fetchHeatmapActivityTypesUseCase,
+        updateHeatmapActivityTypesUseCase: updateHeatmapActivityTypesUseCase
     )
+}
+
+@MainActor
+private struct ProfileStoreTestAdapter {
+    private let store: TestStoreOf<ProfileFeature>
+
+    var avatarImageData: ProfileAvatarImageData? { store.state.avatarImageData }
+    var selectedActivityKinds: Set<ActivityKind> { store.state.selectedActivityKinds }
+
+    init(
+        fetchProfileImageDataUseCase: FetchProfileImageDataUseCase = FetchProfileImageDataUseCaseSpy(data: Data()),
+        upsertStatusMessageUseCase: UpsertStatusMessageUseCase = UpsertStatusMessageUseCaseSpy(),
+        fetchHeatmapActivityTypesUseCase: FetchHeatmapActivityTypesUseCase = FetchHeatmapActivityTypesUseCaseSpy(),
+        updateHeatmapActivityTypesUseCase: UpdateHeatmapActivityTypesUseCase = UpdateHeatmapActivityTypesUseCaseSpy()
+    ) {
+        store = TestStore(initialState: ProfileFeature.State()) {
+            ProfileFeature()
+        } withDependencies: {
+            $0.profileFetchUserDataUseCase = FetchUserDataUseCaseSpy(
+                profile: UserProfile(
+                    name: "opfic",
+                    email: "opfic@example.com",
+                    statusMessage: "",
+                    avatarURL: nil,
+                    createdAt: Date(timeIntervalSince1970: 0)
+                )
+            )
+            $0.profileFetchImageDataUseCase = fetchProfileImageDataUseCase
+            $0.profileFetchTodosUseCase = FetchTodosUseCaseSpy()
+            $0.profileUpsertStatusMessageUseCase = upsertStatusMessageUseCase
+            $0.networkConnectivityUseCase = ObserveNetworkConnectivityUseCaseSpy()
+            $0.profileFetchHeatmapActivityTypesUseCase = fetchHeatmapActivityTypesUseCase
+            $0.profileUpdateHeatmapActivityTypesUseCase = updateHeatmapActivityTypesUseCase
+            $0.continuousClock = ImmediateClock()
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+    }
+
+    func fetchData() async {
+        await store.send(.fetchData)
+        await drainReceivedActions()
+    }
+
+    func fetchUserData(_ profile: UserProfile) async {
+        await store.send(.store(.fetchUserData(profile)))
+        await drainReceivedActions()
+    }
+
+    func updateStatusMessage(_ message: String) async {
+        await store.send(.binding(.set(\.statusMessage, message))) {
+            $0.statusMessage = message
+        }
+    }
+
+    func willUpdateStatusMessage() async {
+        await store.send(.willUpdateStatusMessage)
+        await drainReceivedActions()
+    }
+
+    func toggleActivityKind(_ activityKind: ActivityKind) async {
+        await store.send(.toggleActivityKind(activityKind))
+        await drainReceivedActions()
+    }
+
+    private func drainReceivedActions() async {
+        for _ in 0..<10 {
+            await store.skipReceivedActions(strict: false)
+        }
+    }
 }


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #580

## 🎯 의도
ProfileView의 기존 ViewModel 상태 변화를 유지하면서 TCA 기반 Store 구조로 전환

## 📝 작업 내용

### 📌 요약
- ProfileFeature 추가 및 ProfileView에 StoreOf<ProfileFeature> 적용
- 기존 ProfileViewModel과 동일한 상태 변화를 검증하는 TestStore 기반 테스트 추가
- 히트맵 데이터 구성 로직을 ProfileHeatmapBuilder로 분리
- ProfileView의 activity Toggle을 BindingAction 경로로 정리
- TextField focus animation 적용 중 프로필 이미지가 깜빡이는 문제 수정

### 🔍 상세
- ProfileFeature에 프로필 정보 조회, 상태 메시지 저장, 분기별 히트맵 조회, activity filter 상태 처리 추가
- ProfileFeature+Dependencies로 Profile 전용 use case dependency key 분리
- ProfileFeature+State로 View 표시용 computed state 분리
- ProfileHeatmapBuilder에서 quarter 계산, activity type 정규화, heatmap data 구성 처리
- ProfileViewCoordinator가 ProfileFeature Store를 생성하고 ProfileView에 주입하도록 변경
- Toggle의 isOn에서 수동 Binding(get:set:) 제거 후 $store 기반 BindingAction 사용
- focus 변경 시 TCA send animation API를 사용하되, 프로필 이미지 영역은 animation transaction에서 제외
- ProfileViewModelTests에 ProfileFeature parity 검증 추가

## 📸 영상 / 이미지 (Optional)
없음