### PR TITLE
[#615] TestFlight에서 dSYM 보존 및 Crashlytics 업로드를 자동화한다

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -116,6 +116,32 @@ jobs:
       - name: Build for TestFlight
         run: bundle exec fastlane testflight_build_only
 
+      - name: Upload dSYM to Firebase Crashlytics
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          google_service_info_path="Application/DevLogApp/Sources/Resource/GoogleService-Info.plist"
+          dsym_zip_path="$(find fastlane/testflight_build -maxdepth 1 -name '*.dSYM.zip' -print -quit)"
+          upload_symbols_path="$(find "$HOME/Library/Developer/Xcode/DerivedData" "$HOME/Library/Developer/Xcode/SourcePackages" "$GITHUB_WORKSPACE" -path '*/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/upload-symbols' -type f -print -quit 2>/dev/null || true)"
+
+          if [ ! -f "$google_service_info_path" ]; then
+            echo "Missing GoogleService-Info.plist at $google_service_info_path" >&2
+            exit 1
+          fi
+
+          if [ -z "$dsym_zip_path" ]; then
+            echo "Missing dSYM zip in fastlane/testflight_build" >&2
+            exit 1
+          fi
+
+          if [ -z "$upload_symbols_path" ]; then
+            echo "Missing Firebase Crashlytics upload-symbols script" >&2
+            exit 1
+          fi
+
+          "$upload_symbols_path" -gsp "$google_service_info_path" -p ios "$dsym_zip_path"
+
       - name: Upload TestFlight build log
         if: always()
         uses: actions/upload-artifact@v6

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -91,6 +91,8 @@ jobs:
           cache: true
 
       - name: Install SwiftLint
+        env:
+          HOMEBREW_REQUIRE_TAP_TRUST: "1"
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -122,6 +122,14 @@ jobs:
           path: ~/Library/Logs/gym/*.log
           if-no-files-found: ignore
 
+      - name: Upload TestFlight dSYM
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: testflight-dsym
+          path: fastlane/testflight_build/*.dSYM.zip
+          if-no-files-found: warn
+
       - name: Skip TestFlight Upload
         if: (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'qa-local')) || (github.event_name == 'workflow_dispatch' && inputs.upload_to_app_store_connect != 'true')
         run: echo "Skipping TestFlight upload"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -131,8 +131,14 @@ platform :ios do
       export_method: "app-store",
       output_directory: TESTFLIGHT_BUILD_OUTPUT_DIRECTORY,
       output_name: "#{APP_PRODUCT_NAME}.ipa",
+      include_symbols: true,
       xcargs: "-skipPackagePluginValidation -skipMacroValidation"
     )
+
+    dsym_output_path = lane_context[SharedValues::DSYM_OUTPUT_PATH].to_s
+    archive_path = lane_context[SharedValues::XCODEBUILD_ARCHIVE].to_s
+    UI.message("dSYM output path: #{dsym_output_path}") if !dsym_output_path.empty?
+    UI.message("Xcode archive path: #{archive_path}") if !archive_path.empty?
 
     next api_key
   end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -135,10 +135,10 @@ platform :ios do
       xcargs: "-skipPackagePluginValidation -skipMacroValidation"
     )
 
-    dsym_output_path = lane_context[SharedValues::DSYM_OUTPUT_PATH].to_s
-    archive_path = lane_context[SharedValues::XCODEBUILD_ARCHIVE].to_s
-    UI.message("dSYM output path: #{dsym_output_path}") if !dsym_output_path.empty?
-    UI.message("Xcode archive path: #{archive_path}") if !archive_path.empty?
+    dsym_output_path = lane_context[SharedValues::DSYM_OUTPUT_PATH]
+    archive_path = lane_context[SharedValues::XCODEBUILD_ARCHIVE]
+    UI.message("dSYM output path: #{dsym_output_path}") unless dsym_output_path.to_s.empty?
+    UI.message("Xcode archive path: #{archive_path}") unless archive_path.to_s.empty?
 
     next api_key
   end


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #615

## 🎯 의도

- TestFlight CD에서 생성된 dSYM이 GitHub Actions runner 종료와 함께 유실되면서 Crashlytics에서 누락 dSYM을 복구 불가
- dSYM 산출물을 artifact로 보존하고 Firebase Crashlytics에 자동 업로드해 TestFlight 배포 이후의 심볼 누락을 방지

## 📝 작업 내용

### 📌 요약

- TestFlight CD에서 dSYM zip 생성
- 생성된 dSYM zip을 GitHub Actions artifact로 보존
- TestFlight 빌드 직후 Firebase Crashlytics `upload-symbols`로 dSYM을 자동 업로드
- Homebrew tap trust 전환 경고에 대응

### 🔍 상세

- `fastlane build_app`에 `include_symbols: true`를 추가해 dSYM zip 생성
- `DSYM_OUTPUT_PATH`, `XCODEBUILD_ARCHIVE`를 fastlane 로그에 출력해 CD 산출물 추적 가능
- `testflight.yml`에서 `fastlane/testflight_build/*.dSYM.zip`을 `testflight-dsym` artifact로 업로드
- `GoogleService-Info.plist`, dSYM zip, Firebase SDK의 `Crashlytics/upload-symbols` 경로를 검증한 뒤 dSYM을 Firebase에 업로드
- `Install SwiftLint` 단계에 `HOMEBREW_REQUIRE_TAP_TRUST=1`을 적용해 Homebrew tap trust 경고를 제거

## 📸 영상 / 이미지 (Optional)
