### PR TITLE
[#[599] Firebase Crashlytics를 붙인다

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,8 @@ jobs:
           cache: true
 
       - name: Install SwiftLint
+        env:
+          HOMEBREW_REQUIRE_TAP_TRUST: "1"
         shell: bash
         run: |
           set -euo pipefail
@@ -264,6 +266,8 @@ jobs:
           cache: true
 
       - name: Install SwiftLint
+        env:
+          HOMEBREW_REQUIRE_TAP_TRUST: "1"
         shell: bash
         run: |
           set -euo pipefail

--- a/Application/DevLogApp/Project.swift
+++ b/Application/DevLogApp/Project.swift
@@ -29,6 +29,7 @@ let project = Project(
                     sourcePath: "Sources",
                     configPath: "Sources/.swiftlint.yml"
                 ),
+                DevLogScripts.firebaseCrashlyticsDSYMUpload(),
             ],
             dependencies: [
                 .project(target: "DevLogPresentation", path: "../DevLogPresentation"),

--- a/Application/DevLogApp/Project.swift
+++ b/Application/DevLogApp/Project.swift
@@ -47,6 +47,7 @@ let project = Project(
                 base: [
                     "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
                     "CODE_SIGN_STYLE": "Automatic",
+                    "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
                     "ENABLE_USER_SCRIPT_SANDBOXING": "NO",
                     "PRODUCT_MODULE_NAME": "DevLogApp",
                 ],

--- a/Application/DevLogApp/Project.swift
+++ b/Application/DevLogApp/Project.swift
@@ -53,9 +53,11 @@ let project = Project(
                 ],
                 debug: [
                     "APS_ENVIRONMENT": "development",
+                    "INFOPLIST_KEY_FirebaseCrashlyticsCollectionEnabled": "NO",
                 ],
                 release: [
                     "APS_ENVIRONMENT": "production",
+                    "INFOPLIST_KEY_FirebaseCrashlyticsCollectionEnabled": "YES",
                 ]
             )
         ),

--- a/Application/DevLogApp/Project.swift
+++ b/Application/DevLogApp/Project.swift
@@ -29,7 +29,6 @@ let project = Project(
                     sourcePath: "Sources",
                     configPath: "Sources/.swiftlint.yml"
                 ),
