### PR TITLE
[#619] FCM Token을 해제하지 못할 시 로그아웃에 실패하는 현상을 해결한다

### DIFF
--- a/Application/DevLogData/Sources/Common/DataLayerError.swift
+++ b/Application/DevLogData/Sources/Common/DataLayerError.swift
@@ -5,7 +5,6 @@
 //  Created by opfic on 3/11/26.
 //
 
-import AuthenticationServices
 import Foundation
 import DevLogCore
 
@@ -47,18 +46,4 @@ public enum DataError: Error {
 public enum DataLayerError: Error {
     case notAuthenticated
     case linkCredentialAlreadyInUse
-}
-
-public extension Error {
-    var isSocialLoginCancelled: Bool {
-        switch self {
-        case let authError as ASAuthorizationError:
-            return authError.code == .canceled
-        case let webAuthError as ASWebAuthenticationSessionError:
-            return webAuthError.code == .canceledLogin
-        default:
-            let nsError = self as NSError
-            return nsError.domain == "com.google.GIDSignIn" && nsError.code == -5
-        }
-    }
 }

--- a/Application/DevLogData/Sources/Protocol/AuthenticationService.swift
+++ b/Application/DevLogData/Sources/Protocol/AuthenticationService.swift
@@ -8,9 +8,9 @@
 import Foundation
 
 public protocol AuthenticationService {
-    func signIn() async throws -> AuthDataResponse
+    func signIn() async throws -> AuthDataResponse?
     func signOut(_ uid: String) async throws
     func deleteAuth(_ uid: String) async throws
-    func link(uid: String, email: String) async throws
+    func link(uid: String, email: String) async throws -> Bool
     func unlink(_ uid: String) async throws
 }

--- a/Application/DevLogData/Sources/Repository/AuthDataRepositoryImpl.swift
+++ b/Application/DevLogData/Sources/Repository/AuthDataRepositoryImpl.swift
@@ -37,7 +37,7 @@ final class AuthDataRepositoryImpl: AuthDataRepository {
         return providerStrings.compactMap { AuthProvider(rawValue: $0) }
     }
     
-    func linkProvider(_ provider: AuthProvider) async throws {
+    func linkProvider(_ provider: AuthProvider) async throws -> Bool {
         guard let uid = authService.uid,
               let email = authService.currentUserEmail else {
             throw AuthError.notAuthenticated
@@ -54,7 +54,7 @@ final class AuthDataRepositoryImpl: AuthDataRepository {
         }
 
         do {
-            try await service.link(uid: uid, email: email)
+            return try await service.link(uid: uid, email: email)
         } catch {
             throw mapLinkError(error)
         }

--- a/Application/DevLogData/Sources/Repository/AuthenticationRepositoryImpl.swift
+++ b/Application/DevLogData/Sources/Repository/AuthenticationRepositoryImpl.swift
@@ -31,11 +31,11 @@ final class AuthenticationRepositoryImpl: AuthenticationRepository {
         self.widgetSnapshotUpdater = widgetSnapshotUpdater
     }
 
-    func signIn(_ provider: AuthProvider) async throws {
+    func signIn(_ provider: AuthProvider) async throws -> Bool {
         authService.beginSignIn()
 
         do {
-            let response: AuthDataResponse
+            let response: AuthDataResponse?
             switch provider {
             case .apple:
                 response = try await appleAuthService.signIn()
@@ -45,8 +45,14 @@ final class AuthenticationRepositoryImpl: AuthenticationRepository {
                 response = try await googleAuthService.signIn()
             }
 
+            guard let response else {
+                authService.cancelSignIn()
+                return false
+            }
+
             try await userService.upsertUser(response)
             authService.completeSignIn()
+            return true
         } catch {
             if authService.uid != nil {
                 try? await authService.clearCurrentSession()

--- a/Application/DevLogDomain/Sources/Protocol/AuthDataRepository.swift
+++ b/Application/DevLogDomain/Sources/Protocol/AuthDataRepository.swift
@@ -13,7 +13,7 @@ public protocol AuthDataRepository {
     func fetchAllProviders() async throws -> [AuthProvider]
     
     /// 특정 프로바이더를 계정에 연결합니다
-    func linkProvider(_ provider: AuthProvider) async throws
+    func linkProvider(_ provider: AuthProvider) async throws -> Bool
     
     /// 특정 프로바이더를 계정에서 해제합니다
     func unlinkProvider(_ provider: AuthProvider) async throws

--- a/Application/DevLogDomain/Sources/Protocol/AuthenticationRepository.swift
+++ b/Application/DevLogDomain/Sources/Protocol/AuthenticationRepository.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 public protocol AuthenticationRepository {
-    func signIn(_ provider: AuthProvider) async throws
+    func signIn(_ provider: AuthProvider) async throws -> Bool
     func signOut() async throws
     func restore() -> Bool
     func delete() async throws

--- a/Application/DevLogDomain/Sources/UseCase/Auth/Provider/LinkAuthProviderUseCase.swift
+++ b/Application/DevLogDomain/Sources/UseCase/Auth/Provider/LinkAuthProviderUseCase.swift
@@ -6,5 +6,5 @@
 //
 
 public protocol LinkAuthProviderUseCase {
-    func execute(_ provider: AuthProvider) async throws
+    func execute(_ provider: AuthProvider) async throws -> Bool
 }

--- a/Application/DevLogDomain/Sources/UseCase/Auth/Provider/LinkAuthProviderUseCaseImpl.swift
+++ b/Application/DevLogDomain/Sources/UseCase/Auth/Provider/LinkAuthProviderUseCaseImpl.swift
@@ -12,7 +12,7 @@ public final class LinkAuthProviderUseCaseImpl: LinkAuthProviderUseCase {
         self.repository = repository
     }
     
-    public func execute(_ provider: AuthProvider) async throws {
+    public func execute(_ provider: AuthProvider) async throws -> Bool {
         try await repository.linkProvider(provider)
     }
 }

--- a/Application/DevLogDomain/Sources/UseCase/Auth/SignIn/SignInUseCase.swift
+++ b/Application/DevLogDomain/Sources/UseCase/Auth/SignIn/SignInUseCase.swift
@@ -6,5 +6,5 @@
 //
 
 public protocol SignInUseCase {
-    func execute(_ provider: AuthProvider) async throws
+    func execute(_ provider: AuthProvider) async throws -> Bool
 }

--- a/Application/DevLogDomain/Sources/UseCase/Auth/SignIn/SignInUseCaseImpl.swift
+++ b/Application/DevLogDomain/Sources/UseCase/Auth/SignIn/SignInUseCaseImpl.swift
@@ -12,7 +12,7 @@ public final class SignInUseCaseImpl: SignInUseCase {
         self.repository = repository
     }
 
-    public func execute(_ provider: AuthProvider) async throws {
+    public func execute(_ provider: AuthProvider) async throws -> Bool {
         try await repository.signIn(provider)
     }
 }

--- a/Application/DevLogInfra/Sources/Common/InfraLayerError.swift
+++ b/Application/DevLogInfra/Sources/Common/InfraLayerError.swift
@@ -33,3 +33,17 @@ enum SocialLoginError: Error {
     case failedToStartWebAuthenticationSession
     case authenticationAlreadyInProgress
 }
+
+extension Error {
+    var isSocialLoginCancelled: Bool {
+        switch self {
+        case let authError as ASAuthorizationError:
+            return authError.code == .canceled
+        case let webAuthError as ASWebAuthenticationSessionError:
+            return webAuthError.code == .canceledLogin
+        default:
+            let nsError = self as NSError
+            return nsError.domain == "com.google.GIDSignIn" && nsError.code == -5
+        }
+    }
+}

--- a/Application/DevLogInfra/Sources/Service/AuthServiceImpl.swift
+++ b/Application/DevLogInfra/Sources/Service/AuthServiceImpl.swift
@@ -124,10 +124,11 @@ final class AuthServiceImpl: AuthService {
         logger.info("Clearing current auth session")
 
         do {
-            try await messaging.deleteToken()
+            if messaging.fcmToken != nil {
+                try await messaging.deleteToken()
+            }
         } catch {
             logger.error("Failed to delete FCM token while clearing session", error: error)
-            record(error, code: .deleteMessagingToken)
         }
 
         do {

--- a/Application/DevLogInfra/Sources/Service/SocialLogin/AppleAuthenticationServiceImpl.swift
+++ b/Application/DevLogInfra/Sources/Service/SocialLogin/AppleAuthenticationServiceImpl.swift
@@ -44,7 +44,7 @@ final class AppleAuthenticationServiceImpl: AuthenticationService {
     private let providerID = AuthProviderID.apple
     private let logger = Logger(category: "AppleAuthService")
 
-    func signIn() async throws -> AuthDataResponse {
+    func signIn() async throws -> AuthDataResponse? {
         logger.info("Starting Apple sign in")
         
         do {
@@ -105,6 +105,8 @@ final class AppleAuthenticationServiceImpl: AuthenticationService {
             logger.info("Successfully signed in with Apple")
             return result.user.makeResponse(providerID: .apple)
         } catch {
+            if error.isSocialLoginCancelled { return nil }
+
             logger.error("Failed to sign in with Apple", error: error)
             record(error, code: .signIn)
             throw error
@@ -142,7 +144,7 @@ final class AppleAuthenticationServiceImpl: AuthenticationService {
         }
     }
 
-    func link(uid: String, email: String) async throws {
+    func link(uid: String, email: String) async throws -> Bool {
         do {
             let response = try await authenticateWithAppleAsync()
 
@@ -170,7 +172,10 @@ final class AppleAuthenticationServiceImpl: AuthenticationService {
             )
 
             try await user?.link(with: appleCredential)
+            return true
         } catch {
+            if error.isSocialLoginCancelled { return false }
+
             logger.error("Failed to link Apple account", error: error)
             record(error, code: .link)
             if error.isFirebaseCredentialAlreadyInUse {

--- a/Application/DevLogInfra/Sources/Service/SocialLogin/AppleAuthenticationServiceImpl.swift
+++ b/Application/DevLogInfra/Sources/Service/SocialLogin/AppleAuthenticationServiceImpl.swift
@@ -116,11 +116,7 @@ final class AppleAuthenticationServiceImpl: AuthenticationService {
     func signOut(_ uid: String) async throws {
         do {
             let infoRef = store.document(FirestorePath.userData(uid, document: .tokens))
-            let doc = try await infoRef.getDocument()
-
-            if doc.exists {
-                try await infoRef.updateData(["fcmToken": FieldValue.delete()])
-            }
+            try? await infoRef.updateData(["fcmToken": FieldValue.delete()])
 
             if messaging.fcmToken != nil {
                 do {

--- a/Application/DevLogInfra/Sources/Service/SocialLogin/AppleAuthenticationServiceImpl.swift
+++ b/Application/DevLogInfra/Sources/Service/SocialLogin/AppleAuthenticationServiceImpl.swift
@@ -122,7 +122,13 @@ final class AppleAuthenticationServiceImpl: AuthenticationService {
                 try await infoRef.updateData(["fcmToken": FieldValue.delete()])
             }
 
-            try await messaging.deleteToken()
+            if messaging.fcmToken != nil {
+                do {
+                    try await messaging.deleteToken()
+                } catch {
+                    logger.error("Failed to delete FCM token while signing out with Apple", error: error)
+                }
+            }
 
             try Auth.auth().signOut()
         } catch {

--- a/Application/DevLogInfra/Sources/Service/SocialLogin/GithubAuthenticationServiceImpl.swift
+++ b/Application/DevLogInfra/Sources/Service/SocialLogin/GithubAuthenticationServiceImpl.swift
@@ -107,7 +107,13 @@ final class GithubAuthenticationServiceImpl: NSObject, AuthenticationService {
                 try await infoRef.updateData(["fcmToken": FieldValue.delete()])
             }
 
-            try await messaging.deleteToken()
+            if messaging.fcmToken != nil {
+                do {
+                    try await messaging.deleteToken()
+                } catch {
+                    logger.error("Failed to delete FCM token while signing out with GitHub", error: error)
+                }
+            }
 
             try Auth.auth().signOut()
         } catch {

--- a/Application/DevLogInfra/Sources/Service/SocialLogin/GithubAuthenticationServiceImpl.swift
+++ b/Application/DevLogInfra/Sources/Service/SocialLogin/GithubAuthenticationServiceImpl.swift
@@ -52,7 +52,7 @@ final class GithubAuthenticationServiceImpl: NSObject, AuthenticationService {
         )
     )
 
-    func signIn() async throws -> AuthDataResponse {
+    func signIn() async throws -> AuthDataResponse? {
         logger.info("Starting GitHub sign in")
         
         do {
@@ -90,6 +90,8 @@ final class GithubAuthenticationServiceImpl: NSObject, AuthenticationService {
                 accessToken: accessToken
             )
         } catch {
+            if error.isSocialLoginCancelled { return nil }
+
             logger.error("Failed to sign in with GitHub", error: error)
             record(error, code: .signIn)
             throw error
@@ -125,7 +127,7 @@ final class GithubAuthenticationServiceImpl: NSObject, AuthenticationService {
         }
     }
 
-    func link(uid: String, email: String) async throws {
+    func link(uid: String, email: String) async throws -> Bool {
         logger.info("Linking GitHub account for user: \(uid)")
         
         do {
@@ -153,7 +155,10 @@ final class GithubAuthenticationServiceImpl: NSObject, AuthenticationService {
             try await user?.link(with: credential)
             
             logger.info("Successfully linked GitHub account")
+            return true
         } catch {
+            if error.isSocialLoginCancelled { return false }
+
             logger.error("Failed to link GitHub account", error: error)
             record(error, code: .link)
             if error.isFirebaseCredentialAlreadyInUse {

--- a/Application/DevLogInfra/Sources/Service/SocialLogin/GithubAuthenticationServiceImpl.swift
+++ b/Application/DevLogInfra/Sources/Service/SocialLogin/GithubAuthenticationServiceImpl.swift
@@ -101,11 +101,7 @@ final class GithubAuthenticationServiceImpl: NSObject, AuthenticationService {
     func signOut(_ uid: String) async throws {
         do {
             let infoRef = store.document(FirestorePath.userData(uid, document: .tokens))
-            let doc = try await infoRef.getDocument()
-
-            if doc.exists {
-                try await infoRef.updateData(["fcmToken": FieldValue.delete()])
-            }
+            try? await infoRef.updateData(["fcmToken": FieldValue.delete()])
 
             if messaging.fcmToken != nil {
                 do {

--- a/Application/DevLogInfra/Sources/Service/SocialLogin/GoogleAuthenticationServiceImpl.swift
+++ b/Application/DevLogInfra/Sources/Service/SocialLogin/GoogleAuthenticationServiceImpl.swift
@@ -86,7 +86,13 @@ final class GoogleAuthenticationServiceImpl: AuthenticationService {
             GIDSignIn.sharedInstance.signOut()
             try await GIDSignIn.sharedInstance.disconnect()
 
-            try await messaging.deleteToken()
+            if messaging.fcmToken != nil {
+                do {
+                    try await messaging.deleteToken()
+                } catch {
+                    logger.error("Failed to delete FCM token while signing out with Google", error: error)
+                }
+            }
 
             try Auth.auth().signOut()
         } catch {

--- a/Application/DevLogInfra/Sources/Service/SocialLogin/GoogleAuthenticationServiceImpl.swift
+++ b/Application/DevLogInfra/Sources/Service/SocialLogin/GoogleAuthenticationServiceImpl.swift
@@ -77,11 +77,7 @@ final class GoogleAuthenticationServiceImpl: AuthenticationService {
     func signOut(_ uid: String) async throws {
         do {
             let infoRef = store.document(FirestorePath.userData(uid, document: .tokens))
-            let doc = try await infoRef.getDocument()
-
-            if doc.exists {
-                try await infoRef.updateData(["fcmToken": FieldValue.delete()])
-            }
+            try? await infoRef.updateData(["fcmToken": FieldValue.delete()])
 
             GIDSignIn.sharedInstance.signOut()
             try await GIDSignIn.sharedInstance.disconnect()

--- a/Application/DevLogInfra/Sources/Service/SocialLogin/GoogleAuthenticationServiceImpl.swift
+++ b/Application/DevLogInfra/Sources/Service/SocialLogin/GoogleAuthenticationServiceImpl.swift
@@ -33,7 +33,7 @@ final class GoogleAuthenticationServiceImpl: AuthenticationService {
     private let logger = Logger(category: "GoogleAuthService")
 
     @MainActor
-    func signIn() async throws -> AuthDataResponse {
+    func signIn() async throws -> AuthDataResponse? {
         logger.info("Starting Google sign in")
         
         guard let topViewController = provider.topViewController() else {
@@ -66,6 +66,8 @@ final class GoogleAuthenticationServiceImpl: AuthenticationService {
             logger.info("Successfully signed in with Google")
             return result.user.makeResponse(providerID: .google)
         } catch {
+            if error.isSocialLoginCancelled { return nil }
+
             logger.error("Failed to sign in with Google", error: error)
             record(error, code: .signIn)
             throw error
@@ -106,7 +108,7 @@ final class GoogleAuthenticationServiceImpl: AuthenticationService {
     }
 
     @MainActor
-    func link(uid: String, email: String) async throws {
+    func link(uid: String, email: String) async throws -> Bool {
         do {
             guard let topViewController = provider.topViewController() else {
                 throw UIError.notFoundTopViewController
@@ -134,7 +136,10 @@ final class GoogleAuthenticationServiceImpl: AuthenticationService {
             let credential = GoogleAuthProvider.credential(withIDToken: idToken, accessToken: accessToken)
 
             try await user?.link(with: credential)
+            return true
         } catch {
+            if error.isSocialLoginCancelled { return false }
+
             logger.error("Failed to link Google account", error: error)
             record(error, code: .link)
             if error.isFirebaseCredentialAlreadyInUse {

--- a/Application/DevLogPresentation/Sources/Extension/Error+SocialLogin.swift
+++ b/Application/DevLogPresentation/Sources/Extension/Error+SocialLogin.swift
@@ -4,20 +4,3 @@
 //
 //  Created by opfic on 5/15/26.
 //
-
-import AuthenticationServices
-import Foundation
-
-extension Error {
-    var isSocialLoginCancelled: Bool {
-        switch self {
-        case let authError as ASAuthorizationError:
-            return authError.code == .canceled
-        case let webAuthError as ASWebAuthenticationSessionError:
-            return webAuthError.code == .canceledLogin
-        default:
-            let nsError = self as NSError
-            return nsError.domain == "com.google.GIDSignIn" && nsError.code == -5
-        }
-    }
-}

--- a/Application/DevLogPresentation/Sources/Login/LoginFeature.swift
+++ b/Application/DevLogPresentation/Sources/Login/LoginFeature.swift
@@ -78,11 +78,12 @@ private extension LoginFeature {
         .run { [signInUseCase] send in
             await send(.loading(.begin(target: .default, mode: .immediate)))
             do {
-                try await signInUseCase.execute(provider)
+                let signedIn = try await signInUseCase.execute(provider)
                 // 유스케이스 완료가 화면 전환 완료를 의미하지 않으므로 LoginView가 교체될 때까지 로딩을 유지한다.
+                guard !signedIn else { return }
+                await send(.loading(.end(target: .default, mode: .immediate)))
             } catch {
                 await send(.loading(.end(target: .default, mode: .immediate)))
-                if error.isSocialLoginCancelled { return }
                 await send(.signInFailed(Self.alertType(for: error)))
             }
         }

--- a/Application/DevLogPresentation/Sources/Settings/AccountFeature.swift
+++ b/Application/DevLogPresentation/Sources/Settings/AccountFeature.swift
@@ -141,7 +141,12 @@ private extension AccountFeature {
         .run { [fetchProvidersUseCase, linkProviderUseCase] send in
             await send(.loading(.begin(target: .default, mode: .delayed)))
             do {
-                try await linkProviderUseCase.execute(provider)
+                let linked = try await linkProviderUseCase.execute(provider)
+                guard linked else {
+                    await send(.loading(.end(target: .default, mode: .delayed)))
+                    return
+                }
+
                 await ToastPresenter.present(message: String(localized: "account_toast_link_success"))
                 let providers = try await fetchProvidersUseCase.execute()
                 await send(.setProviders(
@@ -151,9 +156,6 @@ private extension AccountFeature {
                 await send(.loading(.end(target: .default, mode: .delayed)))
             } catch {
                 await send(.loading(.end(target: .default, mode: .delayed)))
-
-                if error.isSocialLoginCancelled { return }
-
                 await send(.setAlert(Self.linkAlertType(for: error)))
             }
         }

--- a/Application/DevLogPresentation/Tests/Login/LoginFeatureTests.swift
+++ b/Application/DevLogPresentation/Tests/Login/LoginFeatureTests.swift
@@ -110,10 +110,10 @@ struct LoginFeatureTests {
         ))
     }
 
-    @Test("소셜 로그인 취소 에러가 발생하면 알림을 표시하지 않는다")
-    func 소셜_로그인_취소_에러가_발생하면_알림을_표시하지_않는다() async {
+    @Test("소셜 로그인이 취소되어도 알림을 표시하지 않는다")
+    func 소셜_로그인이_취소되어도_알림을_표시하지_않는다() async {
         let spy = SignInUseCaseSpy()
-        spy.error = NSError(domain: "com.google.GIDSignIn", code: -5)
+        spy.signedIn = false
         let driver = LoginTestDriver(useCase: spy)
 
         driver.tapSignInButton(.google)

--- a/Application/DevLogPresentation/Tests/Settings/AccountFeatureTests.swift
+++ b/Application/DevLogPresentation/Tests/Settings/AccountFeatureTests.swift
@@ -181,10 +181,10 @@ struct AccountFeatureTests {
         }
     }
 
-    @Test("소셜 로그인 취소 에러로 연동이 실패하면 알림을 표시하지 않는다")
-    func 소셜_로그인_취소_에러로_연동이_실패하면_알림을_표시하지_않는다() async {
+    @Test("소셜 로그인이 취소되어도 연동 알림을 표시하지 않는다")
+    func 소셜_로그인이_취소되어도_연동_알림을_표시하지_않는다() async {
         let linkSpy = LinkAuthProviderUseCaseSpy()
-        linkSpy.error = NSError(domain: "com.google.GIDSignIn", code: -5)
+        linkSpy.linked = false
         let driver = AccountTestDriver(linkUseCase: linkSpy)
 
         driver.linkWithProvider(.google)
@@ -323,12 +323,13 @@ private final class FetchAuthProvidersUseCaseSpy: FetchAuthProvidersUseCase {
 
 private final class LinkAuthProviderUseCaseSpy: LinkAuthProviderUseCase {
     var error: Error?
+    var linked = true
     var shouldSuspend = false
     private(set) var providers = [AuthProvider]()
     private var continuation: CheckedContinuation<Void, Never>?
     private var shouldResume = false
 
-    func execute(_ provider: AuthProvider) async throws {
+    func execute(_ provider: AuthProvider) async throws -> Bool {
         providers.append(provider)
 
         if shouldSuspend {
@@ -345,6 +346,8 @@ private final class LinkAuthProviderUseCaseSpy: LinkAuthProviderUseCase {
         if let error {
             throw error
         }
+
+        return linked
     }
 
     func resume() {

--- a/Application/DevLogPresentation/Tests/Support/TestSupport.swift
+++ b/Application/DevLogPresentation/Tests/Support/TestSupport.swift
@@ -52,13 +52,14 @@ final class FetchPushNotificationsUseCaseSpy: FetchPushNotificationsUseCase {
 
 final class SignInUseCaseSpy: SignInUseCase {
     var error: Error?
+    var signedIn = true
     var shouldSuspend = false
     private(set) var calledProviders: [AuthProvider] = []
     private(set) var successfulProviders = [AuthProvider]()
     private var continuation: CheckedContinuation<Void, Never>?
     private var shouldResume = false
 
-    func execute(_ provider: AuthProvider) async throws {
+    func execute(_ provider: AuthProvider) async throws -> Bool {
         calledProviders.append(provider)
 
         if shouldSuspend {
@@ -76,7 +77,11 @@ final class SignInUseCaseSpy: SignInUseCase {
             throw error
         }
 
-        successfulProviders.append(provider)
+        if signedIn {
+            successfulProviders.append(provider)
+        }
+
+        return signedIn
     }
 
     func resume() {


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #619

## 🎯 의도

- 로그인 취소와 로그아웃 중 FCM 토큰 해제 실패가 실제 장애가 아닌데도 오류로 전파되거나 Crashlytics에 기록되는 문제를 방지

## 📝 작업 내용

### 📌 요약

- 소셜 로그인 취소를 Infra 레이어에서 비오류 흐름으로 처리
- FCM 토큰이 없는 상태의 로그아웃에서 `deleteToken()` 호출 생략
- FCM 토큰 해제 실패가 로그아웃 실패나 Crashlytics 기록으로 이어지지 않도록 방어

### 🔍 상세

- `AuthenticationService.signIn()`과 `link()`가 취소 흐름을 표현할 수 있도록 결과 기반으로 조정
- Google, GitHub, Apple 로그인 취소 시 Infra 구현체에서 에러를 던지지 않고 흐름 종료
- 로그아웃 시 `messaging.fcmToken`이 있을 때만 FCM 토큰 삭제 수행
- FCM 토큰 삭제 실패는 로컬 로그만 남기고 `Auth.auth().signOut()`은 계속 진행
- 실제 FirebaseAuth 로그아웃 실패는 기존처럼 Crashlytics 기록 유지
- 관련 Data, Domain, Presentation 테스트를 변경된 취소 흐름에 맞게 갱신

## 📸 영상 / 이미지 (Optional)
