### PR TITLE
[#634] Watcher 자동화를 구성한다

### DIFF
--- a/.github/workflows/merge-risk-watch.yml
+++ b/.github/workflows/merge-risk-watch.yml
@@ -1,0 +1,45 @@
+name: Merge Risk Watch
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+  schedule:
+    - cron: "0 15 * * 0-4"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read
+  checks: read
+  pull-requests: read
+
+jobs:
+  watch:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
+    uses: opficdev/Watcher/.github/workflows/merge-risk-watch.yml@0.1.0
+    with:
+      repository: ${{ github.repository }}
+      base_branch: develop
+      default_branch: main
+      critical_file_patterns: |
+        .github/workflows/**
+        .github/actions/**
+        .mise.toml
+        .package.resolved
+        Gemfile.lock
+        Tuist.swift
+        Workspace.swift
+        Tuist/ProjectDescriptionHelpers/**
+        Application/**/Project.swift
+        Application/Shared/**
+        Widget/**/Project.swift
+        fastlane/**
+        **/*.xcstrings
+    secrets:
+      watcher_github_token: ${{ secrets.WATCHER_GITHUB_TOKEN }}
+      gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
+      discord_webhook_url: ${{ secrets.DISCORD_WEBHOOK_URL }}

--- a/.github/workflows/merge-risk-watch.yml
+++ b/.github/workflows/merge-risk-watch.yml
@@ -1,12 +1,6 @@
 name: Merge Risk Watch
 
 on:
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
   schedule:
     - cron: "0 15 * * 0-4"
   workflow_dispatch:


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #634

## 🎯 의도

PR/branch 간 merge conflict 가능성을 GitHub Actions에서 주기적으로 감시하기 위한 Watcher workflow 추가

## 📝 작업 내용

### 📌 요약

- `opficdev/Watcher` reusable workflow 호출용 `Merge Risk Watch` workflow 추가
- `develop` 기준 branch 감시와 `main` 제외 설정 추가
- DevLog_iOS에서 충돌 위험이 큰 workflow, Tuist, Fastlane, version, localization 파일군을 `critical_file_patterns`로 지정

### 🔍 상세

- `pull_request`, `schedule`, `workflow_dispatch` trigger 구성
- `contents`, `actions`, `checks`, `pull-requests` read permission 설정
- `WATCHER_GITHUB_TOKEN`, `GEMINI_API_KEY`, `DISCORD_WEBHOOK_URL` secret 전달 구성
- `opficdev/Watcher/.github/workflows/merge-risk-watch.yml@0.1.0` release tag 고정

## 📸 영상 / 이미지 (Optional)