-                DevLogScripts.firebaseCrashlyticsDSYMUpload(),
             ],
             dependencies: [
                 .project(target: "DevLogPresentation", path: "../DevLogPresentation"),

--- a/Application/DevLogApp/Project.swift
+++ b/Application/DevLogApp/Project.swift
@@ -47,16 +47,17 @@ let project = Project(
                 base: [
                     "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
                     "CODE_SIGN_STYLE": "Automatic",
-                    "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
                     "ENABLE_USER_SCRIPT_SANDBOXING": "NO",
                     "PRODUCT_MODULE_NAME": "DevLogApp",
                 ],
                 debug: [
                     "APS_ENVIRONMENT": "development",
+                    "DEBUG_INFORMATION_FORMAT": "dwarf",
                     "INFOPLIST_KEY_FirebaseCrashlyticsCollectionEnabled": "NO",
                 ],
                 release: [
                     "APS_ENVIRONMENT": "production",
+                    "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
                     "INFOPLIST_KEY_FirebaseCrashlyticsCollectionEnabled": "YES",
                 ]
             )

--- a/Application/DevLogInfra/Sources/Common/FirebaseCrashlyticsHelper.swift
+++ b/Application/DevLogInfra/Sources/Common/FirebaseCrashlyticsHelper.swift
@@ -1,0 +1,59 @@
+//
+//  FirebaseCrashlyticsHelper.swift
+//  DevLogInfra
+//
+//  Created by opfic on 6/16/26.
+//
+
+import FirebaseCrashlytics
+import Foundation
+
+enum FirebaseCrashlyticsHelper {
+    static func record(
+        _ error: Error,
+        domain: String,
+        code: Int,
+        metadata: [String: String] = [:],
+        logs: [String] = []
+    ) {
+        let nsError = error as NSError
+        let report = NSError(
+            domain: domain,
+            code: code,
+            userInfo: userInfo(for: nsError, error: error, metadata: metadata)
+        )
+        let crashlytics = Crashlytics.crashlytics()
+
+        logs.forEach {
+            crashlytics.log($0)
+        }
+
+        crashlytics.record(error: report)
+    }
+}
+
+private extension FirebaseCrashlyticsHelper {
+    enum Key: String {
+        case underlyingType
+        case underlyingDomain
+        case underlyingCode
+    }
+
+    static func userInfo(
+        for nsError: NSError,
+        error: Error,
+        metadata: [String: String]
+    ) -> [String: Any] {
+        var userInfo: [String: Any] = [
+            Key.underlyingType.rawValue: String(describing: type(of: error)),
+            Key.underlyingDomain.rawValue: nsError.domain,
+            Key.underlyingCode.rawValue: nsError.code
+        ]
+
+        metadata.forEach {
+            userInfo[$0.key] = $0.value
+        }
+
+        return userInfo
+    }
+}

--- a/Application/DevLogInfra/Sources/Common/FirebaseCrashlyticsHelper.swift
+++ b/Application/DevLogInfra/Sources/Common/FirebaseCrashlyticsHelper.swift
@@ -45,6 +45,7 @@ private extension FirebaseCrashlyticsHelper {
         metadata: [String: String]
     ) -> [String: Any] {
         var userInfo: [String: Any] = [
+            NSUnderlyingErrorKey: nsError,
             Key.underlyingType.rawValue: String(describing: type(of: error)),
             Key.underlyingDomain.rawValue: nsError.domain,
             Key.underlyingCode.rawValue: nsError.code

--- a/Application/DevLogInfra/Sources/Service/AuthServiceImpl.swift
+++ b/Application/DevLogInfra/Sources/Service/AuthServiceImpl.swift
@@ -13,6 +13,17 @@ import DevLogCore
 import DevLogData
 
 final class AuthServiceImpl: AuthService {
+    private enum CrashlyticsError {
+        static let domain = "DevLogInfra.AuthServiceImpl"
+
+        enum Code: Int {
+            case getProviderID = 1
+            case deleteCurrentUser
+            case deleteMessagingToken
+            case signOut
+        }
+    }
+
     private let store = Firestore.firestore()
     private let messaging = Messaging.messaging()
     private let logger = Logger(category: "AuthServiceImpl")
@@ -87,6 +98,7 @@ final class AuthServiceImpl: AuthService {
             return providerID
         } catch {
             logger.error("Failed to fetch provider ID", error: error)
+            record(error, code: .getProviderID)
             throw error
         }
     }
@@ -103,6 +115,7 @@ final class AuthServiceImpl: AuthService {
             try await currentUser.delete()
         } catch {
             logger.error("Failed to delete FirebaseAuth current user", error: error)
+            record(error, code: .deleteCurrentUser)
             throw error
         }
     }
@@ -114,12 +127,14 @@ final class AuthServiceImpl: AuthService {
             try await messaging.deleteToken()
         } catch {
             logger.error("Failed to delete FCM token while clearing session", error: error)
+            record(error, code: .deleteMessagingToken)
         }
 
         do {
             try Auth.auth().signOut()
         } catch {
             logger.error("Failed to sign out while clearing session", error: error)
+            record(error, code: .signOut)
             throw error
         }
     }
@@ -127,6 +142,18 @@ final class AuthServiceImpl: AuthService {
 }
 
 private extension AuthServiceImpl {
+    private static func record(_ error: Error, code: CrashlyticsError.Code) {
+        FirebaseCrashlyticsHelper.record(
+            error,
+            domain: CrashlyticsError.domain,
+            code: code.rawValue
+        )
+    }
+
+    private func record(_ error: Error, code: CrashlyticsError.Code) {
+        Self.record(error, code: code)
+    }
+
     func handleAuthStateChange(_ user: User?) {
         let signedIn = user != nil
         logger.info("Firebase auth state changed. signedIn: \(signedIn)")

--- a/Application/DevLogInfra/Sources/Service/AuthServiceImpl.swift
+++ b/Application/DevLogInfra/Sources/Service/AuthServiceImpl.swift
@@ -145,7 +145,7 @@ private extension AuthServiceImpl {
     private static func record(_ error: Error, code: CrashlyticsError.Code) {
         FirebaseCrashlyticsHelper.record(
             error,
-            domain: CrashlyticsError.domain,
+            domain: "\(CrashlyticsError.domain).\(code)",
             code: code.rawValue
         )
     }

--- a/Application/DevLogInfra/Sources/Service/FirebaseAppServiceImpl.swift
+++ b/Application/DevLogInfra/Sources/Service/FirebaseAppServiceImpl.swift
@@ -16,15 +16,15 @@ final class FirebaseAppServiceImpl: FirebaseAppService {
         guard !Self.isConfigured else { return }
 
         FirebaseApp.configure()
-        configureCrashlyticsCollection()
+        enableCrashlyticsCollectionIfNeeded()
         Self.isConfigured = true
     }
 }
 
 private extension FirebaseAppServiceImpl {
-    func configureCrashlyticsCollection() {
-        #if DEBUG
-        Crashlytics.crashlytics().setCrashlyticsCollectionEnabled(false)
+    func enableCrashlyticsCollectionIfNeeded() {
+        #if !DEBUG
+        Crashlytics.crashlytics().setCrashlyticsCollectionEnabled(true)
         #endif
     }
 }

--- a/Application/DevLogInfra/Sources/Service/FirebaseAppServiceImpl.swift
+++ b/Application/DevLogInfra/Sources/Service/FirebaseAppServiceImpl.swift
@@ -6,6 +6,7 @@
 //
 
 import DevLogData
+import FirebaseCrashlytics
 import FirebaseCore
 
 final class FirebaseAppServiceImpl: FirebaseAppService {
@@ -15,6 +16,15 @@ final class FirebaseAppServiceImpl: FirebaseAppService {
         guard !Self.isConfigured else { return }
 
         FirebaseApp.configure()
+        configureCrashlyticsCollection()
         Self.isConfigured = true
+    }
+}
+
+private extension FirebaseAppServiceImpl {
+    func configureCrashlyticsCollection() {
+        #if DEBUG
+        Crashlytics.crashlytics().setCrashlyticsCollectionEnabled(false)
+        #endif
     }
 }

--- a/Application/DevLogInfra/Sources/Service/ProfileImageDataServiceImpl.swift
+++ b/Application/DevLogInfra/Sources/Service/ProfileImageDataServiceImpl.swift
@@ -32,7 +32,7 @@ final class ProfileImageDataServiceImpl: ProfileImageDataService {
         } catch {
             FirebaseCrashlyticsHelper.record(
                 error,
-                domain: CrashlyticsError.domain,
+                domain: "\(CrashlyticsError.domain).\(CrashlyticsError.Code.fetchImageData)",
                 code: CrashlyticsError.Code.fetchImageData.rawValue
             )
             throw error

--- a/Application/DevLogInfra/Sources/Service/ProfileImageDataServiceImpl.swift
+++ b/Application/DevLogInfra/Sources/Service/ProfileImageDataServiceImpl.swift
@@ -10,16 +10,33 @@ import Nexa
 import DevLogData
 
 final class ProfileImageDataServiceImpl: ProfileImageDataService {
+    private enum CrashlyticsError {
+        static let domain = "DevLogInfra.ProfileImageDataServiceImpl"
+
+        enum Code: Int {
+            case fetchImageData = 1
+        }
+    }
+
     func fetchImageData(from url: URL) async throws -> Data {
-        try await NXAPIClient(
-            configuration: NXClientConfiguration(baseURL: url)
-        )
-        .get()
-        .timeout(10)
-        .intercept(ProfileImageDataCachePolicyInterceptor())
-        .validate(.successStatusCode)
-        .raw()
-        .data
+        do {
+            return try await NXAPIClient(
+                configuration: NXClientConfiguration(baseURL: url)
+            )
+            .get()
+            .timeout(10)
+            .intercept(ProfileImageDataCachePolicyInterceptor())
+            .validate(.successStatusCode)
+            .raw()
+            .data
+        } catch {
+            FirebaseCrashlyticsHelper.record(
+                error,
+                domain: CrashlyticsError.domain,
+                code: CrashlyticsError.Code.fetchImageData.rawValue
+            )
+            throw error
+        }
     }
 }
 

--- a/Application/DevLogInfra/Sources/Service/PushMessagingServiceImpl.swift
+++ b/Application/DevLogInfra/Sources/Service/PushMessagingServiceImpl.swift
@@ -52,7 +52,7 @@ final class PushMessagingServiceImpl: NSObject, PushMessagingService {
             }
             FirebaseCrashlyticsHelper.record(
                 error,
-                domain: CrashlyticsError.domain,
+                domain: "\(CrashlyticsError.domain).\(CrashlyticsError.Code.fetchFCMToken)",
                 code: CrashlyticsError.Code.fetchFCMToken.rawValue
             )
             throw error

--- a/Application/DevLogInfra/Sources/Service/PushMessagingServiceImpl.swift
+++ b/Application/DevLogInfra/Sources/Service/PushMessagingServiceImpl.swift
@@ -11,6 +11,14 @@ import FirebaseMessaging
 import UserNotifications
 
 final class PushMessagingServiceImpl: NSObject, PushMessagingService {
+    private enum CrashlyticsError {
+        static let domain = "DevLogInfra.PushMessagingServiceImpl"
+
+        enum Code: Int {
+            case fetchFCMToken = 1
+        }
+    }
+
     private weak var delegate: PushMessagingServiceDelegate?
 
     func setDelegate(_ delegate: PushMessagingServiceDelegate?) {
@@ -42,6 +50,11 @@ final class PushMessagingServiceImpl: NSObject, PushMessagingService {
             if error.isMissingAPNSTokenForFCMToken {
                 return nil
             }
+            FirebaseCrashlyticsHelper.record(
+                error,
+                domain: CrashlyticsError.domain,
+                code: CrashlyticsError.Code.fetchFCMToken.rawValue
+            )
             throw error
         }
     }

--- a/Application/DevLogInfra/Sources/Service/PushNotificationServiceImpl.swift
+++ b/Application/DevLogInfra/Sources/Service/PushNotificationServiceImpl.swift
@@ -293,7 +293,7 @@ private extension PushNotificationServiceImpl {
     private static func record(_ error: Error, code: CrashlyticsError.Code) {
         FirebaseCrashlyticsHelper.record(
             error,
-            domain: CrashlyticsError.domain,
+            domain: "\(CrashlyticsError.domain).\(code)",
             code: code.rawValue
         )
     }

--- a/Application/DevLogInfra/Sources/Service/PushNotificationServiceImpl.swift
+++ b/Application/DevLogInfra/Sources/Service/PushNotificationServiceImpl.swift
@@ -13,6 +13,22 @@ import DevLogCore
 import DevLogData
 
 final class PushNotificationServiceImpl: PushNotificationService {
+    private enum CrashlyticsError {
+        static let domain = "DevLogInfra.PushNotificationServiceImpl"
+
+        enum Code: Int {
+            case fetchPushNotificationEnabled = 1
+            case fetchPushNotificationTime
+            case updatePushNotificationSettings
+            case requestNotifications
+            case observeNotifications
+            case observeUnreadPushCount
+            case deleteNotification
+            case undoDeleteNotification
+            case toggleNotificationRead
+        }
+    }
+
     private enum FunctionName: String {
         case requestPushNotificationDeletion
         case undoPushNotificationDeletion
@@ -44,6 +60,7 @@ final class PushNotificationServiceImpl: PushNotificationService {
             throw FirestoreError.dataNotFound("allowPushNotification")
         } catch {
             logger.error("Failed to fetch push notification status", error: error)
+            record(error, code: .fetchPushNotificationEnabled)
             throw error
         }
     }
@@ -72,6 +89,7 @@ final class PushNotificationServiceImpl: PushNotificationService {
             return DateComponents(hour: hour, minute: minute)
         } catch {
             logger.error("Failed to fetch push notification time", error: error)
+            record(error, code: .fetchPushNotificationTime)
             throw error
         }
     }
@@ -102,6 +120,7 @@ final class PushNotificationServiceImpl: PushNotificationService {
             logger.info("Successfully updated push notification settings")
         } catch {
             logger.error("Failed to update push notification settings", error: error)
+            record(error, code: .updatePushNotificationSettings)
             throw error
         }
     }
@@ -144,6 +163,7 @@ final class PushNotificationServiceImpl: PushNotificationService {
             return PushNotificationPageResponse(items: items, nextCursor: nextCursor)
         } catch {
             logger.error("Failed to request notifications", error: error)
+            record(error, code: .requestNotifications)
             throw error
         }
     }
@@ -160,6 +180,7 @@ final class PushNotificationServiceImpl: PushNotificationService {
             .limit(to: pageLimit)
             .addSnapshotListener { [weak self] snapshot, error in
                 if let error {
+                    Self.record(error, code: .observeNotifications)
                     subject.send(completion: .failure(error))
                     return
                 }
@@ -190,6 +211,7 @@ final class PushNotificationServiceImpl: PushNotificationService {
             .whereField(PushNotificationFieldKey.isDeleted.rawValue, isEqualTo: false)
             .addSnapshotListener { snapshot, error in
                 if let error {
+                    Self.record(error, code: .observeUnreadPushCount)
                     subject.send(completion: .failure(error))
                     return
                 }
@@ -213,6 +235,7 @@ final class PushNotificationServiceImpl: PushNotificationService {
             _ = try await function.call(["notificationId": notificationID])
         } catch {
             logger.error("Failed to request notification deletion", error: error)
+            record(error, code: .deleteNotification)
             throw error
         }
     }
@@ -225,6 +248,7 @@ final class PushNotificationServiceImpl: PushNotificationService {
             _ = try await function.call(["notificationId": notificationID])
         } catch {
             logger.error("Failed to undo notification deletion", error: error)
+            record(error, code: .undoDeleteNotification)
             throw error
         }
     }
@@ -259,12 +283,25 @@ final class PushNotificationServiceImpl: PushNotificationService {
             logger.info("Successfully toggled notification read")
         } catch {
             logger.error("Failed to toggle notification read", error: error)
+            record(error, code: .toggleNotificationRead)
             throw error
         }
     }
 }
 
 private extension PushNotificationServiceImpl {
+    private static func record(_ error: Error, code: CrashlyticsError.Code) {
+        FirebaseCrashlyticsHelper.record(
+            error,
+            domain: CrashlyticsError.domain,
+            code: code.rawValue
+        )
+    }
+
+    private func record(_ error: Error, code: CrashlyticsError.Code) {
+        Self.record(error, code: code)
+    }
+
     func makeQuery(
         uid: String,
         query: PushNotificationQuery

--- a/Application/DevLogInfra/Sources/Service/SocialLogin/AppleAuthenticationServiceImpl.swift
+++ b/Application/DevLogInfra/Sources/Service/SocialLogin/AppleAuthenticationServiceImpl.swift
@@ -16,6 +16,18 @@ import DevLogCore
 import DevLogData
 
 final class AppleAuthenticationServiceImpl: AuthenticationService {
+    private enum CrashlyticsError {
+        static let domain = "DevLogInfra.AppleAuthenticationServiceImpl"
+
+        enum Code: Int {
+            case signIn = 1
+            case signOut
+            case deleteAuth
+            case link
+            case unlink
+        }
+    }
+
     private enum FunctionName: String {
         case requestAppleCustomToken
         case refreshAppleAccessToken
@@ -94,6 +106,7 @@ final class AppleAuthenticationServiceImpl: AuthenticationService {
             return result.user.makeResponse(providerID: .apple)
         } catch {
             logger.error("Failed to sign in with Apple", error: error)
+            record(error, code: .signIn)
             throw error
         }
     }
@@ -112,6 +125,7 @@ final class AppleAuthenticationServiceImpl: AuthenticationService {
             try Auth.auth().signOut()
         } catch {
             logger.error("Failed to sign out with Apple", error: error)
+            record(error, code: .signOut)
             throw error
         }
     }
@@ -123,6 +137,7 @@ final class AppleAuthenticationServiceImpl: AuthenticationService {
             try await revokeAppleAccessToken(token: token)
         } catch {
             logger.error("Failed to delete Apple auth", error: error)
+            record(error, code: .deleteAuth)
             throw error
         }
     }
@@ -157,6 +172,7 @@ final class AppleAuthenticationServiceImpl: AuthenticationService {
             try await user?.link(with: appleCredential)
         } catch {
             logger.error("Failed to link Apple account", error: error)
+            record(error, code: .link)
             if error.isFirebaseCredentialAlreadyInUse {
                 throw DataLayerError.linkCredentialAlreadyInUse
             }
@@ -188,6 +204,7 @@ final class AppleAuthenticationServiceImpl: AuthenticationService {
             _ = try await user?.unlink(fromProvider: providerID.rawValue)
         } catch {
             logger.error("Failed to unlink Apple account", error: error)
+            record(error, code: .unlink)
             throw error
         }
     }
@@ -309,5 +326,19 @@ final class AppleAuthenticationServiceImpl: AuthenticationService {
         let revokeFunction = functions.httpsCallable(FunctionName.revokeAppleAccessToken)
         
         _ = try await revokeFunction.call(["token": token])
+    }
+}
+
+private extension AppleAuthenticationServiceImpl {
+    private static func record(_ error: Error, code: CrashlyticsError.Code) {
+        FirebaseCrashlyticsHelper.record(
+            error,
+            domain: CrashlyticsError.domain,
+            code: code.rawValue
+        )
+    }
+
+    private func record(_ error: Error, code: CrashlyticsError.Code) {
+        Self.record(error, code: code)
     }
 }

--- a/Application/DevLogInfra/Sources/Service/SocialLogin/AppleAuthenticationServiceImpl.swift
+++ b/Application/DevLogInfra/Sources/Service/SocialLogin/AppleAuthenticationServiceImpl.swift
@@ -333,7 +333,7 @@ private extension AppleAuthenticationServiceImpl {
     private static func record(_ error: Error, code: CrashlyticsError.Code) {
         FirebaseCrashlyticsHelper.record(
             error,
-            domain: CrashlyticsError.domain,
+            domain: "\(CrashlyticsError.domain).\(code)",
             code: code.rawValue
         )
     }

--- a/Application/DevLogInfra/Sources/Service/SocialLogin/GithubAuthenticationServiceImpl.swift
+++ b/Application/DevLogInfra/Sources/Service/SocialLogin/GithubAuthenticationServiceImpl.swift
@@ -16,6 +16,18 @@ import DevLogCore
 import DevLogData
 
 final class GithubAuthenticationServiceImpl: NSObject, AuthenticationService {
+    private enum CrashlyticsError {
+        static let domain = "DevLogInfra.GithubAuthenticationServiceImpl"
+
+        enum Code: Int {
+            case signIn = 1
+            case signOut
+            case deleteAuth
+            case link
+            case unlink
+        }
+    }
+
     private enum FunctionName: String {
         case requestGithubTokens
         case revokeGithubAccessToken
@@ -79,6 +91,7 @@ final class GithubAuthenticationServiceImpl: NSObject, AuthenticationService {
             )
         } catch {
             logger.error("Failed to sign in with GitHub", error: error)
+            record(error, code: .signIn)
             throw error
         }
     }
@@ -97,6 +110,7 @@ final class GithubAuthenticationServiceImpl: NSObject, AuthenticationService {
             try Auth.auth().signOut()
         } catch {
             logger.error("Failed to sign out with GitHub", error: error)
+            record(error, code: .signOut)
             throw error
         }
     }
@@ -106,6 +120,7 @@ final class GithubAuthenticationServiceImpl: NSObject, AuthenticationService {
             try await revokeAccessToken()
         } catch {
             logger.error("Failed to delete GitHub auth", error: error)
+            record(error, code: .deleteAuth)
             throw error
         }
     }
@@ -140,6 +155,7 @@ final class GithubAuthenticationServiceImpl: NSObject, AuthenticationService {
             logger.info("Successfully linked GitHub account")
         } catch {
             logger.error("Failed to link GitHub account", error: error)
+            record(error, code: .link)
             if error.isFirebaseCredentialAlreadyInUse {
                 throw DataLayerError.linkCredentialAlreadyInUse
             }
@@ -161,6 +177,7 @@ final class GithubAuthenticationServiceImpl: NSObject, AuthenticationService {
             _ = try await user?.unlink(fromProvider: providerID.rawValue)
         } catch {
             logger.error("Failed to unlink GitHub account", error: error)
+            record(error, code: .unlink)
             throw error
         }
     }
@@ -304,6 +321,18 @@ final class GithubAuthenticationServiceImpl: NSObject, AuthenticationService {
 }
 
 private extension GithubAuthenticationServiceImpl {
+    private static func record(_ error: Error, code: CrashlyticsError.Code) {
+        FirebaseCrashlyticsHelper.record(
+            error,
+            domain: CrashlyticsError.domain,
+            code: code.rawValue
+        )
+    }
+
+    private func record(_ error: Error, code: CrashlyticsError.Code) {
+        Self.record(error, code: code)
+    }
+
     struct GitHubUser: Codable {
         let login: String
         let name: String?

--- a/Application/DevLogInfra/Sources/Service/SocialLogin/GithubAuthenticationServiceImpl.swift
+++ b/Application/DevLogInfra/Sources/Service/SocialLogin/GithubAuthenticationServiceImpl.swift
@@ -324,7 +324,7 @@ private extension GithubAuthenticationServiceImpl {
     private static func record(_ error: Error, code: CrashlyticsError.Code) {
         FirebaseCrashlyticsHelper.record(
             error,
-            domain: CrashlyticsError.domain,
+            domain: "\(CrashlyticsError.domain).\(code)",
             code: code.rawValue
         )
     }

--- a/Application/DevLogInfra/Sources/Service/SocialLogin/GoogleAuthenticationServiceImpl.swift
+++ b/Application/DevLogInfra/Sources/Service/SocialLogin/GoogleAuthenticationServiceImpl.swift
@@ -14,6 +14,18 @@ import DevLogCore
 import DevLogData
 
 final class GoogleAuthenticationServiceImpl: AuthenticationService {
+    private enum CrashlyticsError {
+        static let domain = "DevLogInfra.GoogleAuthenticationServiceImpl"
+
+        enum Code: Int {
+            case signIn = 1
+            case signOut
+            case deleteAuth
+            case link
+            case unlink
+        }
+    }
+
     private let store = Firestore.firestore()
     private let messaging = Messaging.messaging()
     private var user: User? { Auth.auth().currentUser }
@@ -55,6 +67,7 @@ final class GoogleAuthenticationServiceImpl: AuthenticationService {
             return result.user.makeResponse(providerID: .google)
         } catch {
             logger.error("Failed to sign in with Google", error: error)
+            record(error, code: .signIn)
             throw error
         }
     }
@@ -76,6 +89,7 @@ final class GoogleAuthenticationServiceImpl: AuthenticationService {
             try Auth.auth().signOut()
         } catch {
             logger.error("Failed to sign out with Google", error: error)
+            record(error, code: .signOut)
             throw error
         }
     }
@@ -86,6 +100,7 @@ final class GoogleAuthenticationServiceImpl: AuthenticationService {
             try await GIDSignIn.sharedInstance.disconnect()
         } catch {
             logger.error("Failed to delete Google auth", error: error)
+            record(error, code: .deleteAuth)
             throw error
         }
     }
@@ -121,6 +136,7 @@ final class GoogleAuthenticationServiceImpl: AuthenticationService {
             try await user?.link(with: credential)
         } catch {
             logger.error("Failed to link Google account", error: error)
+            record(error, code: .link)
             if error.isFirebaseCredentialAlreadyInUse {
                 throw DataLayerError.linkCredentialAlreadyInUse
             }
@@ -138,8 +154,22 @@ final class GoogleAuthenticationServiceImpl: AuthenticationService {
             _ = try await user?.unlink(fromProvider: AuthProviderID.google.rawValue)
         } catch {
             logger.error("Failed to unlink Google account", error: error)
+            record(error, code: .unlink)
             throw error
         }
     }
+}
 
+private extension GoogleAuthenticationServiceImpl {
+    private static func record(_ error: Error, code: CrashlyticsError.Code) {
+        FirebaseCrashlyticsHelper.record(
+            error,
+            domain: CrashlyticsError.domain,
+            code: code.rawValue
+        )
+    }
+
+    private func record(_ error: Error, code: CrashlyticsError.Code) {
+        Self.record(error, code: code)
+    }
 }

--- a/Application/DevLogInfra/Sources/Service/SocialLogin/GoogleAuthenticationServiceImpl.swift
+++ b/Application/DevLogInfra/Sources/Service/SocialLogin/GoogleAuthenticationServiceImpl.swift
@@ -164,7 +164,7 @@ private extension GoogleAuthenticationServiceImpl {
     private static func record(_ error: Error, code: CrashlyticsError.Code) {
         FirebaseCrashlyticsHelper.record(
             error,
-            domain: CrashlyticsError.domain,
+            domain: "\(CrashlyticsError.domain).\(code)",
             code: code.rawValue
         )
     }

--- a/Application/DevLogInfra/Sources/Service/TodoCategoryServiceImpl.swift
+++ b/Application/DevLogInfra/Sources/Service/TodoCategoryServiceImpl.swift
@@ -99,7 +99,7 @@ private extension TodoCategoryServiceImpl {
     private static func record(_ error: Error, code: CrashlyticsError.Code) {
         FirebaseCrashlyticsHelper.record(
             error,
-            domain: CrashlyticsError.domain,
+            domain: "\(CrashlyticsError.domain).\(code)",
             code: code.rawValue
         )
     }

--- a/Application/DevLogInfra/Sources/Service/TodoCategoryServiceImpl.swift
+++ b/Application/DevLogInfra/Sources/Service/TodoCategoryServiceImpl.swift
@@ -11,6 +11,15 @@ import DevLogCore
 import DevLogData
 
 final class TodoCategoryServiceImpl: TodoCategoryService {
+    private enum CrashlyticsError {
+        static let domain = "DevLogInfra.TodoCategoryServiceImpl"
+
+        enum Code: Int {
+            case fetchCategoryPreferences = 1
+            case updateCategoryPreferences
+        }
+    }
+
     private enum Field: String {
         case items
         case kind
@@ -57,6 +66,7 @@ final class TodoCategoryServiceImpl: TodoCategoryService {
             return preferences
         } catch {
             logger.error("Failed to fetch todo category preferences", error: error)
+            record(error, code: .fetchCategoryPreferences)
             throw error
         }
     }
@@ -79,12 +89,25 @@ final class TodoCategoryServiceImpl: TodoCategoryService {
             logger.info("Successfully updated todo category preferences")
         } catch {
             logger.error("Failed to update todo category preferences", error: error)
+            record(error, code: .updateCategoryPreferences)
             throw error
         }
     }
 }
 
 private extension TodoCategoryServiceImpl {
+    private static func record(_ error: Error, code: CrashlyticsError.Code) {
+        FirebaseCrashlyticsHelper.record(
+            error,
+            domain: CrashlyticsError.domain,
+            code: code.rawValue
+        )
+    }
+
+    private func record(_ error: Error, code: CrashlyticsError.Code) {
+        Self.record(error, code: code)
+    }
+
     func makePreference(_ items: [String: Any]) -> TodoCategoryPreferenceResponse? {
         guard
             let kindString = items[Field.kind.rawValue] as? String,

--- a/Application/DevLogInfra/Sources/Service/TodoServiceImpl.swift
+++ b/Application/DevLogInfra/Sources/Service/TodoServiceImpl.swift
@@ -12,6 +12,19 @@ import DevLogCore
 import DevLogData
 
 final class TodoServiceImpl: TodoService {
+    private enum CrashlyticsError {
+        static let domain = "DevLogInfra.TodoServiceImpl"
+
+        enum Code: Int {
+            case fetchTodos = 1
+            case upsertTodo
+            case deleteTodo
+            case undoDeleteTodo
+            case fetchTodo
+            case fetchReferences
+        }
+    }
+
     private enum FunctionName: String {
         case requestTodoDeletion
         case undoTodoDeletion
@@ -49,122 +62,128 @@ final class TodoServiceImpl: TodoService {
         ]
         logger.info("Fetching todo page: \(logComponents.compactMap { $0 }.joined(separator: ", "))")
 
-        var firestoreQuery = makeQuery(uid: uid, query: query)
+        do {
+            var firestoreQuery = makeQuery(uid: uid, query: query)
 
-        if let categoryId = query.categoryId {
-            firestoreQuery = firestoreQuery.whereField(
-                TodoFieldKey.category.rawValue,
-                isEqualTo: categoryId
-            )
-        }
+            if let categoryId = query.categoryId {
+                firestoreQuery = firestoreQuery.whereField(
+                    TodoFieldKey.category.rawValue,
+                    isEqualTo: categoryId
+                )
+            }
 
-        if query.isPinned {
-            firestoreQuery = firestoreQuery.whereField("isPinned", isEqualTo: true)
-        }
+            if query.isPinned {
+                firestoreQuery = firestoreQuery.whereField("isPinned", isEqualTo: true)
+            }
 
-        if let isCompleted = query.completionFilter.isCompletedValue {
-            firestoreQuery = firestoreQuery.whereField("isCompleted", isEqualTo: isCompleted)
-        }
+            if let isCompleted = query.completionFilter.isCompletedValue {
+                firestoreQuery = firestoreQuery.whereField("isCompleted", isEqualTo: isCompleted)
+            }
 
-        switch query.dueDateFilter {
-        case .all:
-            break
-        case .withDueDate:
-            firestoreQuery = firestoreQuery.whereField(
-                "dueDate",
-                isGreaterThan: Timestamp(date: Date(timeIntervalSince1970: 0))
-            )
-        case .withoutDueDate:
-            firestoreQuery = firestoreQuery.whereField("dueDate", isEqualTo: NSNull())
-        }
+            switch query.dueDateFilter {
+            case .all:
+                break
+            case .withDueDate:
+                firestoreQuery = firestoreQuery.whereField(
+                    "dueDate",
+                    isGreaterThan: Timestamp(date: Date(timeIntervalSince1970: 0))
+                )
+            case .withoutDueDate:
+                firestoreQuery = firestoreQuery.whereField("dueDate", isEqualTo: NSNull())
+            }
 
-        if let sortDateFrom = query.sortDateFrom {
-            firestoreQuery = firestoreQuery.whereField(
-                query.sortTarget.fieldName,
-                isGreaterThanOrEqualTo: Timestamp(date: sortDateFrom)
-            )
-        }
+            if let sortDateFrom = query.sortDateFrom {
+                firestoreQuery = firestoreQuery.whereField(
+                    query.sortTarget.fieldName,
+                    isGreaterThanOrEqualTo: Timestamp(date: sortDateFrom)
+                )
+            }
 
-        if let sortDateTo = query.sortDateTo {
-            firestoreQuery = firestoreQuery.whereField(
-                query.sortTarget.fieldName,
-                isLessThan: Timestamp(date: sortDateTo)
-            )
-        }
+            if let sortDateTo = query.sortDateTo {
+                firestoreQuery = firestoreQuery.whereField(
+                    query.sortTarget.fieldName,
+                    isLessThan: Timestamp(date: sortDateTo)
+                )
+            }
 
-        if trimmedKeyword.isEmpty {
-            if query.fetchAllPages {
-                var allItems: [TodoResponse] = []
-                var pageCursor = cursor
+            if trimmedKeyword.isEmpty {
+                if query.fetchAllPages {
+                    var allItems: [TodoResponse] = []
+                    var pageCursor = cursor
 
-                while true {
-                    var pageQuery = firestoreQuery
-                    if let pageCursor {
-                        guard let cursorValues = cursorValues(
-                            for: query,
-                            cursor: pageCursor
-                        ) else {
-                            logger.error("Failed to build cursor values for paginated todo fetch.")
+                    while true {
+                        var pageQuery = firestoreQuery
+                        if let pageCursor {
+                            guard let cursorValues = cursorValues(
+                                for: query,
+                                cursor: pageCursor
+                            ) else {
+                                logger.error("Failed to build cursor values for paginated todo fetch.")
+                                break
+                            }
+                            pageQuery = pageQuery.start(after: cursorValues)
+                        }
+
+                        pageQuery = pageQuery.limit(to: query.pageSize)
+                        let snapshot = try await pageQuery.getDocuments()
+                        allItems.append(contentsOf: snapshot.documents.compactMap { makeResponse(from: $0) })
+
+                        guard snapshot.documents.count == query.pageSize else {
                             break
                         }
-                        pageQuery = pageQuery.start(after: cursorValues)
+
+                        guard let lastDocument = snapshot.documents.last,
+                              let nextCursor = makeCursor(
+                                from: lastDocument,
+                                query: query
+                              ) else {
+                            break
+                        }
+
+                        pageCursor = nextCursor
                     }
 
-                    pageQuery = pageQuery.limit(to: query.pageSize)
-                    let snapshot = try await pageQuery.getDocuments()
-                    allItems.append(contentsOf: snapshot.documents.compactMap { makeResponse(from: $0) })
-
-                    guard snapshot.documents.count == query.pageSize else {
-                        break
-                    }
-
-                    guard let lastDocument = snapshot.documents.last,
-                          let nextCursor = makeCursor(
-                            from: lastDocument,
-                            query: query
-                          ) else {
-                        break
-                    }
-
-                    pageCursor = nextCursor
+                    return TodoPageResponse(items: allItems, nextCursor: nil)
                 }
 
-                return TodoPageResponse(items: allItems, nextCursor: nil)
-            }
-
-            if let cursor {
-                guard let cursorValues = cursorValues(for: query, cursor: cursor) else {
-                    logger.error("Failed to build cursor values for todo fetch.")
-                    return TodoPageResponse(items: [], nextCursor: nil)
+                if let cursor {
+                    guard let cursorValues = cursorValues(for: query, cursor: cursor) else {
+                        logger.error("Failed to build cursor values for todo fetch.")
+                        return TodoPageResponse(items: [], nextCursor: nil)
+                    }
+                    firestoreQuery = firestoreQuery.start(after: cursorValues)
                 }
-                firestoreQuery = firestoreQuery.start(after: cursorValues)
+
+                firestoreQuery = firestoreQuery.limit(to: query.pageSize)
+                let snapshot = try await firestoreQuery.getDocuments()
+                let items = snapshot.documents.compactMap { makeResponse(from: $0) }
+                let nextCursor = snapshot.documents.last.flatMap {
+                    makeCursor(from: $0, query: query)
+                }
+
+                return TodoPageResponse(items: items, nextCursor: nextCursor)
             }
 
-            firestoreQuery = firestoreQuery.limit(to: query.pageSize)
             let snapshot = try await firestoreQuery.getDocuments()
-            let items = snapshot.documents.compactMap { makeResponse(from: $0) }
-            let nextCursor = snapshot.documents.last.flatMap {
-                makeCursor(from: $0, query: query)
+            let todos = snapshot.documents.compactMap { makeResponse(from: $0) }
+
+            let todoNumber = searchedTodoNumber(from: trimmedKeyword)
+            let filtered = todos.filter { todo in
+                if let todoNumber, todo.number == todoNumber {
+                    return true
+                }
+
+                return todo.title.localizedCaseInsensitiveContains(trimmedKeyword)
+                    || todo.content.localizedCaseInsensitiveContains(trimmedKeyword)
+                    || todo.tags.contains { $0.localizedCaseInsensitiveContains(trimmedKeyword) }
             }
 
-            return TodoPageResponse(items: items, nextCursor: nextCursor)
+            return TodoPageResponse(items: filtered, nextCursor: nil)
+        } catch {
+            logger.error("Failed to fetch todos", error: error)
+            record(error, code: .fetchTodos)
+            throw error
         }
-
-        let snapshot = try await firestoreQuery.getDocuments()
-        let todos = snapshot.documents.compactMap { makeResponse(from: $0) }
-
-        let todoNumber = searchedTodoNumber(from: trimmedKeyword)
-        let filtered = todos.filter { todo in
-            if let todoNumber, todo.number == todoNumber {
-                return true
-            }
-
-            return todo.title.localizedCaseInsensitiveContains(trimmedKeyword)
-                || todo.content.localizedCaseInsensitiveContains(trimmedKeyword)
-                || todo.tags.contains { $0.localizedCaseInsensitiveContains(trimmedKeyword) }
-        }
-
-        return TodoPageResponse(items: filtered, nextCursor: nil)
     }
     // swiftlint:enable function_body_length
 
@@ -198,6 +217,7 @@ final class TodoServiceImpl: TodoService {
             logger.info("Successfully upserted todo")
         } catch {
             logger.error("Failed to upsert todo", error: error)
+            record(error, code: .upsertTodo)
             throw error
         }
     }
@@ -214,6 +234,7 @@ final class TodoServiceImpl: TodoService {
             logger.info("Successfully requested todo deletion")
         } catch {
             logger.error("Failed to request todo deletion", error: error)
+            record(error, code: .deleteTodo)
             throw error
         }
     }
@@ -230,6 +251,7 @@ final class TodoServiceImpl: TodoService {
             logger.info("Successfully undone todo deletion")
         } catch {
             logger.error("Failed to undo todo deletion", error: error)
+            record(error, code: .undoDeleteTodo)
             throw error
         }
     }
@@ -253,6 +275,7 @@ final class TodoServiceImpl: TodoService {
             return todo
         } catch {
             logger.error("Failed to fetch todo", error: error)
+            record(error, code: .fetchTodo)
             throw error
         }
     }
@@ -263,45 +286,63 @@ final class TodoServiceImpl: TodoService {
         let uniqueNumbers = Array(Set(numbers)).sorted()
         if uniqueNumbers.isEmpty { return [:] }
 
-        let collection = store.collection(FirestorePath.todos(uid))
-        let snapshots = try await withThrowingTaskGroup(of: [QueryDocumentSnapshot].self) { group in
-            for chunk in uniqueNumbers.chunked(maxCount: 10) {
-                group.addTask {
-                    let snapshot = try await collection
-                        .whereField(TodoFieldKey.number.rawValue, in: chunk)
-                        .whereField(TodoFieldKey.deletedAt.rawValue, isEqualTo: NSNull())
-                        .getDocuments()
-                    return snapshot.documents
+        do {
+            let collection = store.collection(FirestorePath.todos(uid))
+            let snapshots = try await withThrowingTaskGroup(of: [QueryDocumentSnapshot].self) { group in
+                for chunk in uniqueNumbers.chunked(maxCount: 10) {
+                    group.addTask {
+                        let snapshot = try await collection
+                            .whereField(TodoFieldKey.number.rawValue, in: chunk)
+                            .whereField(TodoFieldKey.deletedAt.rawValue, isEqualTo: NSNull())
+                            .getDocuments()
+                        return snapshot.documents
+                    }
                 }
+
+                var documents = [QueryDocumentSnapshot]()
+                for try await chunkDocuments in group {
+                    documents.append(contentsOf: chunkDocuments)
+                }
+                return documents
             }
 
-            var documents = [QueryDocumentSnapshot]()
-            for try await chunkDocuments in group {
-                documents.append(contentsOf: chunkDocuments)
-            }
-            return documents
-        }
+            return snapshots.reduce(into: [Int: TodoReferenceResponse]()) { partialResult, document in
+                let data = document.data()
+                guard
+                    data[TodoFieldKey.deletedAt.rawValue] is NSNull,
+                    let response = makeResponse(from: document)
+                else {
+                    return
+                }
 
-        return snapshots.reduce(into: [Int: TodoReferenceResponse]()) { partialResult, document in
-            let data = document.data()
-            guard
-                data[TodoFieldKey.deletedAt.rawValue] is NSNull,
-                let response = makeResponse(from: document)
-            else {
-                return
+                partialResult[response.number] = TodoReferenceResponse(
+                    id: response.id,
+                    number: response.number,
+                    title: response.title,
+                    category: response.category
+                )
             }
-
-            partialResult[response.number] = TodoReferenceResponse(
-                id: response.id,
-                number: response.number,
-                title: response.title,
-                category: response.category
-            )
+        } catch {
+            logger.error("Failed to fetch todo references", error: error)
+            record(error, code: .fetchReferences)
+            throw error
         }
     }
 }
 
 private extension TodoServiceImpl {
+    private static func record(_ error: Error, code: CrashlyticsError.Code) {
+        FirebaseCrashlyticsHelper.record(
+            error,
+            domain: CrashlyticsError.domain,
+            code: code.rawValue
+        )
+    }
+
+    private func record(_ error: Error, code: CrashlyticsError.Code) {
+        Self.record(error, code: code)
+    }
+
     func upsertTodoWithNumberOnCreate(
         _ data: [String: Any],
         for todoRef: DocumentReference,

--- a/Application/DevLogInfra/Sources/Service/TodoServiceImpl.swift
+++ b/Application/DevLogInfra/Sources/Service/TodoServiceImpl.swift
@@ -334,7 +334,7 @@ private extension TodoServiceImpl {
     private static func record(_ error: Error, code: CrashlyticsError.Code) {
         FirebaseCrashlyticsHelper.record(
             error,
-            domain: CrashlyticsError.domain,
+            domain: "\(CrashlyticsError.domain).\(code)",
             code: code.rawValue
         )
     }

--- a/Application/DevLogInfra/Sources/Service/UserServiceImpl.swift
+++ b/Application/DevLogInfra/Sources/Service/UserServiceImpl.swift
@@ -11,6 +11,18 @@ import DevLogCore
 import DevLogData
 
 final class UserServiceImpl: UserService {
+    private enum CrashlyticsError {
+        static let domain = "DevLogInfra.UserServiceImpl"
+
+        enum Code: Int {
+            case upsertUser = 1
+            case fetchUserProfile
+            case upsertStatusMessage
+            case updateFCMToken
+            case updateUserTimeZone
+        }
+    }
+
     private let store = Firestore.firestore()
     private let logger = Logger(category: "UserServiceImpl")
     
@@ -112,6 +124,7 @@ final class UserServiceImpl: UserService {
             logger.info("Successfully upserted user: \(user.uid)")
         } catch {
             logger.error("Failed to upsert user", error: error)
+            record(error, code: .upsertUser)
             throw error
         }
     }
@@ -150,6 +163,7 @@ final class UserServiceImpl: UserService {
             )
         } catch {
             logger.error("Failed to fetch user profile", error: error)
+            record(error, code: .fetchUserProfile)
             throw error
         }
     }
@@ -168,6 +182,7 @@ final class UserServiceImpl: UserService {
             logger.info("Successfully upserted status message")
         } catch {
             logger.error("Failed to upsert status message", error: error)
+            record(error, code: .upsertStatusMessage)
             throw error
         }
     }
@@ -186,6 +201,7 @@ final class UserServiceImpl: UserService {
             logger.info("Successfully updated FCM token")
         } catch {
             logger.error("Failed to update FCM token", error: error)
+            record(error, code: .updateFCMToken)
             throw error
         }
     }
@@ -207,7 +223,22 @@ final class UserServiceImpl: UserService {
             logger.info("Successfully updated timeZone")
         } catch {
             logger.error("Failed to update timeZone", error: error)
+            record(error, code: .updateUserTimeZone)
             throw error
         }
+    }
+}
+
+private extension UserServiceImpl {
+    private static func record(_ error: Error, code: CrashlyticsError.Code) {
+        FirebaseCrashlyticsHelper.record(
+            error,
+            domain: CrashlyticsError.domain,
+            code: code.rawValue
+        )
+    }
+
+    private func record(_ error: Error, code: CrashlyticsError.Code) {
+        Self.record(error, code: code)
     }
 }

--- a/Application/DevLogInfra/Sources/Service/UserServiceImpl.swift
+++ b/Application/DevLogInfra/Sources/Service/UserServiceImpl.swift
@@ -233,7 +233,7 @@ private extension UserServiceImpl {
     private static func record(_ error: Error, code: CrashlyticsError.Code) {
         FirebaseCrashlyticsHelper.record(
             error,
-            domain: CrashlyticsError.domain,
+            domain: "\(CrashlyticsError.domain).\(code)",
             code: code.rawValue
         )
     }

--- a/Application/DevLogInfra/Sources/Service/WebPageMetadataServiceImpl.swift
+++ b/Application/DevLogInfra/Sources/Service/WebPageMetadataServiceImpl.swift
@@ -120,7 +120,7 @@ private extension WebPageMetadataServiceImpl {
     private static func record(_ error: Error, code: CrashlyticsError.Code) {
         FirebaseCrashlyticsHelper.record(
             error,
-            domain: CrashlyticsError.domain,
+            domain: "\(CrashlyticsError.domain).\(code)",
             code: code.rawValue
         )
     }

--- a/Application/DevLogInfra/Sources/Service/WebPageMetadataServiceImpl.swift
+++ b/Application/DevLogInfra/Sources/Service/WebPageMetadataServiceImpl.swift
@@ -12,6 +12,16 @@ import DevLogCore
 import DevLogData
 
 final class WebPageMetadataServiceImpl: WebPageMetadataService {
+    private enum CrashlyticsError {
+        static let domain = "DevLogInfra.WebPageMetadataServiceImpl"
+
+        enum Code: Int {
+            case fetchMetadata = 1
+            case removeCachedImage
+            case cachedImageURL
+        }
+    }
+
     private let imageStore: WebPageImageStore
     private let logger = Logger(category: "WebPageMetadataServiceImpl")
 
@@ -42,6 +52,7 @@ final class WebPageMetadataServiceImpl: WebPageMetadataService {
             )
         } catch {
             logger.error("Failed to fetch metadata", error: error)
+            record(error, code: .fetchMetadata)
             throw error
         }
     }
@@ -60,6 +71,7 @@ final class WebPageMetadataServiceImpl: WebPageMetadataService {
             }
         } catch {
             logger.error("Failed to remove cached image", error: error)
+            record(error, code: .removeCachedImage)
         }
     }
 
@@ -68,7 +80,13 @@ final class WebPageMetadataServiceImpl: WebPageMetadataService {
             throw URLError(.badURL)
         }
 
-        return try await imageStore.cachedImageURL(for: url)
+        do {
+            return try await imageStore.cachedImageURL(for: url)
+        } catch {
+            logger.error("Failed to fetch cached image URL", error: error)
+            record(error, code: .cachedImageURL)
+            throw error
+        }
     }
 
     private func extractImageURL(from imageProvider: NSItemProvider?, url: URL) async throws -> URL? {
@@ -95,5 +113,19 @@ final class WebPageMetadataServiceImpl: WebPageMetadataService {
                 continuation.resume(returning: data)
             }
         }
+    }
+}
+
+private extension WebPageMetadataServiceImpl {
+    private static func record(_ error: Error, code: CrashlyticsError.Code) {
+        FirebaseCrashlyticsHelper.record(
+            error,
+            domain: CrashlyticsError.domain,
+            code: code.rawValue
+        )
+    }
+
+    private func record(_ error: Error, code: CrashlyticsError.Code) {
+        Self.record(error, code: code)
     }
 }

--- a/Application/DevLogInfra/Sources/Service/WebPageServiceImpl.swift
+++ b/Application/DevLogInfra/Sources/Service/WebPageServiceImpl.swift
@@ -143,7 +143,7 @@ private extension WebPageServiceImpl {
     private static func record(_ error: Error, code: CrashlyticsError.Code) {
         FirebaseCrashlyticsHelper.record(
             error,
-            domain: CrashlyticsError.domain,
+            domain: "\(CrashlyticsError.domain).\(code)",
             code: code.rawValue
         )
     }

--- a/Application/DevLogInfra/Sources/Service/WebPageServiceImpl.swift
+++ b/Application/DevLogInfra/Sources/Service/WebPageServiceImpl.swift
@@ -12,6 +12,17 @@ import DevLogCore
 import DevLogData
 
 final class WebPageServiceImpl: WebPageService {
+    private enum CrashlyticsError {
+        static let domain = "DevLogInfra.WebPageServiceImpl"
+
+        enum Code: Int {
+            case fetchWebPages = 1
+            case upsertWebPage
+            case deleteWebPage
+            case undoDeleteWebPage
+        }
+    }
+
     private enum FunctionName: String {
         case requestWebPageDeletion
         case undoWebPageDeletion
@@ -51,6 +62,7 @@ final class WebPageServiceImpl: WebPageService {
             return filtered
         } catch {
             logger.error("Failed to fetch web pages", error: error)
+            record(error, code: .fetchWebPages)
             throw error
         }
     }
@@ -72,6 +84,7 @@ final class WebPageServiceImpl: WebPageService {
             logger.info("Successfully upserted web page")
         } catch {
             logger.error("Failed to upsert web page", error: error)
+            record(error, code: .upsertWebPage)
             throw error
         }
     }
@@ -90,6 +103,7 @@ final class WebPageServiceImpl: WebPageService {
             logger.info("Successfully requested web page deletion")
         } catch {
             logger.error("Failed to request web page deletion", error: error)
+            record(error, code: .deleteWebPage)
             throw error
         }
     }
@@ -108,6 +122,7 @@ final class WebPageServiceImpl: WebPageService {
             logger.info("Successfully undone web page deletion")
         } catch {
             logger.error("Failed to undo web page deletion", error: error)
+            record(error, code: .undoDeleteWebPage)
             throw error
         }
     }
@@ -125,6 +140,18 @@ final class WebPageServiceImpl: WebPageService {
 }
 
 private extension WebPageServiceImpl {
+    private static func record(_ error: Error, code: CrashlyticsError.Code) {
+        FirebaseCrashlyticsHelper.record(
+            error,
+            domain: CrashlyticsError.domain,
+            code: code.rawValue
+        )
+    }
+
+    private func record(_ error: Error, code: CrashlyticsError.Code) {
+        Self.record(error, code: code)
+    }
+
     func makeResponse(from snapshot: QueryDocumentSnapshot) -> WebPageResponse? {
         let data = snapshot.data()
         guard

--- a/README.md
+++ b/README.md
@@ -129,7 +129,8 @@ Todo, 저장 링크, 오늘 할 일, 받은 알림, 누적 활동을 하나의 �
 | Architecture | Tuist Modular based Clean Architecture |
 | UI | SwiftUI, MarkdownUI, WidgetKit, AppIntents |
 | State & Async | Observable, Combine, async/await, The Composable Architecture |
-| Backend | Firebase Authentication, Firestore, Cloud Functions, Cloud Messaging, Analytics |
+| Backend | Firebase Authentication, Firestore, Cloud Functions, Cloud Messaging |
+| Monitoring | Firebase Analytics, Crashlytics |
 | Apple Frameworks | AuthenticationServices, UserNotifications, LinkPresentation, Network, CryptoKit, os.log |
 | External Packages | ComposableArchitecture, MarkdownUI, OrderedCollections, GoogleSignIn, Nexa |
 | Testing | swift-testing, TCA TestStore |

--- a/Tuist/ProjectDescriptionHelpers/Project+Packages.swift
+++ b/Tuist/ProjectDescriptionHelpers/Project+Packages.swift
@@ -60,6 +60,25 @@ public enum DevLogPackages {
 }
 
 public enum DevLogScripts {
+    public static func firebaseCrashlyticsDSYMUpload() -> TargetScript {
+        TargetScript.post(
+        script: """
+        "${BUILD_DIR%/Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run"
+        """,
+        name: "Firebase Crashlytics dSYM Upload",
+        inputPaths: [
+            "${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}",
+            "${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${PRODUCT_NAME}",
+            "${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${PRODUCT_NAME}.debug.dylib",
+            "${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Info.plist",
+            "$(TARGET_BUILD_DIR)/$(UNLOCALIZED_RESOURCES_FOLDER_PATH)/GoogleService-Info.plist",
+            "$(TARGET_BUILD_DIR)/$(EXECUTABLE_PATH)",
+        ],
+        basedOnDependencyAnalysis: false,
+        shellPath: "/bin/bash"
+        )
+    }
+
     public static func swiftLint(
         sourcePath: String,
         configPath: String = "../../.swiftlint.yml"

--- a/Tuist/ProjectDescriptionHelpers/Project+Packages.swift
+++ b/Tuist/ProjectDescriptionHelpers/Project+Packages.swift
@@ -37,6 +37,7 @@ public enum DevLogPackages {
         .package(product: "FirebaseCore"),
         .package(product: "FirebaseFunctions"),
         .package(product: "FirebaseAuth"),
+        .package(product: "FirebaseCrashlytics"),
         .package(product: "FirebaseMessaging"),
         .package(product: "FirebaseFirestore"),
         .package(product: "GoogleSignIn"),

--- a/Tuist/ProjectDescriptionHelpers/Project+Packages.swift
+++ b/Tuist/ProjectDescriptionHelpers/Project+Packages.swift
@@ -60,25 +60,6 @@ public enum DevLogPackages {
 }
 
 public enum DevLogScripts {
-    public static func firebaseCrashlyticsDSYMUpload() -> TargetScript {
-        TargetScript.post(
-        script: """
-        "${BUILD_DIR%/Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run"
-        """,
-        name: "Firebase Crashlytics dSYM Upload",
-        inputPaths: [
-            "${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}",
-            "${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${PRODUCT_NAME}",
-            "${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${PRODUCT_NAME}.debug.dylib",
-            "${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Info.plist",
-            "$(TARGET_BUILD_DIR)/$(UNLOCALIZED_RESOURCES_FOLDER_PATH)/GoogleService-Info.plist",
-            "$(TARGET_BUILD_DIR)/$(EXECUTABLE_PATH)",
-        ],
-        basedOnDependencyAnalysis: false,
-        shellPath: "/bin/bash"
-        )
-    }
-
     public static func swiftLint(
         sourcePath: String,
         configPath: String = "../../.swiftlint.yml"

--- a/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
+++ b/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
@@ -30,6 +30,9 @@ public extension Project {
                     versionXcconfigPath: versionXcconfigPath,
                     base: [
                         "ENABLE_USER_SCRIPT_SANDBOXING": "NO",
+                    ],
+                    debug: [
+                        "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
                     ]
                 )
             ),

--- a/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
+++ b/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
@@ -32,6 +32,9 @@ public extension Project {
                         "ENABLE_USER_SCRIPT_SANDBOXING": "NO",
                     ],
                     debug: [
+                        "DEBUG_INFORMATION_FORMAT": "dwarf",
+                    ],
+                    release: [
                         "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
                     ]
                 )


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #599

## 🎯 의도
- Firebase Crashlytics를 DevLog Infra 오류 관측 경로에 추가
- production Crashlytics에 로컬 Debug 이벤트가 섞이지 않도록 빌드 설정과 수집 정책을 정리하기 위함

## 📝 작업 내용

### 📌 요약
- Firebase Crashlytics 의존성 및 dSYM 업로드 스크립트 추가
- Infra 서비스 실패 지점에 non-fatal error 기록 추가
- Crashlytics 오류 도메인을 기능/작업 단위로 세분화
- Debug 빌드 Crashlytics 수집 비활성화 및 Release 수집 활성화
- Debug 빌드는 `dwarf`, Release 빌드는 `dwarf-with-dsym` 사용하도록 dSYM 생성 정책 정리
- README 기술 스택에 Crashlytics 모니터링 항목 반영

### 🔍 상세
- `FirebaseCrashlyticsHelper`를 추가해 공통 non-fatal 기록 경로 구성
- 원본 `NSError`를 `NSUnderlyingErrorKey`로 보존해 Crashlytics 대시보드에서 원본 에러 정보 확인 가능하도록 처리
- Auth, SocialLogin, Todo, TodoCategory, User, WebPage, PushNotification, PushMessaging, ProfileImageData, WebPageMetadata 서비스의 catch 경로에 Crashlytics 기록 추가
- Crashlytics grouping 가독성을 위해 `DevLogInfra.<Service>.<Code>` 형태의 도메인 사용
- Debug 빌드는 `FirebaseCrashlyticsCollectionEnabled = NO`로 설정해 로컬 개발 이벤트 전송 방지
- Release 빌드는 `FirebaseCrashlyticsCollectionEnabled = YES` 및 런타임 collection 활성화로 배포 빌드 수집 유지
- App target과 framework template의 `DEBUG_INFORMATION_FORMAT`을 Debug/Release별로 분리해 Debug 빌드 dSYM 생성 비용 제거

## 📸 영상 / 이미지 (Optional)

<img width="1283" height="260" alt="image" src="https://github.com/user-attachments/assets/5db2b160-f119-4363-8cef-5a25e86c17b5" />

