### PR TITLE
[#610] SearchView가 뜰 때 키보드 포커싱이 되지 않는 현상을 해결한다

### DIFF
--- a/Application/DevLogPresentation/Sources/Search/SearchFeature.swift
+++ b/Application/DevLogPresentation/Sources/Search/SearchFeature.swift
@@ -105,7 +105,10 @@ struct SearchFeature {
             switch action {
             case .onAppear:
                 return .run { send in
-                    await Task.yield()
+                    // `.searchable` 바인딩이 화면에 붙은 뒤 포커스를 요청하도록 main queue 다음 턴으로 넘긴다.
+                    await withCheckedContinuation { continuation in
+                        DispatchQueue.main.async { continuation.resume() }
+                    }
                     await send(.binding(.set(\.isSearching, true)))
                 }
             case .alert:

--- a/Application/DevLogPresentation/Sources/Search/SearchFeature.swift
+++ b/Application/DevLogPresentation/Sources/Search/SearchFeature.swift
@@ -64,6 +64,7 @@ struct SearchFeature {
     }
 
     enum Action: BindableAction, Equatable {
+        case onAppear
         case alert(PresentationAction<Never>)
         case binding(BindingAction<State>)
         case addRecentQuery(String)
@@ -102,6 +103,11 @@ struct SearchFeature {
         BindingReducer()
         Reduce { state, action in
             switch action {
+            case .onAppear:
+                return .run { send in
+                    await Task.yield()
+                    await send(.binding(.set(\.isSearching, true)))
+                }
             case .alert:
                 break
             case .binding(\.isSearching):

--- a/Application/DevLogPresentation/Sources/Search/SearchView.swift
+++ b/Application/DevLogPresentation/Sources/Search/SearchView.swift
@@ -41,11 +41,7 @@ struct SearchView: View {
                             }
                     }
                 }
-                .onAppear {
-                    DispatchQueue.main.async {
-                        store.send(.binding(.set(\.isSearching, true)))
-                    }
-                }
+                .onAppear { store.send(.onAppear) }
                 .onChange(of: store.isSearching) { _, isSearching in
                     if !isSearching {
                         dismiss()

--- a/Application/DevLogPresentation/Sources/Search/SearchView.swift
+++ b/Application/DevLogPresentation/Sources/Search/SearchView.swift
@@ -41,7 +41,11 @@ struct SearchView: View {
                             }
                     }
                 }
-                .onAppear { store.send(.binding(.set(\.isSearching, true))) }
+                .onAppear {
+                    DispatchQueue.main.async {
+                        store.send(.binding(.set(\.isSearching, true)))
+                    }
+                }
                 .onChange(of: store.isSearching) { _, isSearching in
                     if !isSearching {
                         dismiss()

--- a/Application/DevLogPresentation/Tests/Search/SearchFeatureTestDoubles.swift
+++ b/Application/DevLogPresentation/Tests/Search/SearchFeatureTestDoubles.swift
@@ -82,6 +82,13 @@ struct SearchStoreTestAdapter {
         }
     }
 
+    func onAppear() async {
+        await store.send(.onAppear)
+        await store.receive(.binding(.set(\.isSearching, true))) {
+            $0.isSearching = true
+        }
+    }
+
     func setShowAllTodos(_ value: Bool) async {
         await store.send(.setShowAllTodos(value)) {
             $0.showAllTodos = value

--- a/Application/DevLogPresentation/Tests/Search/SearchFeatureTests.swift
+++ b/Application/DevLogPresentation/Tests/Search/SearchFeatureTests.swift
@@ -21,6 +21,15 @@ struct SearchFeatureTests {
         #expect(adapter.recentQueries == ["swift", "tca"])
     }
 
+    @Test("onAppear는 검색 상태를 활성화한다")
+    func onAppear는_검색_상태를_활성화한다() async {
+        let adapter = SearchStoreTestAdapter()
+
+        await adapter.onAppear()
+
+        #expect(adapter.isSearching)
+    }
+
     @Test("addRecentQuery는 공백을 제거하고 중복 제거 후 앞에 추가한다")
     func addRecentQuery는_공백을_제거하고_중복_제거_후_앞에_추가한다() async {
         let updateSpy = SearchUpdateRecentQueriesUseCaseSpy()


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #610

## 🎯 의도

- SearchView가 표시된 직후 검색 필드가 자동 포커스되지 않는 문제 해결

## 📝 작업 내용

### 📌 요약

SearchView 진입 시 검색 상태 변경을 다음 main queue 턴에 수행하도록 조정

### 🔍 상세

- 기존 SearchViewModel 시절의 `DispatchQueue.main.async` 기반 포커스 요청 타이밍 복원
- TCA 전환 이후 `onAppear`에서 즉시 `isSearching`을 변경하던 흐름을 기존 동작과 동일한 형태로 조정
- SearchView 표시 직후 `.searchable`이 붙는 시점과 포커스 요청 시점의 경합 완화

## 📸 영상 / 이미지 (Optional)
