### PR TITLE
[#621] 로그아웃, 회원탈퇴 이후 앱 배지가 그대로 남아있는 현상을 해결한다

### DIFF
--- a/Application/DevLogPresentation/Sources/Root/RootFeature.swift
+++ b/Application/DevLogPresentation/Sources/Root/RootFeature.swift
@@ -109,7 +109,10 @@ struct RootFeature {
                 if result {
                     state.selectedMainTab = .home
                 } else {
-                    return trackLoginScreenEffect()
+                    return .merge(
+                        trackLoginScreenEffect(),
+                        clearApplicationBadgeCountEffect()
+                    )
                 }
             }
 

--- a/Application/DevLogPresentation/Tests/Root/RootFeatureTestSupport.swift
+++ b/Application/DevLogPresentation/Tests/Root/RootFeatureTestSupport.swift
@@ -9,6 +9,7 @@ import Combine
 import ComposableArchitecture
 import DevLogCore
 import DevLogDomain
+import Foundation
 import Testing
 @testable import DevLogPresentation
 
@@ -299,9 +300,18 @@ final class RootTrackAnalyticsEventUseCaseSpy: TrackAnalyticsEventUseCase {
 }
 
 final class RootApplicationBadgeCountSpy: @unchecked Sendable {
-    private(set) var counts = [Int]()
+    private let lock = NSLock()
+    private var protectedCounts = [Int]()
+
+    var counts: [Int] {
+        lock.withLock {
+            protectedCounts
+        }
+    }
 
     func setBadgeCount(_ count: Int) async throws {
-        counts.append(count)
+        lock.withLock {
+            protectedCounts.append(count)
+        }
     }
 }

--- a/Application/DevLogPresentation/Tests/Root/RootFeatureTests.swift
+++ b/Application/DevLogPresentation/Tests/Root/RootFeatureTests.swift
@@ -39,6 +39,19 @@ struct RootFeatureTests {
         await verifyDidLoginedFalse(adapter: adapter, trackAnalyticsEventUseCaseSpy: trackSpy)
     }
 
+    @Test("RootFeature didLogined(false)는 앱 badge 초기화를 요청한다")
+    func RootFeature_didLogined_false는_앱_badge_초기화를_요청한다() async {
+        let badgeSpy = RootApplicationBadgeCountSpy()
+        let adapter = RootStoreTestAdapter(badgeCountSpy: badgeSpy)
+
+        await adapter.didLogined(false)
+        await waitUntil {
+            badgeSpy.counts == [0]
+        }
+
+        #expect(badgeSpy.counts == [0])
+    }
+
     @Test("RootFeature didLogined(true)는 기존 Root 상태관리처럼 signIn 상태를 true로 갱신하고 selectedMainTab을 home으로 되돌린다")
     func RootFeature_didLogined_true는_기존_Root_상태관리처럼_signIn_상태를_true로_갱신하고_selectedMainTab을_home으로_되돌린다() async {
         let trackSpy = RootTrackAnalyticsEventUseCaseSpy()


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
## 🔗 연관된 이슈
- closed #621

## 🎯 의도
- 로그아웃 또는 회원탈퇴 후에도 앱 아이콘 badge count가 이전 알림 수로 남아 있는 문제 해결

## 📝 작업 내용

### 📌 요약
- `RootFeature`의 auth session 관찰 결과가 로그아웃 상태로 전환될 때 앱 badge count를 `0`으로 초기화하도록 처리
- `didLogined(false)` 처리 시 badge 초기화를 요청하는 테스트 추가

### 🔍 상세
- 기존 `clearApplicationBadgeCountEffect()`를 재사용해 Root 진입 시점뿐 아니라 auth session이 `false`로 바뀌는 시점에도 badge 초기화 수행
- 로그아웃과 회원탈퇴 모두 session listener를 통해 `didLogined(false)` 흐름으로 수렴하므로 동일 경로에서 badge 제거 처리
- `RootFeature didLogined(false)는 앱 badge 초기화를 요청한다` 테스트로 badge count `0` 요청 검증

## 📸 영상 / 이미지 (Optional)