### PR TITLE
[#595] SearchView에서 '#' 만 입력했을 때 보여주는 뷰를 다르게 구성한다

### DIFF
--- a/Application/DevLogApp/Sources/Resource/Localizable.xcstrings
+++ b/Application/DevLogApp/Sources/Resource/Localizable.xcstrings
@@ -1595,7 +1595,7 @@
         }
       }
     },
-    "search_todo_number_instruction_message" : {
+    "search_hash_guide_message" : {
       "extractionState" : "manual",
       "localizations" : {
         "en" : {
@@ -1612,7 +1612,7 @@
         }
       }
     },
-    "search_todo_number_instruction_title" : {
+    "search_hash_guide_title" : {
       "extractionState" : "manual",
       "localizations" : {
         "en" : {

--- a/Application/DevLogApp/Sources/Resource/Localizable.xcstrings
+++ b/Application/DevLogApp/Sources/Resource/Localizable.xcstrings
@@ -1595,6 +1595,40 @@
         }
       }
     },
+    "search_todo_number_instruction_message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Type like #123 to find that Todo directly."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "#123처럼 입력하면 해당 Todo를 바로 찾을 수 있습니다."
+          }
+        }
+      }
+    },
+    "search_todo_number_instruction_title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enter a Todo number"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Todo 번호를 입력해주세요"
+          }
+        }
+      }
+    },
     "settings_account" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Application/DevLogPresentation/Sources/Search/SearchFeature.swift
+++ b/Application/DevLogPresentation/Sources/Search/SearchFeature.swift
@@ -58,8 +58,8 @@ struct SearchFeature {
             !showAllWebPages && contentsLimit < webPages.count
         }
 
-        var showsTodoNumberSearchInstruction: Bool {
-            SearchFeature.showsTodoNumberSearchInstruction(searchQuery)
+        var isHashOnlyQuery: Bool {
+            SearchFeature.isHashOnlyQuery(searchQuery)
         }
     }
 
