### PR TITLE
[#630] Presentation 레이어의 ci 테스트에 걸리는 시간을 개선한다

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,8 +224,10 @@ jobs:
         include:
           - name: Domain-Data
             schemes: "DevLogDomain DevLogData"
-          - name: Persistence-Presentation
-            schemes: "DevLogPersistence DevLogPresentation"
+          - name: Persistence
+            schemes: "DevLogPersistence"
+          - name: Presentation
+            schemes: "DevLogPresentation"
           - name: Widget
             schemes: "DevLogWidget DevLogWidgetCore"
     steps:

--- a/Application/DevLogPresentation/Tests/Settings/AccountFeatureTests.swift
+++ b/Application/DevLogPresentation/Tests/Settings/AccountFeatureTests.swift
@@ -98,8 +98,6 @@ struct AccountFeatureTests {
             $0.unlinkAuthProviderUseCase = UnlinkAuthProviderUseCaseSpy()
             $0.continuousClock = clock
         }
-        store.exhaustivity = .off(showSkippedAssertions: false)
-
         await store.send(.linkWithProvider(.github)) {
             $0.activeLoadingProvider = .github
         }

--- a/Application/DevLogPresentation/Tests/Settings/AccountFeatureTests.swift
+++ b/Application/DevLogPresentation/Tests/Settings/AccountFeatureTests.swift
@@ -5,6 +5,8 @@
 //  Created by opfic on 6/11/26.
 //
 
+// swiftlint:disable file_length
+
 import Testing
 import ComposableArchitecture
 import Foundation
@@ -87,38 +89,53 @@ struct AccountFeatureTests {
         )
         let linkSpy = LinkAuthProviderUseCaseSpy()
         linkSpy.shouldSuspend = true
-        let driver = AccountTestDriver(
-            fetchUseCase: fetchSpy,
-            linkUseCase: linkSpy,
-            configureDependencies: {
-                $0.continuousClock = clock
-            }
-        )
-
-        driver.linkWithProvider(.github)
-
-        await waitUntil {
-            linkSpy.providers == [.github]
+        let target = LoadingFeature.Target.default
+        let store = TestStore(initialState: AccountFeature.State()) {
+            AccountFeature()
+        } withDependencies: {
+            $0.fetchAuthProvidersUseCase = fetchSpy
+            $0.linkAuthProviderUseCase = linkSpy
+            $0.unlinkAuthProviderUseCase = UnlinkAuthProviderUseCaseSpy()
+            $0.continuousClock = clock
         }
+        store.exhaustivity = .off(showSkippedAssertions: false)
 
-        #expect(!driver.isLoading)
+        await store.send(.linkWithProvider(.github)) {
+            $0.activeLoadingProvider = .github
+        }
+        await store.receive(\.loading.begin) {
+            $0.loading.delayedCountByTarget[target] = 1
+            $0.loading.scheduledDelayedTargets = [target]
+        }
+        #expect(linkSpy.providers == [.github])
+        #expect(!store.state.isLoading)
 
         await clock.advance(by: .milliseconds(300))
-
-        await waitUntil {
-            driver.isLoading
+        await store.receive(\.loading.delayedLoadingDidBecomeVisible, target) {
+            $0.loading.scheduledDelayedTargets = []
+            $0.loading.visibleDelayedTargets = [target]
+            $0.loading.visibleTargets = [target]
+            $0.loading.isLoading = true
         }
 
-        #expect(driver.isLoading)
-        #expect(driver.activeLoadingProvider == .github)
+        #expect(store.state.isLoading)
+        #expect(store.state.activeLoadingProvider == .github)
 
         linkSpy.resume()
-
-        await waitUntil {
-            !driver.isLoading && fetchSpy.executeCallCount == 1
+        await store.receive(\.setProviders) {
+            $0.currentProvider = .google
+            $0.connectedProviders = [.github]
+            $0.disconnectedProviders = [.apple]
+        }
+        await store.receive(\.loading.end) {
+            $0.loading.delayedCountByTarget[target] = 0
+            $0.loading.visibleDelayedTargets = []
+            $0.loading.visibleTargets = []
+            $0.loading.isLoading = false
+            $0.activeLoadingProvider = nil
         }
 
-        #expect(!driver.isLoading)
+        #expect(!store.state.isLoading)
     }
 
     @Test("인증 제공자 조회에 실패하면 공통 에러 알림을 표시한다")
@@ -253,10 +270,6 @@ private struct AccountTestDriver {
         feature.state.isLoading
     }
 
-    var activeLoadingProvider: AuthProvider? {
-        feature.state.activeLoadingProvider
-    }
-
     var alert: AlertState<Never>? {
         feature.state.alert
     }
@@ -264,8 +277,7 @@ private struct AccountTestDriver {
     init(
         fetchUseCase: FetchAuthProvidersUseCase = FetchAuthProvidersUseCaseSpy(),
         linkUseCase: LinkAuthProviderUseCase = LinkAuthProviderUseCaseSpy(),
-        unlinkUseCase: UnlinkAuthProviderUseCase = UnlinkAuthProviderUseCaseSpy(),
-        configureDependencies: ((inout DependencyValues) -> Void)? = nil
+        unlinkUseCase: UnlinkAuthProviderUseCase = UnlinkAuthProviderUseCaseSpy()
     ) {
         feature = Store(initialState: AccountFeature.State()) {
             AccountFeature()
@@ -274,7 +286,6 @@ private struct AccountTestDriver {
             $0.linkAuthProviderUseCase = linkUseCase
             $0.unlinkAuthProviderUseCase = unlinkUseCase
             $0.continuousClock = ContinuousClock()
-            configureDependencies?(&$0)
         }
     }
 


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #630

## 🎯 의도

CI에서 `Persistence-Presentation` 테스트 job이 병목이 되는 문제 완화

## 📝 작업 내용

### 📌 요약

- `DevLogPersistence`와 `DevLogPresentation` 테스트 job 분리
- `AccountFeatureTests`의 지연 로딩 테스트에서 `waitUntil` 폴링 제거
- `TestStore.receive` 기반 액션 검증으로 테스트 대기 시간 단축

### 🔍 상세

- `.github/workflows/ci.yml`의 `Persistence-Presentation` matrix를 `Persistence`, `Presentation`으로 분리
- `AccountFeatureTests`의 `연동 작업이 지연되면 로딩 상태를 표시하고 완료되면 해제한다` 테스트를 `AccountTestDriver` 기반 상태 폴링에서 `TestStore` 기반 액션 수신 검증으로 변경
- `loading.begin`, `loading.delayedLoadingDidBecomeVisible`, `setProviders`, `loading.end` 액션 순서를 직접 검증하도록 수정
- 변경 파일 SwiftLint 검증 완료
- `DevLogPresentationTests/AccountFeatureTests` 단독 테스트 통과

## 📸 영상 / 이미지 (Optional)
