### PR TITLE
[#598] refreshable의 로딩 인디케이터와 LoadingView가 같이 뜨는 현상을 해결한다

### DIFF
--- a/Application/DevLogPresentation/Sources/Home/List/TodoListFeature.swift
+++ b/Application/DevLogPresentation/Sources/Home/List/TodoListFeature.swift
@@ -201,10 +201,11 @@ private extension TodoListFeature {
     func fetchEffect(
         query: TodoQuery,
         cursor: TodoCursor?,
-        resetsPagination: Bool = true
+        resetsPagination: Bool = true,
+        showsIndicator: Bool = true
     ) -> Effect<Action> {
         .concatenate(
-            .send(.loading(.begin(target: .default, mode: .delayed))),
+            showsIndicator ? .send(.loading(.begin(target: .default, mode: .delayed))) : .none,
             .run { [fetchTodosUseCase] send in
                 do {
                     let page = try await fetchTodosUseCase.execute(query, cursor: cursor)
@@ -216,12 +217,16 @@ private extension TodoListFeature {
                         nextCursor: page.nextCursor
                     )))
                     await send(.store(.setHasMore(page.items.count == query.pageSize && page.nextCursor != nil)))
-                    await send(.loading(.end(target: .default, mode: .delayed)))
+                    if showsIndicator {
+                        await send(.loading(.end(target: .default, mode: .delayed)))
+                    }
                 } catch is CancellationError {
                     return
                 } catch {
                     await send(.store(.setAlert(true)))
-                    await send(.loading(.end(target: .default, mode: .delayed)))
+                    if showsIndicator {
+                        await send(.loading(.end(target: .default, mode: .delayed)))
+                    }
                 }
             }
         )
@@ -277,7 +282,9 @@ private extension TodoListFeature {
         state: inout State
     ) -> Effect<Action> {
         switch action {
-        case .refresh, .onAppear:
+        case .refresh:
+            return fetchEffect(query: state.query, cursor: nil, showsIndicator: false)
+        case .onAppear:
             return fetchEffect(query: state.query, cursor: nil)
         case .swipeTodo(let todo):
             return swipeTodoEffect(todo, state: &state)

--- a/Application/DevLogPresentation/Sources/Home/List/TodoListView.swift
+++ b/Application/DevLogPresentation/Sources/Home/List/TodoListView.swift
@@ -171,7 +171,7 @@ struct TodoListView: View {
                 }
                 .offset(y: headerOffset)
             }
-            .refreshable { store.send(.view(.refresh)) }
+            .refreshable { await store.send(.view(.refresh)).finish() }
             .scrollDisabled(visibleTodos.isEmpty || store.state.isLoading)
 
             if store.state.isLoading {

--- a/Application/DevLogPresentation/Sources/Profile/ProfileFeature.swift
+++ b/Application/DevLogPresentation/Sources/Profile/ProfileFeature.swift
@@ -108,10 +108,11 @@ struct ProfileFeature {
                 if !settings.isEmpty {
                     state.selectedActivityKinds = settings
                 }
+                let showsIndicator = if case .fetchData = action { true } else { false }
                 if let selectedQuarterStart = state.selectedQuarterStart {
                     return .merge(
                         fetchUserDataEffect(),
-                        fetchActivityQuarterEffect(selectedQuarterStart)
+                        fetchActivityQuarterEffect(selectedQuarterStart, showsIndicator: showsIndicator)
                     )
                 }
                 return fetchUserDataEffect()
@@ -220,9 +221,14 @@ private extension ProfileFeature {
         }
     }
 
-    func fetchActivityQuarterEffect(_ quarterStart: Date) -> Effect<Action> {
+    func fetchActivityQuarterEffect(
+        _ quarterStart: Date,
+        showsIndicator: Bool = true
+    ) -> Effect<Action> {
         .run { [fetchTodosUseCase] send in
-            await send(.loading(.begin(target: .default, mode: .delayed)))
+            if showsIndicator {
+                await send(.loading(.begin(target: .default, mode: .delayed)))
+            }
             do {
                 let data = try await ProfileHeatmapBuilder.fetchQuarterActivityData(
                     from: quarterStart,
@@ -237,9 +243,13 @@ private extension ProfileFeature {
                         )
                     )
                 )
-                await send(.loading(.end(target: .default, mode: .delayed)))
+                if showsIndicator {
+                    await send(.loading(.end(target: .default, mode: .delayed)))
+                }
             } catch {
-                await send(.loading(.end(target: .default, mode: .delayed)))
+                if showsIndicator {
+                    await send(.loading(.end(target: .default, mode: .delayed)))
+                }
                 await send(.setAlert(true))
             }
         }

--- a/Application/DevLogPresentation/Sources/PushNotification/PushNotificationListFeature.swift
+++ b/Application/DevLogPresentation/Sources/PushNotification/PushNotificationListFeature.swift
@@ -153,7 +153,12 @@ private extension PushNotificationListFeature {
         switch action {
         case .refresh:
             state.nextCursor = nil
-            return fetchNotificationsPageEffect(query: state.query, cursor: nil, showsIndicator: false)
+            return fetchNotificationsEffect(
+                query: state.query,
+                cursor: nil,
+                existingCount: 0,
+                showsIndicator: false
+            )
         case .fetchNotifications:
             state.nextCursor = nil
             return fetchNotificationsEffect(query: state.query, cursor: nil, existingCount: 0)
@@ -270,10 +275,11 @@ private extension PushNotificationListFeature {
     func fetchNotificationsEffect(
         query: PushNotificationQuery,
         cursor: PushNotificationCursor?,
-        existingCount: Int
+        existingCount: Int,
+        showsIndicator: Bool = true
     ) -> Effect<Action> {
         let limit = max(query.pageSize, existingCount)
-        let fetchEffect = fetchNotificationsPageEffect(query: query, cursor: cursor)
+        let fetchEffect = fetchNotificationsPageEffect(query: query, cursor: cursor, showsIndicator: showsIndicator)
         let observeEffect = observeNotificationsEffect(
             query: query,
             limit: max(limit, existingCount + query.pageSize)

--- a/Application/DevLogPresentation/Sources/PushNotification/PushNotificationListFeature.swift
+++ b/Application/DevLogPresentation/Sources/PushNotification/PushNotificationListFeature.swift
@@ -58,6 +58,7 @@ struct PushNotificationListFeature {
         case loading(LoadingFeature.Action)
 
         enum ViewAction: Equatable {
+            case refresh
             case fetchNotifications
             case loadNextPage
             case deleteNotification(PushNotificationItem)
@@ -83,7 +84,6 @@ struct PushNotificationListFeature {
             case syncNotifications([PushNotificationItem], nextCursor: PushNotificationCursor?, hasMore: Bool)
             case setNotificationHidden(String, Bool)
             case setNotificationRead(String, Bool)
-            case observeNotifications(PushNotificationQuery, Int)
         }
     }
 
@@ -151,6 +151,9 @@ private extension PushNotificationListFeature {
         state: inout State
     ) -> Effect<Action> {
         switch action {
+        case .refresh:
+            state.nextCursor = nil
+            return fetchNotificationsPageEffect(query: state.query, cursor: nil)
         case .fetchNotifications:
             state.nextCursor = nil
             return fetchNotificationsEffect(query: state.query, cursor: nil, existingCount: 0)
@@ -252,8 +255,6 @@ private extension PushNotificationListFeature {
             if let index = state.notifications.firstIndex(where: { $0.id == notificationId }) {
                 state.notifications[index].isRead = isRead
             }
-        case .observeNotifications(let query, let limit):
-            return observeNotificationsEffect(query: query, limit: limit)
         }
 
         return .none
@@ -272,7 +273,28 @@ private extension PushNotificationListFeature {
         existingCount: Int
     ) -> Effect<Action> {
         let limit = max(query.pageSize, existingCount)
-        let fetchEffect: Effect<Action> = .run { [fetchPushNotificationsUseCase] send in
+        let fetchEffect = fetchNotificationsPageEffect(query: query, cursor: cursor)
+        let observeEffect = observeNotificationsEffect(
+            query: query,
+            limit: max(limit, existingCount + query.pageSize)
+        )
+
+        if cursor == nil {
+            return .concatenate(
+                .cancel(id: CancelID.observeNotifications),
+                fetchEffect,
+                observeEffect
+            )
+        }
+
+        return fetchEffect
+    }
+
+    func fetchNotificationsPageEffect(
+        query: PushNotificationQuery,
+        cursor: PushNotificationCursor?
+    ) -> Effect<Action> {
+        .run { [fetchPushNotificationsUseCase] send in
             await send(.loading(.begin(target: .default, mode: .delayed)))
             do {
                 let page = try await fetchPushNotificationsUseCase.execute(query, cursor: cursor)
@@ -286,7 +308,6 @@ private extension PushNotificationListFeature {
                     ))
                 )
                 await send(.store(.setHasMore(page.items.count == query.pageSize && page.nextCursor != nil)))
-                await send(.store(.observeNotifications(query, max(limit, existingCount + page.items.count))))
                 await send(.loading(.end(target: .default, mode: .delayed)))
             } catch {
                 await send(.loading(.end(target: .default, mode: .delayed)))
@@ -294,15 +315,6 @@ private extension PushNotificationListFeature {
             }
         }
         .cancellable(id: CancelID.fetchNotifications, cancelInFlight: true)
-
-        if cursor == nil {
-            return .concatenate(
-                .cancel(id: CancelID.observeNotifications),
-                fetchEffect
-            )
-        }
-
-        return fetchEffect
     }
 
     func observeNotificationsEffect(

--- a/Application/DevLogPresentation/Sources/PushNotification/PushNotificationListFeature.swift
+++ b/Application/DevLogPresentation/Sources/PushNotification/PushNotificationListFeature.swift
@@ -153,7 +153,7 @@ private extension PushNotificationListFeature {
         switch action {
         case .refresh:
             state.nextCursor = nil
-            return fetchNotificationsPageEffect(query: state.query, cursor: nil)
+            return fetchNotificationsPageEffect(query: state.query, cursor: nil, showsIndicator: false)
         case .fetchNotifications:
             state.nextCursor = nil
             return fetchNotificationsEffect(query: state.query, cursor: nil, existingCount: 0)
@@ -292,10 +292,13 @@ private extension PushNotificationListFeature {
 
     func fetchNotificationsPageEffect(
         query: PushNotificationQuery,
-        cursor: PushNotificationCursor?
+        cursor: PushNotificationCursor?,
+        showsIndicator: Bool = true
     ) -> Effect<Action> {
         .run { [fetchPushNotificationsUseCase] send in
-            await send(.loading(.begin(target: .default, mode: .delayed)))
+            if showsIndicator {
+                await send(.loading(.begin(target: .default, mode: .delayed)))
+            }
             do {
                 let page = try await fetchPushNotificationsUseCase.execute(query, cursor: cursor)
                 if cursor == nil {
@@ -308,9 +311,13 @@ private extension PushNotificationListFeature {
                     ))
                 )
                 await send(.store(.setHasMore(page.items.count == query.pageSize && page.nextCursor != nil)))
-                await send(.loading(.end(target: .default, mode: .delayed)))
+                if showsIndicator {
+                    await send(.loading(.end(target: .default, mode: .delayed)))
+                }
             } catch {
-                await send(.loading(.end(target: .default, mode: .delayed)))
+                if showsIndicator {
+                    await send(.loading(.end(target: .default, mode: .delayed)))
+                }
                 await send(.store(.setAlert))
             }
         }

--- a/Application/DevLogPresentation/Sources/PushNotification/PushNotificationListView.swift
+++ b/Application/DevLogPresentation/Sources/PushNotification/PushNotificationListView.swift
@@ -38,7 +38,7 @@ struct PushNotificationListView: View {
                     headerOffset = max(0, -offset)
                 }
                 .safeAreaInset(edge: .top) { safeAreaHeader }
-                .refreshable { store.send(.view(.fetchNotifications)) }
+                .refreshable { await store.send(.view(.refresh)).finish() }
                 .navigationTitle(String(localized: "nav_push_notifications"))
                 .listStyle(.plain)
         }

--- a/Application/DevLogPresentation/Sources/Today/TodayFeature.swift
+++ b/Application/DevLogPresentation/Sources/Today/TodayFeature.swift
@@ -185,7 +185,9 @@ struct TodayFeature {
                 return updateDisplayOptionsEffect(state.displayOptions)
             case .binding:
                 break
-            case .refresh, .fetchData:
+            case .refresh:
+                return fetchTodosEffect(showsIndicator: false)
+            case .fetchData:
                 return fetchTodosEffect()
             case .setSectionScope(let scope):
                 if state.selectedSectionScope == scope, scope != .all {
@@ -255,9 +257,11 @@ private enum UpdateTodayDisplayOptionsUseCaseKey: DependencyKey {
 }
 
 private extension TodayFeature {
-    func fetchTodosEffect() -> Effect<Action> {
+    func fetchTodosEffect(showsIndicator: Bool = true) -> Effect<Action> {
         .run { [fetchTodosUseCase] send in
-            await send(.loading(.begin(target: .default, mode: .delayed)))
+            if showsIndicator {
+                await send(.loading(.begin(target: .default, mode: .delayed)))
+            }
             do {
                 async let todosWithDueDatePage = fetchTodosUseCase.execute(
                     TodoQuery(
@@ -284,9 +288,13 @@ private extension TodayFeature {
                 let todosWithDueDate = try await todosWithDueDatePage.items.compactMap(TodayTodoItem.init(from:))
                 let todosWithoutDueDate = try await todosWithoutDueDatePage.items.compactMap(TodayTodoItem.init(from:))
                 await send(.store(.setTodos(todosWithDueDate + todosWithoutDueDate)))
-                await send(.loading(.end(target: .default, mode: .delayed)))
+                if showsIndicator {
+                    await send(.loading(.end(target: .default, mode: .delayed)))
+                }
             } catch {
-                await send(.loading(.end(target: .default, mode: .delayed)))
+                if showsIndicator {
+                    await send(.loading(.end(target: .default, mode: .delayed)))
+                }
                 await send(.store(.setAlert))
             }
         }

--- a/Application/DevLogPresentation/Sources/Today/TodayView.swift
+++ b/Application/DevLogPresentation/Sources/Today/TodayView.swift
@@ -39,7 +39,7 @@ struct TodayView: View {
         .navigationTitle(String(localized: "nav_today"))
         .toolbar { toolbarContent }
         .background(NavigationBarConfigurator())
-        .refreshable { store.send(.refresh) }
+        .refreshable { await store.send(.refresh).finish() }
         .alert($store.scope(state: \.alert, action: \.alert))
         .overlay {
             if store.isLoading {


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #598

## 🎯 의도

- pull-to-refresh 중 SwiftUI 자체 refresh indicator와 화면 overlay `LoadingView`가 함께 표시되는 중복 로딩 UI를 정리

## 📝 작업 내용

### 📌 요약

- `refreshable`에서 호출하는 액션은 effect 완료까지 기다리도록 `await store.send(...).finish()` 적용
- pull-to-refresh 경로에서는 overlay `LoadingView`를 띄우지 않도록 fetch effect에 `showsIndicator` 옵션 추가
- `PushNotificationListFeature`는 초기 fetch와 refresh 액션을 분리하고, 알림 관찰 effect는 초기 fetch 이후에 이어서 실행되도록 정리

### 🔍 상세

- `TodayView`, `TodoListView`, `PushNotificationListView`의 `refreshable` 호출을 async 완료 대기 방식으로 변경
- `TodayFeature`, `TodoListFeature`, `ProfileFeature`, `PushNotificationListFeature`의 fetch effect에 `showsIndicator` 파라미터를 추가해 일반 fetch와 refresh fetch의 loading 표시 정책을 분리
- `refresh` 액션에서는 `showsIndicator: false`를 전달해 SwiftUI refresh indicator만 표시되도록 처리
- `PushNotificationListFeature`에서 `.refresh`는 첫 페이지 재조회만 수행하고, `.fetchNotifications`는 첫 페이지 fetch 이후 observe 재연결까지 수행하도록 역할 분리
- `fetchNotificationsPageEffect`를 분리해 refresh와 초기 fetch가 같은 페이지 조회 로직을 공유하도록 정리

## 📸 영상 / 이미지 (Optional)