### PR TITLE
[#639] Watcher의 설정을 수정한다

### DIFF
--- a/.github/workflows/merge-risk-watch.yml
+++ b/.github/workflows/merge-risk-watch.yml
@@ -19,6 +19,7 @@ jobs:
       repository: ${{ github.repository }}
       base_branch: develop
       default_branch: main
+      github_app_client_id: ${{ vars.WATCHER_GITHUB_APP_CLIENT_ID }}
       critical_file_patterns: |
         .github/workflows/**
         .github/actions/**
@@ -34,6 +35,6 @@ jobs:
         fastlane/**
         **/*.xcstrings
     secrets:
-      watcher_github_token: ${{ secrets.WATCHER_GITHUB_TOKEN }}
+      watcher_github_app_private_key: ${{ secrets.WATCHER_GITHUB_APP_PRIVATE_KEY }}
       openai_api_key: ${{ secrets.OPENAI_API_KEY }}
       discord_webhook_url: ${{ secrets.DISCORD_WEBHOOK_URL }}

--- a/.github/workflows/merge-risk-watch.yml
+++ b/.github/workflows/merge-risk-watch.yml
@@ -7,14 +7,11 @@ on:
 
 permissions:
   contents: read
-  actions: read
-  checks: read
-  pull-requests: read
 
 jobs:
   watch:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
-    uses: opficdev/Watcher/.github/workflows/merge-risk-watch.yml@0.1.0
+    uses: opficdev/Watcher/.github/workflows/merge-risk-watch.yml@0.2.0
     with:
       repository: ${{ github.repository }}
       base_branch: develop

--- a/.github/workflows/merge-risk-watch.yml
+++ b/.github/workflows/merge-risk-watch.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   watch:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
-    uses: opficdev/Watcher/.github/workflows/merge-risk-watch.yml@0.2.0
+    uses: opficdev/Watcher/.github/workflows/merge-risk-watch.yml@0.2.1
     with:
       repository: ${{ github.repository }}
       base_branch: develop

--- a/.github/workflows/merge-risk-watch.yml
+++ b/.github/workflows/merge-risk-watch.yml
@@ -35,5 +35,5 @@ jobs:
         **/*.xcstrings
     secrets:
       watcher_github_token: ${{ secrets.WATCHER_GITHUB_TOKEN }}
-      gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
+      openai_api_key: ${{ secrets.OPENAI_API_KEY }}
       discord_webhook_url: ${{ secrets.DISCORD_WEBHOOK_URL }}

--- a/.github/workflows/merge-risk-watch.yml
+++ b/.github/workflows/merge-risk-watch.yml
@@ -19,7 +19,6 @@ jobs:
       repository: ${{ github.repository }}
       base_branch: develop
       default_branch: main
-      github_app_client_id: ${{ vars.WATCHER_GITHUB_APP_CLIENT_ID }}
       critical_file_patterns: |
         .github/workflows/**
         .github/actions/**
@@ -35,6 +34,6 @@ jobs:
         fastlane/**
         **/*.xcstrings
     secrets:
-      watcher_github_app_private_key: ${{ secrets.WATCHER_GITHUB_APP_PRIVATE_KEY }}
+      watcher_github_token: ${{ secrets.WATCHER_GITHUB_TOKEN }}
       openai_api_key: ${{ secrets.OPENAI_API_KEY }}
       discord_webhook_url: ${{ secrets.DISCORD_WEBHOOK_URL }}

--- a/.github/workflows/merge-risk-watch.yml
+++ b/.github/workflows/merge-risk-watch.yml
@@ -2,7 +2,7 @@ name: Merge Risk Watch
 
 on:
   schedule:
-    - cron: "0 15 * * 0-4"
+    - cron: "30 15 * * 0-4"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## 🔗 연관된 이슈
- closed #639

## 🎯 의도

Watcher 0.2.1의 PAT 기반 실행 방식과 OpenAI prediction 설정을 DevLog_iOS merge risk workflow에 반영하기 위한 변경

## 📝 작업 내용

### 📌 요약

Merge Risk Watch workflow가 Watcher 0.2.1을 사용하고, `WATCHER_GITHUB_TOKEN`과 `OPENAI_API_KEY`를 전달하도록 수정

### 🔍 상세

- reusable workflow ref를 `opficdev/Watcher/.github/workflows/merge-risk-watch.yml@0.2.1`로 갱신
- `GEMINI_API_KEY` 전달 제거
- `openai_api_key` secret 전달 추가
- Watcher 0.2.1 기준으로 workflow permission을 `contents: read`만 남기도록 정리
- 기존 schedule 실행 시각을 `30 15 * * 0-4`로 조정

## 📸 영상 / 이미지 (Optional)

없음
