### PR TITLE
[#596] SearchView에서 '#' 뒤 숫자를 입력했을 때 숫자 기반이 아닌 문자열 기반으로 검색하도록 수정한다

### DIFF
--- a/Application/DevLogInfra/Sources/Service/TodoServiceImpl.swift
+++ b/Application/DevLogInfra/Sources/Service/TodoServiceImpl.swift
@@ -167,8 +167,9 @@ final class TodoServiceImpl: TodoService {
             let snapshot = try await firestoreQuery.getDocuments()
             let todos = snapshot.documents.compactMap { makeResponse(from: $0) }
 
+            let numberKeyword = TodoResponse.normalizedNumberKeyword(from: trimmedKeyword) ?? trimmedKeyword
             let filtered = todos.filter { todo in
-                todo.matchesSearchKeyword(trimmedKeyword)
+                todo.matchesSearchKeyword(trimmedKeyword, numberKeyword: numberKeyword)
             }
 
             return TodoPageResponse(items: filtered, nextCursor: nil)
@@ -324,12 +325,12 @@ final class TodoServiceImpl: TodoService {
 }
 
 extension TodoResponse {
-    func matchesSearchKeyword(_ keyword: String) -> Bool {
-        let numberKeyword = normalizedNumberKeyword(from: keyword) ?? keyword
+    func matchesSearchKeyword(_ keyword: String, numberKeyword: String? = nil) -> Bool {
+        let resolvedNumberKeyword = numberKeyword ?? Self.normalizedNumberKeyword(from: keyword) ?? keyword
 
         if keyword.hasPrefix("#"),
            1 < keyword.count,
-           "#\(number)".localizedCaseInsensitiveContains(numberKeyword) {
+           "#\(number)".localizedCaseInsensitiveContains(resolvedNumberKeyword) {
             return true
         }
 
@@ -338,7 +339,7 @@ extension TodoResponse {
             || tags.contains { $0.localizedCaseInsensitiveContains(keyword) }
     }
 
-    private func normalizedNumberKeyword(from keyword: String) -> String? {
+    static func normalizedNumberKeyword(from keyword: String) -> String? {
         guard keyword.hasPrefix("#") else {
             return nil
         }

--- a/Application/DevLogInfra/Sources/Service/TodoServiceImpl.swift
+++ b/Application/DevLogInfra/Sources/Service/TodoServiceImpl.swift
@@ -325,15 +325,33 @@ final class TodoServiceImpl: TodoService {
 
 extension TodoResponse {
     func matchesSearchKeyword(_ keyword: String) -> Bool {
+        let numberKeyword = normalizedNumberKeyword(from: keyword) ?? keyword
+
         if keyword.hasPrefix("#"),
            1 < keyword.count,
-           "#\(number)".localizedCaseInsensitiveContains(keyword) {
+           "#\(number)".localizedCaseInsensitiveContains(numberKeyword) {
             return true
         }
 
         return title.localizedCaseInsensitiveContains(keyword)
             || content.localizedCaseInsensitiveContains(keyword)
             || tags.contains { $0.localizedCaseInsensitiveContains(keyword) }
+    }
+
+    private func normalizedNumberKeyword(from keyword: String) -> String? {
+        guard keyword.hasPrefix("#") else {
+            return nil
+        }
+
+        let digits = keyword.dropFirst()
+        guard !digits.isEmpty, digits.allSatisfy(\.isNumber) else {
+            return nil
+        }
+
+        let normalizedDigits = digits.drop(while: { $0 == "0" })
+        let numberText = normalizedDigits.isEmpty ? "0" : String(normalizedDigits)
+
+        return "#\(numberText)"
     }
 }
 

--- a/Application/DevLogInfra/Sources/Service/TodoServiceImpl.swift
+++ b/Application/DevLogInfra/Sources/Service/TodoServiceImpl.swift
@@ -167,15 +167,8 @@ final class TodoServiceImpl: TodoService {
             let snapshot = try await firestoreQuery.getDocuments()
             let todos = snapshot.documents.compactMap { makeResponse(from: $0) }
 
-            let todoNumber = searchedTodoNumber(from: trimmedKeyword)
             let filtered = todos.filter { todo in
-                if let todoNumber, todo.number == todoNumber {
-                    return true
-                }
-
-                return todo.title.localizedCaseInsensitiveContains(trimmedKeyword)
-                    || todo.content.localizedCaseInsensitiveContains(trimmedKeyword)
-                    || todo.tags.contains { $0.localizedCaseInsensitiveContains(trimmedKeyword) }
+                todo.matchesSearchKeyword(trimmedKeyword)
             }
 
             return TodoPageResponse(items: filtered, nextCursor: nil)
@@ -327,6 +320,20 @@ final class TodoServiceImpl: TodoService {
             record(error, code: .fetchReferences)
             throw error
         }
+    }
+}
+
+extension TodoResponse {
+    func matchesSearchKeyword(_ keyword: String) -> Bool {
+        if keyword.hasPrefix("#"),
+           1 < keyword.count,
+           "#\(number)".localizedCaseInsensitiveContains(keyword) {
+            return true
+        }
+
+        return title.localizedCaseInsensitiveContains(keyword)
+            || content.localizedCaseInsensitiveContains(keyword)
+            || tags.contains { $0.localizedCaseInsensitiveContains(keyword) }
     }
 }
 
@@ -525,19 +532,6 @@ private extension TodoServiceImpl {
             tags: tags,
             category: .raw(category)
         )
-    }
-
-    func searchedTodoNumber(from keyword: String) -> Int? {
-        guard keyword.hasPrefix("#") else {
-            return nil
-        }
-
-        let numberText = String(keyword.dropFirst())
-        guard !numberText.isEmpty, numberText.allSatisfy(\.isNumber) else {
-            return nil
-        }
-
-        return Int(numberText)
     }
 
     enum TodoFieldKey: String {

--- a/Application/DevLogInfra/Tests/Service/TodoSearchMatchingTests.swift
+++ b/Application/DevLogInfra/Tests/Service/TodoSearchMatchingTests.swift
@@ -14,10 +14,12 @@ struct TodoSearchMatchingTests {
     @Test("#숫자 검색어는 Todo 번호를 문자열 기반으로 부분 검색한다")
     func 해시_숫자_검색어는_Todo_번호를_문자열_기반으로_부분_검색한다() {
         let todo = makeTodo(number: 123)
+        let numberKeyword = TodoResponse.normalizedNumberKeyword(from: "#0001")
 
         #expect(todo.matchesSearchKeyword("#1"))
         #expect(todo.matchesSearchKeyword("#12"))
         #expect(todo.matchesSearchKeyword("#0001"))
+        #expect(todo.matchesSearchKeyword("#0001", numberKeyword: numberKeyword))
     }
 
     @Test("# 단독 검색어는 Todo 번호로 매칭하지 않는다")

--- a/Application/DevLogInfra/Tests/Service/TodoSearchMatchingTests.swift
+++ b/Application/DevLogInfra/Tests/Service/TodoSearchMatchingTests.swift
@@ -17,6 +17,7 @@ struct TodoSearchMatchingTests {
 
         #expect(todo.matchesSearchKeyword("#1"))
         #expect(todo.matchesSearchKeyword("#12"))
+        #expect(todo.matchesSearchKeyword("#0001"))
     }
 
     @Test("# 단독 검색어는 Todo 번호로 매칭하지 않는다")

--- a/Application/DevLogInfra/Tests/Service/TodoSearchMatchingTests.swift
+++ b/Application/DevLogInfra/Tests/Service/TodoSearchMatchingTests.swift
@@ -1,0 +1,47 @@
+//
+//  TodoSearchMatchingTests.swift
+//  DevLogInfraTests
+//
+//  Created by opfic on 6/26/26.
+//
+
+import Foundation
+import Testing
+import DevLogData
+@testable import DevLogInfra
+
+struct TodoSearchMatchingTests {
+    @Test("#숫자 검색어는 Todo 번호를 문자열 기반으로 부분 검색한다")
+    func 해시_숫자_검색어는_Todo_번호를_문자열_기반으로_부분_검색한다() {
+        let todo = makeTodo(number: 123)
+
+        #expect(todo.matchesSearchKeyword("#1"))
+        #expect(todo.matchesSearchKeyword("#12"))
+    }
+
+    @Test("# 단독 검색어는 Todo 번호로 매칭하지 않는다")
+    func 해시_단독_검색어는_Todo_번호로_매칭하지_않는다() {
+        let todo = makeTodo(number: 123)
+
+        #expect(!todo.matchesSearchKeyword("#"))
+    }
+
+    private func makeTodo(number: Int) -> TodoResponse {
+        TodoResponse(
+            id: "todo-id",
+            isPinned: false,
+            isCompleted: false,
+            isChecked: false,
+            number: number,
+            title: "title",
+            content: "content",
+            createdAt: .now,
+            updatedAt: .now,
+            completedAt: nil,
+            deletedAt: nil,
+            dueDate: nil,
+            tags: [],
+            category: .raw("feature")
+        )
+    }
+}


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #596

## 🎯 의도

- SearchView에서 `#` 뒤 숫자를 입력했을 때 Todo 번호를 일치가 아닌 문자열 기반으로 검색하도록 수정

## 📝 작업 내용

### 📌 요약

- Todo 번호 검색 로직을 `Int` 정확 일치에서 `#\(number)` 문자열 포함 비교로 변경
- `#0001`처럼 선행 0이 포함된 숫자 검색어 정규화 처리 추가
- Todo 검색 매칭 회귀 테스트 추가

### 🔍 상세

- `searchedTodoNumber(from:)` 기반 숫자 파싱 제거
- `TodoResponse.matchesSearchKeyword(_:)`로 제목, 본문, 태그, Todo 번호 검색 조건 통합
- `#1`, `#12`가 `#123`을 검색 결과로 포함하도록 변경
- `#0001`이 `#123`을 검색 결과로 포함하도록 선행 0 제거 처리
- `#` 단독 검색어는 Todo 번호로 매칭하지 않도록 테스트 고정

## 📸 영상 / 이미지 (Optional)

없음