### PR TITLE
[#636] macOS에서는 토스트가 상단에 뜨도록 수정한다

### DIFF
--- a/Application/DevLogPresentation/Sources/Common/Component/Toast.swift
+++ b/Application/DevLogPresentation/Sources/Common/Component/Toast.swift
@@ -88,6 +88,7 @@ private struct ToastHostModifier: ViewModifier {
     @Environment(\.safeAreaInsets) private var safeAreaInsets
     @State private var tabBarHeight = CGFloat.zero
     private let toastPresenter = ToastPresenter.presenter
+    private let placement = ToastPresentationPlacement.current
 
     func body(content: Content) -> some View {
         content
@@ -98,7 +99,7 @@ private struct ToastHostModifier: ViewModifier {
             .onChange(of: toastPresenter.item?.id) { _, _ in
                 updateTabBarHeight()
             }
-            .overlay(alignment: .bottom) {
+            .overlay(alignment: placement.alignment) {
                 if let item = toastPresenter.item {
                     ToastOverlayView(
                         isPresented: Binding(
@@ -110,6 +111,7 @@ private struct ToastHostModifier: ViewModifier {
                             }
                         ),
                         duration: item.duration,
+                        presentedOffset: placement.presentedOffset,
                         action: item.action,
                         onDismiss: item.onDismiss
                     ) {
@@ -117,7 +119,7 @@ private struct ToastHostModifier: ViewModifier {
                     }
                     .id(item.id)
                     .padding(.horizontal, 12)
-                    .padding(.bottom, toastBottomInset)
+                    .padding(.bottom, placement.bottomPadding(toastBottomInset))
                 }
             }
     }
@@ -141,6 +143,42 @@ private struct ToastHostModifier: ViewModifier {
     }
 }
 
+private enum ToastPresentationPlacement {
+    case top
+    case bottom
+
+    static var current: ToastPresentationPlacement {
+        ProcessInfo.processInfo.isiOSAppOnMac ? .top : .bottom
+    }
+
+    var alignment: Alignment {
+        switch self {
+        case .top:
+            return .top
+        case .bottom:
+            return .bottom
+        }
+    }
+
+    var presentedOffset: CGFloat {
+        switch self {
+        case .top:
+            return 50
+        case .bottom:
+            return -50
+        }
+    }
+
+    func bottomPadding(_ inset: CGFloat) -> CGFloat {
+        switch self {
+        case .top:
+            return 0
+        case .bottom:
+            return inset
+        }
+    }
+}
+
 private struct ToastItemLabel: View {
     let item: ToastItem
 
@@ -161,6 +199,7 @@ private struct ToastItemLabel: View {
 private struct ToastOverlayView<Label: View>: View {
     @Binding var isPresented: Bool
     let duration: TimeInterval
+    let presentedOffset: CGFloat
     let action: (() -> Void)?
     let onDismiss: (() -> Void)?
     @ViewBuilder let label: () -> Label
@@ -209,7 +248,7 @@ private struct ToastOverlayView<Label: View>: View {
         guard opacityValue == 0 else { return }
 
         withAnimation(.spring(response: 0.5, dampingFraction: 1, blendDuration: 0.0)) {
-            yOffset = -50
+            yOffset = presentedOffset
             opacityValue = 1
         }
     }


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #636

## 🎯 의도

Apple Silicon Mac 환경에서 토스트가 화면 하단이 아니라 상단에서 아래 방향으로 표시되도록 동작 분기

## 📝 작업 내용

### 📌 요약

- 토스트 표시 위치를 실행 환경에 따라 결정하는 `ToastPresentationPlacement` 추가
- iOS/iPadOS에서는 기존 하단 표시 유지
- Mac 환경에서는 상단 정렬 및 아래 방향 표시 애니메이션 적용

### 🔍 상세

- `ToastHostModifier`의 overlay alignment를 고정 `.bottom`에서 placement 기반 alignment로 변경
- 토스트 표시 offset을 고정 `-50`에서 placement 기반 offset으로 변경
- Mac 환경에서는 tab bar 보정용 bottom padding 미적용

## 📸 영상 / 이미지 (Optional)

<img width="1680" height="1020" alt="image" src="https://github.com/user-attachments/assets/cf56eb9d-44b3-4871-95af-29c8dde3181e" />