@@ -116,7 +116,7 @@ struct SearchFeature {
                     state.webPages = []
                     state.todos = []
                     return Self.cancelSearchEffect(isLoading: state.isLoading)
-                } else if Self.showsTodoNumberSearchInstruction(trimmed) {
+                } else if Self.isHashOnlyQuery(trimmed) {
                     state.webPages = []
                     state.todos = []
                     return Self.cancelSearchEffect(isLoading: state.isLoading)
@@ -153,7 +153,7 @@ struct SearchFeature {
                     state.webPages = []
                     state.todos = []
                     return Self.cancelSearchEffect(isLoading: state.isLoading)
-                } else if Self.showsTodoNumberSearchInstruction(trimmed) {
+                } else if Self.isHashOnlyQuery(trimmed) {
                     state.webPages = []
                     state.todos = []
                     return Self.cancelSearchEffect(isLoading: state.isLoading)
@@ -289,7 +289,7 @@ private extension SearchFeature {
         query.trimmingCharacters(in: .whitespacesAndNewlines).hasPrefix("#")
     }
 
-    static func showsTodoNumberSearchInstruction(_ query: String) -> Bool {
+    static func isHashOnlyQuery(_ query: String) -> Bool {
         query.trimmingCharacters(in: .whitespacesAndNewlines) == "#"
     }
 

--- a/Application/DevLogPresentation/Sources/Search/SearchFeature.swift
+++ b/Application/DevLogPresentation/Sources/Search/SearchFeature.swift
@@ -57,6 +57,10 @@ struct SearchFeature {
         var shouldShowMoreWebPages: Bool {
             !showAllWebPages && contentsLimit < webPages.count
         }
+
+        var showsTodoNumberSearchInstruction: Bool {
+            SearchFeature.showsTodoNumberSearchInstruction(searchQuery)
+        }
     }
 
     enum Action: BindableAction, Equatable {
@@ -112,6 +116,10 @@ struct SearchFeature {
                     state.webPages = []
                     state.todos = []
                     return Self.cancelSearchEffect(isLoading: state.isLoading)
+                } else if Self.showsTodoNumberSearchInstruction(trimmed) {
+                    state.webPages = []
+                    state.todos = []
+                    return Self.cancelSearchEffect(isLoading: state.isLoading)
                 } else {
                     return .concatenate(
                         Self.cancelSearchEffect(isLoading: state.isLoading),
@@ -142,6 +150,10 @@ struct SearchFeature {
             case .store(.applySearchQuery(let query)):
                 let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
                 if trimmed.isEmpty {
+                    state.webPages = []
+                    state.todos = []
+                    return Self.cancelSearchEffect(isLoading: state.isLoading)
+                } else if Self.showsTodoNumberSearchInstruction(trimmed) {
                     state.webPages = []
                     state.todos = []
                     return Self.cancelSearchEffect(isLoading: state.isLoading)
@@ -275,6 +287,10 @@ private extension SearchFeature {
 
     static func searchesTodoOnly(_ query: String) -> Bool {
         query.trimmingCharacters(in: .whitespacesAndNewlines).hasPrefix("#")
+    }
+
+    static func showsTodoNumberSearchInstruction(_ query: String) -> Bool {
+        query.trimmingCharacters(in: .whitespacesAndNewlines) == "#"
     }
 
     static func fetchWebPageItems(

--- a/Application/DevLogPresentation/Sources/Search/SearchFeature.swift
+++ b/Application/DevLogPresentation/Sources/Search/SearchFeature.swift
@@ -59,7 +59,7 @@ struct SearchFeature {
         }
 
         var isHashOnlyQuery: Bool {
-            SearchFeature.isHashOnlyQuery(searchQuery)
+            searchQuery.trimmingCharacters(in: .whitespacesAndNewlines) == "#"
         }
     }
 
@@ -112,11 +112,7 @@ struct SearchFeature {
                 state.showAllTodos = false
                 state.showAllWebPages = false
                 let trimmed = state.searchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
-                if trimmed.isEmpty {
-                    state.webPages = []
-                    state.todos = []
-                    return Self.cancelSearchEffect(isLoading: state.isLoading)
-                } else if Self.isHashOnlyQuery(trimmed) {
+                if trimmed.isEmpty || trimmed == "#" {
                     state.webPages = []
                     state.todos = []
                     return Self.cancelSearchEffect(isLoading: state.isLoading)
@@ -149,11 +145,7 @@ struct SearchFeature {
                 return saveRecentQueriesEffect([])
             case .store(.applySearchQuery(let query)):
                 let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
-                if trimmed.isEmpty {
-                    state.webPages = []
-                    state.todos = []
-                    return Self.cancelSearchEffect(isLoading: state.isLoading)
-                } else if Self.isHashOnlyQuery(trimmed) {
+                if trimmed.isEmpty || trimmed == "#" {
                     state.webPages = []
                     state.todos = []
                     return Self.cancelSearchEffect(isLoading: state.isLoading)
@@ -244,20 +236,16 @@ private extension SearchFeature {
     }
 
     func fetchEffect(_ query: String, isLoading: Bool) -> Effect<Action> {
-        let searchesTodoOnly = Self.searchesTodoOnly(query)
+        let skipsWebPages = query.hasPrefix("#")
 
         return .run { [fetchTodosUseCase, fetchWebPagesUseCase] send in
             do {
                 async let todos = fetchTodosUseCase.execute(TodoQuery(keyword: query), cursor: nil)
-                async let webPageItems = Self.fetchWebPageItems(
-                    query: query,
-                    searchesTodoOnly: searchesTodoOnly,
-                    fetchWebPagesUseCase: fetchWebPagesUseCase
-                )
+                let webPages = skipsWebPages ? [] : try await fetchWebPagesUseCase.execute(query)
                 let todoItems = try await todos.items.compactMap { TodoListItem(from: $0) }
-                let resolvedWebPageItems = try await webPageItems
+                let webPageItems = webPages.map { WebPageItem(from: $0) }
                 await send(.store(.fetchTodos(todoItems)))
-                await send(.store(.fetchWebPage(resolvedWebPageItems)))
+                await send(.store(.fetchWebPage(webPageItems)))
                 if isLoading {
                     await send(.loading(.end(target: .default, mode: .immediate)))
                 }
@@ -283,27 +271,6 @@ private extension SearchFeature {
         return .run { [updateRecentSearchQueriesUseCase] _ in
             updateRecentSearchQueriesUseCase.execute(values)
         }
-    }
-
-    static func searchesTodoOnly(_ query: String) -> Bool {
-        query.trimmingCharacters(in: .whitespacesAndNewlines).hasPrefix("#")
-    }
-
-    static func isHashOnlyQuery(_ query: String) -> Bool {
-        query.trimmingCharacters(in: .whitespacesAndNewlines) == "#"
-    }
-
-    static func fetchWebPageItems(
-        query: String,
-        searchesTodoOnly: Bool,
-        fetchWebPagesUseCase: FetchWebPagesUseCase
-    ) async throws -> [WebPageItem] {
-        if searchesTodoOnly {
-            return []
-        }
-
-        let webPages = try await fetchWebPagesUseCase.execute(query)
-        return webPages.map { WebPageItem(from: $0) }
     }
 
     static func alertState() -> AlertState<Never> {

--- a/Application/DevLogPresentation/Sources/Search/SearchView.swift
+++ b/Application/DevLogPresentation/Sources/Search/SearchView.swift
@@ -62,8 +62,8 @@ struct SearchView: View {
                         recentQueries
                     }
                 }
-            } else if store.showsTodoNumberSearchInstruction {
-                todoNumberSearchInstruction
+            } else if store.isHashOnlyQuery {
+                hashGuide
             } else if store.isLoading {
                 LoadingView()
             } else if store.webPages.isEmpty && store.todos.isEmpty {
@@ -106,13 +106,13 @@ struct SearchView: View {
         .frame(maxWidth: .infinity)
     }
 
-    private var todoNumberSearchInstruction: some View {
+    private var hashGuide: some View {
         VStack(spacing: 8) {
             Spacer()
-            Text(String(localized: "search_todo_number_instruction_title"))
+            Text(String(localized: "search_hash_guide_title"))
                 .font(.headline)
                 .foregroundStyle(Color(.label))
-            Text(String(localized: "search_todo_number_instruction_message"))
+            Text(String(localized: "search_hash_guide_message"))
                 .font(.subheadline)
                 .foregroundStyle(Color.gray)
                 .multilineTextAlignment(.center)

--- a/Application/DevLogPresentation/Sources/Search/SearchView.swift
+++ b/Application/DevLogPresentation/Sources/Search/SearchView.swift
@@ -62,6 +62,8 @@ struct SearchView: View {
                         recentQueries
                     }
                 }
+            } else if store.showsTodoNumberSearchInstruction {
+                todoNumberSearchInstruction
             } else if store.isLoading {
                 LoadingView()
             } else if store.webPages.isEmpty && store.todos.isEmpty {
@@ -101,6 +103,22 @@ struct SearchView: View {
                 .foregroundStyle(Color.gray)
             Spacer()
         }
+        .frame(maxWidth: .infinity)
+    }
+
+    private var todoNumberSearchInstruction: some View {
+        VStack(spacing: 8) {
+            Spacer()
+            Text(String(localized: "search_todo_number_instruction_title"))
+                .font(.headline)
+                .foregroundStyle(Color(.label))
+            Text(String(localized: "search_todo_number_instruction_message"))
+                .font(.subheadline)
+                .foregroundStyle(Color.gray)
+                .multilineTextAlignment(.center)
+            Spacer()
+        }
+        .padding(.horizontal, 24)
         .frame(maxWidth: .infinity)
     }
 

--- a/Application/DevLogPresentation/Tests/Search/SearchFeatureTestDoubles.swift
+++ b/Application/DevLogPresentation/Tests/Search/SearchFeatureTestDoubles.swift
@@ -24,7 +24,7 @@ struct SearchStoreTestAdapter {
     var recentQueries: [String] { Array(store.state.recentQueries) }
     var showAllTodos: Bool { store.state.showAllTodos }
     var showAllWebPages: Bool { store.state.showAllWebPages }
-    var showsTodoNumberSearchInstruction: Bool { store.state.showsTodoNumberSearchInstruction }
+    var isHashOnlyQuery: Bool { store.state.isHashOnlyQuery }
     var alert: AlertState<Never>? { store.state.alert }
 
     init(
@@ -101,7 +101,7 @@ struct SearchStoreTestAdapter {
             $0.searchQuery = query
             $0.showAllTodos = false
             $0.showAllWebPages = false
-            if trimmed.isEmpty || $0.showsTodoNumberSearchInstruction {
+            if trimmed.isEmpty || $0.isHashOnlyQuery {
                 $0.todos = []
                 $0.webPages = []
             }
@@ -109,7 +109,7 @@ struct SearchStoreTestAdapter {
         if wasLoading {
             await receiveEndLoading()
         }
-        if !trimmed.isEmpty && !store.state.showsTodoNumberSearchInstruction {
+        if !trimmed.isEmpty && !store.state.isHashOnlyQuery {
             await receiveBeginLoading()
         }
     }

--- a/Application/DevLogPresentation/Tests/Search/SearchFeatureTestDoubles.swift
+++ b/Application/DevLogPresentation/Tests/Search/SearchFeatureTestDoubles.swift
@@ -101,10 +101,7 @@ struct SearchStoreTestAdapter {
             $0.searchQuery = query
             $0.showAllTodos = false
             $0.showAllWebPages = false
-            if trimmed.isEmpty {
-                $0.todos = []
-                $0.webPages = []
-            } else if trimmed == "#" {
+            if trimmed.isEmpty || $0.showsTodoNumberSearchInstruction {
                 $0.todos = []
                 $0.webPages = []
             }
@@ -112,7 +109,7 @@ struct SearchStoreTestAdapter {
         if wasLoading {
             await receiveEndLoading()
         }
-        if !trimmed.isEmpty && trimmed != "#" {
+        if !trimmed.isEmpty && !store.state.showsTodoNumberSearchInstruction {
             await receiveBeginLoading()
         }
     }

--- a/Application/DevLogPresentation/Tests/Search/SearchFeatureTestDoubles.swift
+++ b/Application/DevLogPresentation/Tests/Search/SearchFeatureTestDoubles.swift
@@ -24,6 +24,7 @@ struct SearchStoreTestAdapter {
     var recentQueries: [String] { Array(store.state.recentQueries) }
     var showAllTodos: Bool { store.state.showAllTodos }
     var showAllWebPages: Bool { store.state.showAllWebPages }
+    var showsTodoNumberSearchInstruction: Bool { store.state.showsTodoNumberSearchInstruction }
     var alert: AlertState<Never>? { store.state.alert }
 
     init(
@@ -103,12 +104,15 @@ struct SearchStoreTestAdapter {
             if trimmed.isEmpty {
                 $0.todos = []
                 $0.webPages = []
+            } else if trimmed == "#" {
+                $0.todos = []
+                $0.webPages = []
             }
         }
         if wasLoading {
             await receiveEndLoading()
         }
-        if !trimmed.isEmpty {
+        if !trimmed.isEmpty && trimmed != "#" {
             await receiveBeginLoading()
         }
     }

--- a/Application/DevLogPresentation/Tests/Search/SearchFeatureTests.swift
+++ b/Application/DevLogPresentation/Tests/Search/SearchFeatureTests.swift
@@ -122,6 +122,30 @@ struct SearchFeatureTests {
         #expect(!adapter.isLoading)
     }
 
+    @Test("# 단독 검색어는 안내 상태로 전환하고 조회를 시작하지 않는다")
+    func 해시_단독_검색어는_안내_상태로_전환하고_조회를_시작하지_않는다() async {
+        let todo = TodoListItem(from: makeSearchTodo(id: "todo-1"))!
+        let webPage = WebPageItem(from: makeSearchWebPage(urlString: "https://swift.org"))
+        let todoSpy = SearchFetchTodosUseCaseSpy()
+        let webSpy = SearchFetchWebPagesUseCaseSpy()
+        let adapter = SearchStoreTestAdapter(
+            initialTodos: [todo],
+            initialWebPages: [webPage],
+            isLoading: true,
+            fetchWebPagesUseCase: webSpy,
+            fetchTodosUseCase: todoSpy
+        )
+
+        await adapter.setSearchQuery("#")
+
+        #expect(adapter.showsTodoNumberSearchInstruction)
+        #expect(adapter.todos.isEmpty)
+        #expect(adapter.webPages.isEmpty)
+        #expect(!adapter.isLoading)
+        #expect(todoSpy.queries.isEmpty)
+        #expect(webSpy.queries.isEmpty)
+    }
+
     @Test("# 검색어는 WebPage 조회를 생략하고 Todo만 반영한다")
     func 해시태그_검색어는_WebPage_조회를_생략하고_Todo만_반영한다() async {
         let todo = makeSearchTodo(id: "todo-1", title: "Issue")

--- a/Application/DevLogPresentation/Tests/Search/SearchFeatureTests.swift
+++ b/Application/DevLogPresentation/Tests/Search/SearchFeatureTests.swift
@@ -138,7 +138,7 @@ struct SearchFeatureTests {
 
         await adapter.setSearchQuery("#")
 
-        #expect(adapter.showsTodoNumberSearchInstruction)
+        #expect(adapter.isHashOnlyQuery)
         #expect(adapter.todos.isEmpty)
         #expect(adapter.webPages.isEmpty)
         #expect(!adapter.isLoading)


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #595

## 🎯 의도

- SearchView에서 `#`만 입력한 상태를 일반 검색 결과로 처리하지 않고, Todo 번호 검색을 이어서 입력하도록 안내하는 상태로 분리

## 📝 작업 내용

### 📌 요약

`#` 단독 입력 시 Todo/WebPage 조회를 시작하지 않고, Todo 번호 입력 안내 문구를 표시하도록 SearchView 검색 상태 개선

### 🔍 상세

- `#` 단독 입력 상태를 판별하는 `showsTodoNumberSearchInstruction` 상태 추가
- `#` 단독 입력 시 기존 검색 결과를 비우고 진행 중인 검색 요청을 취소하도록 처리
- SearchView에서 `#` 단독 입력 상태일 때 안내 뷰 표시
- 안내 문구 localization 추가
  - `Todo 번호를 입력해주세요`
  - `#123처럼 입력하면 해당 Todo를 바로 찾을 수 있습니다.`
- `#` 단독 입력 시 조회가 시작되지 않는 회귀 테스트 추가

## 📸 영상 / 이미지 (Optional)

<img width="300" alt="image" src="https://github.com/user-attachments/assets/44a1cb7d-34ca-4916-b7e2-e633741a3a30" />