### PR TITLE
[#628] Firebase 구성을 staging / prod로 분리한다

### DIFF
--- a/.github/workflows/appstore.yml
+++ b/.github/workflows/appstore.yml
@@ -1,0 +1,143 @@
+name: iOS App Store
+
+on:
+  workflow_dispatch:
+    inputs:
+      upload_to_app_store_connect:
+        description: Upload to App Store Connect
+        required: true
+        default: "false"
+        type: choice
+        options:
+          - "false"
+          - "true"
+
+env:
+  RUBY_VERSION: "3.2"
+  XCODE_VERSION: latest
+  APP_STORE_TEAM_ID: ${{ secrets.APP_STORE_TEAM_ID }}
+  ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+  ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+  ASC_KEY_PATH: fastlane/AuthKey.p8
+  SPACESHIP_CONNECT_API_IN_HOUSE: "false"
+  MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
+  MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+  MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
+
+permissions:
+  contents: read
+
+jobs:
+  appstore:
+    runs-on: macos-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install private config files
+        uses: ./.github/actions/install-private-config
+        with:
+          git_url: ${{ env.MATCH_GIT_URL }}
+          git_basic_authorization: ${{ env.MATCH_GIT_BASIC_AUTHORIZATION }}
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: ${{ env.RUBY_VERSION }}
+
+      - name: Select Xcode
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ "$XCODE_VERSION" = "latest" ]; then
+            XCODE_APP="$(find /Applications -maxdepth 1 -name 'Xcode*.app' -type d | sort -V | tail -n 1)"
+          else
+            XCODE_APP="/Applications/Xcode_${XCODE_VERSION}.app"
+            if [ ! -d "$XCODE_APP" ]; then
+              XCODE_APP="/Applications/Xcode-${XCODE_VERSION}.app"
+            fi
+          fi
+
+          if [ ! -d "${XCODE_APP:-}" ]; then
+            echo "Requested Xcode not found for version: $XCODE_VERSION" >&2
+            exit 1
+          fi
+
+          sudo xcode-select -s "$XCODE_APP/Contents/Developer"
+          xcodebuild -version
+
+      - name: Set up Tuist
+        uses: jdx/mise-action@v4
+        with:
+          install: true
+          cache: true
+
+      - name: Generate Xcode workspace with Tuist
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          tuist generate --no-open
+
+      - name: Write App Store Connect API key
+        env:
+          ASC_KEY_CONTENT: ${{ secrets.ASC_KEY_CONTENT }}
+        run: |
+          printf '%s' "$ASC_KEY_CONTENT" | base64 -D > "$ASC_KEY_PATH"
+
+      - name: Build for App Store
+        run: bundle exec fastlane appstore_build_only
+
+      - name: Upload dSYM to Firebase Crashlytics
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          google_service_info_path="Application/DevLogApp/Sources/Resource/GoogleService-Info.plist"
+          dsym_zip_path="$(find fastlane/appstore_build -maxdepth 1 -name '*.dSYM.zip' -print -quit)"
+          upload_symbols_path="$(find "$HOME/Library/Developer/Xcode/DerivedData" "$HOME/Library/Developer/Xcode/SourcePackages" "$GITHUB_WORKSPACE" -path '*/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/upload-symbols' -type f -print -quit 2>/dev/null || true)"
+
+          if [ ! -f "$google_service_info_path" ]; then
+            echo "Missing GoogleService-Info.plist at $google_service_info_path" >&2
+            exit 1
+          fi
+
+          if [ -z "$dsym_zip_path" ]; then
+            echo "Missing dSYM zip in fastlane/appstore_build" >&2
+            exit 1
+          fi
+
+          if [ -z "$upload_symbols_path" ]; then
+            echo "Missing Firebase Crashlytics upload-symbols script" >&2
+            exit 1
+          fi
+
+          "$upload_symbols_path" -gsp "$google_service_info_path" -p ios "$dsym_zip_path"
+
+      - name: Upload App Store build log
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: appstore-build-log
+          path: ~/Library/Logs/gym/*.log
+          if-no-files-found: ignore
+
+      - name: Upload App Store dSYM
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: appstore-dsym
+          path: fastlane/appstore_build/*.dSYM.zip
+          if-no-files-found: warn
+
+      - name: Skip App Store Upload
+        if: inputs.upload_to_app_store_connect != 'true'
+        run: echo "Skipping App Store upload"
+
+      - name: Upload to App Store Connect
+        if: inputs.upload_to_app_store_connect == 'true'
+        run: bundle exec fastlane upload_appstore_build

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -3,19 +3,14 @@ name: iOS TestFlight
 on:
   workflow_dispatch:
     inputs:
-      upload_to_app_store_connect:
-        description: Upload to App Store Connect
+      upload_to_testflight:
+        description: Upload to TestFlight
         required: true
         default: "false"
         type: choice
         options:
           - "false"
           - "true"
-  pull_request:
-    types:
-      - closed
-    branches:
-      - develop
 
 env:
   SCHEME: DevLogApp
@@ -35,19 +30,11 @@ permissions:
 
 jobs:
   testflight:
-    if: github.event_name == 'workflow_dispatch' || (github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'develop' && (contains(github.event.pull_request.labels.*.name, 'qa') || contains(github.event.pull_request.labels.*.name, 'qa-local')))
     runs-on: macos-latest
     timeout-minutes: 45
 
     steps:
-      - name: Checkout merge commit
-        if: github.event_name == 'pull_request'
-        uses: actions/checkout@v5
-        with:
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
-
-      - name: Checkout current ref
-        if: github.event_name == 'workflow_dispatch'
+      - name: Checkout
         uses: actions/checkout@v5
 
       - name: Install private config files
@@ -159,9 +146,9 @@ jobs:
           if-no-files-found: warn
 
       - name: Skip TestFlight Upload
-        if: (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'qa-local')) || (github.event_name == 'workflow_dispatch' && inputs.upload_to_app_store_connect != 'true')
+        if: inputs.upload_to_testflight != 'true'
         run: echo "Skipping TestFlight upload"
 
       - name: Upload to TestFlight
-        if: (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'qa') && !contains(github.event.pull_request.labels.*.name, 'qa-local')) || (github.event_name == 'workflow_dispatch' && inputs.upload_to_app_store_connect == 'true')
+        if: inputs.upload_to_testflight == 'true'
         run: bundle exec fastlane upload_testflight_build

--- a/Application/DevLogApp/Project.swift
+++ b/Application/DevLogApp/Project.swift
@@ -52,11 +52,19 @@ let project = Project(
                 debug: [
                     "APS_ENVIRONMENT": "development",
                     "DEBUG_INFORMATION_FORMAT": "dwarf",
+                    "FIRESTORE_DATABASE_ID": "staging",
                     "INFOPLIST_KEY_FirebaseCrashlyticsCollectionEnabled": "NO",
+                ],
+                staging: [
+                    "APS_ENVIRONMENT": "production",
+                    "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
+                    "FIRESTORE_DATABASE_ID": "staging",
+                    "INFOPLIST_KEY_FirebaseCrashlyticsCollectionEnabled": "YES",
                 ],
                 release: [
                     "APS_ENVIRONMENT": "production",
                     "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
+                    "FIRESTORE_DATABASE_ID": "prod",
                     "INFOPLIST_KEY_FirebaseCrashlyticsCollectionEnabled": "YES",
                 ]
             )

--- a/Application/DevLogApp/Sources/Resource/App.xcconfig
+++ b/Application/DevLogApp/Sources/Resource/App.xcconfig
@@ -1,3 +1,2 @@
 #include "../../../Shared/Version.xcconfig"
-FIRESTORE_DATABASE_ID = staging
 #include? "Config.xcconfig"

--- a/Application/DevLogApp/Sources/Resource/App.xcconfig
+++ b/Application/DevLogApp/Sources/Resource/App.xcconfig
@@ -1,2 +1,3 @@
 #include "../../../Shared/Version.xcconfig"
+FIRESTORE_DATABASE_ID = staging
 #include? "Config.xcconfig"

--- a/Application/DevLogApp/Sources/Resource/Info.plist
+++ b/Application/DevLogApp/Sources/Resource/Info.plist
@@ -40,6 +40,8 @@
 	<false/>
 	<key>FirebaseAutomaticScreenReportingEnabled</key>
 	<false/>
+	<key>FIRESTORE_DATABASE_ID</key>
+	<string>$(FIRESTORE_DATABASE_ID)</string>
 	<key>GIDClientID</key>
 	<string>$(CLIENT_ID)</string>
 	<key>GITHUB_CLIENT_ID</key>

--- a/Application/DevLogApp/Tests/Support/LocalFirebaseRESTSupport.swift
+++ b/Application/DevLogApp/Tests/Support/LocalFirebaseRESTSupport.swift
@@ -149,7 +149,7 @@ final class LocalFirebaseRESTSupport {
     func fetchPushNotificationIDs(userId: String) async throws -> [String] {
         let googleServiceInfo = try loadGoogleServiceInfo()
         let url = firestoreBaseURL.appending(
-            path: "v1/projects/\(googleServiceInfo.projectId)/databases/(default)/documents/users/" +
+            path: "v1/projects/\(googleServiceInfo.projectId)/databases/\(databaseID())/documents/users/" +
                 "\(userId)/notifications",
             directoryHint: .notDirectory
         )
@@ -181,7 +181,8 @@ final class LocalFirebaseRESTSupport {
     func fetchWebPageURLs(userId: String) async throws -> [String] {
         let googleServiceInfo = try loadGoogleServiceInfo()
         let url = firestoreBaseURL.appending(
-            path: "v1/projects/\(googleServiceInfo.projectId)/databases/(default)/documents/users/\(userId)/webPages",
+            path: "v1/projects/\(googleServiceInfo.projectId)/databases/\(databaseID())" +
+                "/documents/users/\(userId)/webPages",
             directoryHint: .notDirectory
         )
         let (data, response) = try await URLSession.shared.data(from: url)
@@ -289,6 +290,8 @@ private extension LocalFirebaseRESTSupport {
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue("Bearer \(idToken)", forHTTPHeaderField: "Authorization")
+        var data = data
+        data["databaseID"] = databaseID()
         request.httpBody = try JSONSerialization.data(withJSONObject: ["data": data])
         return try await sendJSON(request)
     }
@@ -301,7 +304,8 @@ private extension LocalFirebaseRESTSupport {
         let encodedPath = encode(documentPath)
         var request = URLRequest(
             url: firestoreBaseURL.appending(
-                path: "v1/projects/\(googleServiceInfo.projectId)/databases/(default)/documents/\(encodedPath)",
+                path: "v1/projects/\(googleServiceInfo.projectId)/databases/\(databaseID())" +
+                    "/documents/\(encodedPath)",
                 directoryHint: .notDirectory
             )
         )
@@ -334,6 +338,22 @@ private extension LocalFirebaseRESTSupport {
         path.split(separator: "/").map {
             String($0).addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? String($0)
         }.joined(separator: "/")
+    }
+
+    func databaseID() -> String {
+        let environmentValue = ProcessInfo.processInfo.environment["FIRESTORE_DATABASE_ID"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if let environmentValue, !environmentValue.isEmpty {
+            return environmentValue
+        }
+
+        let bundleValue = Bundle.main.object(forInfoDictionaryKey: "FIRESTORE_DATABASE_ID") as? String
+        let databaseID = bundleValue?.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let databaseID, !databaseID.isEmpty, !databaseID.hasPrefix("$(") else {
+            return "staging"
+        }
+
+        return databaseID
     }
 
     func stringValue(_ value: String) -> [String: Any] {

--- a/Application/DevLogApp/Tests/Support/LocalFirebaseRESTSupport.swift
+++ b/Application/DevLogApp/Tests/Support/LocalFirebaseRESTSupport.swift
@@ -290,8 +290,6 @@ private extension LocalFirebaseRESTSupport {
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue("Bearer \(idToken)", forHTTPHeaderField: "Authorization")
-        var data = data
-        data["databaseID"] = databaseID()
         request.httpBody = try JSONSerialization.data(withJSONObject: ["data": data])
         return try await sendJSON(request)
     }

--- a/Application/DevLogInfra/Sources/Common/FirebaseConfiguration.swift
+++ b/Application/DevLogInfra/Sources/Common/FirebaseConfiguration.swift
@@ -14,10 +14,6 @@ enum FirebaseConfiguration {
         static let databaseID = "FIRESTORE_DATABASE_ID"
     }
 
-    private enum CallablePayloadKey {
-        static let databaseID = "databaseID"
-    }
-
     static let defaultDatabaseID = "staging"
 
     static var databaseID: String {
@@ -45,11 +41,5 @@ enum FirebaseConfiguration {
 
     static var functions: Functions {
         Functions.functions(region: "asia-northeast3")
-    }
-
-    static func callablePayload(_ payload: [String: Any] = [:]) -> [String: Any] {
-        var payload = payload
-        payload[CallablePayloadKey.databaseID] = databaseID
-        return payload
     }
 }

--- a/Application/DevLogInfra/Sources/Common/FirebaseConfiguration.swift
+++ b/Application/DevLogInfra/Sources/Common/FirebaseConfiguration.swift
@@ -21,6 +21,12 @@ enum FirebaseConfiguration {
     static let defaultDatabaseID = "staging"
 
     static var databaseID: String {
+        let environmentValue = ProcessInfo.processInfo.environment[InfoKey.databaseID]?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if let environmentValue, !environmentValue.isEmpty {
+            return environmentValue
+        }
+
         guard let rawValue = Bundle.main.object(forInfoDictionaryKey: InfoKey.databaseID) as? String else {
             return defaultDatabaseID
         }

--- a/Application/DevLogInfra/Sources/Common/FirebaseConfiguration.swift
+++ b/Application/DevLogInfra/Sources/Common/FirebaseConfiguration.swift
@@ -1,0 +1,49 @@
+//
+//  FirebaseConfiguration.swift
+//  DevLogInfra
+//
+//  Created by opfic on 6/26/26.
+//
+
+import FirebaseFirestore
+import FirebaseFunctions
+import Foundation
+
+enum FirebaseConfiguration {
+    private enum InfoKey {
+        static let databaseID = "FIRESTORE_DATABASE_ID"
+    }
+
+    private enum CallablePayloadKey {
+        static let databaseID = "databaseID"
+    }
+
+    static let defaultDatabaseID = "staging"
+
+    static var databaseID: String {
+        guard let rawValue = Bundle.main.object(forInfoDictionaryKey: InfoKey.databaseID) as? String else {
+            return defaultDatabaseID
+        }
+
+        let databaseID = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        if databaseID.isEmpty || databaseID.hasPrefix("$(") {
+            return defaultDatabaseID
+        }
+
+        return databaseID
+    }
+
+    static var firestore: Firestore {
+        Firestore.firestore(database: databaseID)
+    }
+
+    static var functions: Functions {
+        Functions.functions(region: "asia-northeast3")
+    }
+
+    static func callablePayload(_ payload: [String: Any] = [:]) -> [String: Any] {
+        var payload = payload
+        payload[CallablePayloadKey.databaseID] = databaseID
+        return payload
+    }
+}

--- a/Application/DevLogInfra/Sources/Extension/FirebaseFunctions+.swift
+++ b/Application/DevLogInfra/Sources/Extension/FirebaseFunctions+.swift
@@ -6,10 +6,21 @@
 //
 
 import FirebaseFunctions
-import DevLogData
 
 extension Functions {
-    func httpsCallable(_ name: some RawRepresentable<String>) -> HTTPSCallable {
-        httpsCallable(name.rawValue)
+    func httpsCallable(_ name: some RawRepresentable<String>) -> FirebaseFunction {
+        FirebaseFunction(callable: httpsCallable(name.rawValue))
+    }
+}
+
+struct FirebaseFunction {
+    private let callable: HTTPSCallable
+
+    init(callable: HTTPSCallable) {
+        self.callable = callable
+    }
+
+    func call(_ data: [String: Any] = [:]) async throws -> HTTPSCallableResult {
+        try await callable.call(FirebaseConfiguration.callablePayload(data))
     }
 }

--- a/Application/DevLogInfra/Sources/Extension/FirebaseFunctions+.swift
+++ b/Application/DevLogInfra/Sources/Extension/FirebaseFunctions+.swift
@@ -8,19 +8,7 @@
 import FirebaseFunctions
 
 extension Functions {
-    func httpsCallable(_ name: some RawRepresentable<String>) -> FirebaseFunction {
-        FirebaseFunction(callable: httpsCallable(name.rawValue))
-    }
-}
-
-struct FirebaseFunction {
-    private let callable: HTTPSCallable
-
-    init(callable: HTTPSCallable) {
-        self.callable = callable
-    }
-
-    func call(_ data: [String: Any] = [:]) async throws -> HTTPSCallableResult {
-        try await callable.call(FirebaseConfiguration.callablePayload(data))
+    func httpsCallable(_ name: some RawRepresentable<String>) -> HTTPSCallable {
+        httpsCallable(name.rawValue)
     }
 }

--- a/Application/DevLogInfra/Sources/Service/AuthServiceImpl.swift
+++ b/Application/DevLogInfra/Sources/Service/AuthServiceImpl.swift
@@ -24,7 +24,7 @@ final class AuthServiceImpl: AuthService {
         }
     }
 
-    private let store = Firestore.firestore()
+    private let store = FirebaseConfiguration.firestore
     private let messaging = Messaging.messaging()
     private let logger = Logger(category: "AuthServiceImpl")
     private let subject = CurrentValueSubject<Bool, Never>(Auth.auth().currentUser != nil)

--- a/Application/DevLogInfra/Sources/Service/PushNotificationServiceImpl.swift
+++ b/Application/DevLogInfra/Sources/Service/PushNotificationServiceImpl.swift
@@ -34,8 +34,8 @@ final class PushNotificationServiceImpl: PushNotificationService {
         case undoPushNotificationDeletion
     }
 
-    private let store = Firestore.firestore()
-    private let functions = Functions.functions(region: "asia-northeast3")
+    private let store = FirebaseConfiguration.firestore
+    private let functions = FirebaseConfiguration.functions
     private let logger = Logger(category: "PushNotificationServiceImpl")
 
     /// 푸시 알림 On/Off 설정

--- a/Application/DevLogInfra/Sources/Service/SocialLogin/AppleAuthenticationServiceImpl.swift
+++ b/Application/DevLogInfra/Sources/Service/SocialLogin/AppleAuthenticationServiceImpl.swift
@@ -37,8 +37,8 @@ final class AppleAuthenticationServiceImpl: AuthenticationService {
 
     private var appleSignInDelegate: AppleSignInDelegate?
     private var appleSignInContinuation: CheckedContinuation<ASAuthorization, Error>?
-    private let store = Firestore.firestore()
-    private let functions = Functions.functions(region: "asia-northeast3")
+    private let store = FirebaseConfiguration.firestore
+    private let functions = FirebaseConfiguration.functions
     private let messaging = Messaging.messaging()
     private var user: User? { Auth.auth().currentUser }
     private let providerID = AuthProviderID.apple

--- a/Application/DevLogInfra/Sources/Service/SocialLogin/GithubAuthenticationServiceImpl.swift
+++ b/Application/DevLogInfra/Sources/Service/SocialLogin/GithubAuthenticationServiceImpl.swift
@@ -38,8 +38,8 @@ final class GithubAuthenticationServiceImpl: NSObject, AuthenticationService {
         static let acceptHeader = "application/vnd.github.v3+json"
     }
 
-    private let store = Firestore.firestore()
-    private let functions = Functions.functions(region: "asia-northeast3")
+    private let store = FirebaseConfiguration.firestore
+    private let functions = FirebaseConfiguration.functions
     private let messaging = Messaging.messaging()
     private var user: User? { Auth.auth().currentUser }
     private let providerID = AuthProviderID.gitHub

--- a/Application/DevLogInfra/Sources/Service/SocialLogin/GoogleAuthenticationServiceImpl.swift
+++ b/Application/DevLogInfra/Sources/Service/SocialLogin/GoogleAuthenticationServiceImpl.swift
@@ -26,7 +26,7 @@ final class GoogleAuthenticationServiceImpl: AuthenticationService {
         }
     }
 
-    private let store = Firestore.firestore()
+    private let store = FirebaseConfiguration.firestore
     private let messaging = Messaging.messaging()
     private var user: User? { Auth.auth().currentUser }
     private let provider = TopViewControllerProvider()

--- a/Application/DevLogInfra/Sources/Service/TodoCategoryServiceImpl.swift
+++ b/Application/DevLogInfra/Sources/Service/TodoCategoryServiceImpl.swift
@@ -35,7 +35,7 @@ final class TodoCategoryServiceImpl: TodoCategoryService {
         case user
     }
 
-    private let store = Firestore.firestore()
+    private let store = FirebaseConfiguration.firestore
     private let logger = Logger(category: "TodoCategoryServiceImpl")
 
     func fetchCategoryPreferences() async throws -> [TodoCategoryPreferenceResponse] {

--- a/Application/DevLogInfra/Sources/Service/TodoServiceImpl.swift
+++ b/Application/DevLogInfra/Sources/Service/TodoServiceImpl.swift
@@ -30,8 +30,8 @@ final class TodoServiceImpl: TodoService {
         case undoTodoDeletion
     }
 
-    private let store = Firestore.firestore()
-    private let functions = Functions.functions(region: "asia-northeast3")
+    private let store = FirebaseConfiguration.firestore
+    private let functions = FirebaseConfiguration.functions
     private let encoder = Firestore.Encoder()
     private let logger = Logger(category: "TodoServiceImpl")
     

--- a/Application/DevLogInfra/Sources/Service/UserServiceImpl.swift
+++ b/Application/DevLogInfra/Sources/Service/UserServiceImpl.swift
@@ -23,7 +23,7 @@ final class UserServiceImpl: UserService {
         }
     }
 
-    private let store = Firestore.firestore()
+    private let store = FirebaseConfiguration.firestore
     private let logger = Logger(category: "UserServiceImpl")
     
     // 유저를 Firestore에 저장 및 업데이트

--- a/Application/DevLogInfra/Sources/Service/WebPageServiceImpl.swift
+++ b/Application/DevLogInfra/Sources/Service/WebPageServiceImpl.swift
@@ -28,8 +28,8 @@ final class WebPageServiceImpl: WebPageService {
         case undoWebPageDeletion
     }
 
-    private let store = Firestore.firestore()
-    private let functions = Functions.functions(region: "asia-northeast3")
+    private let store = FirebaseConfiguration.firestore
+    private let functions = FirebaseConfiguration.functions
     private let encoder = Firestore.Encoder()
     private let logger = Logger(category: "WebPageServiceImpl")
 

--- a/README.md
+++ b/README.md
@@ -183,6 +183,8 @@ Release -> prod
 
 TestFlight archive는 `Staging`, App Store 실제 서비스 archive는 `Release` configuration을 사용함
 GitHub Actions 배포 workflow는 PR label 기반 자동 실행 없이 수동 실행함
+TestFlight build는 App Store 심사 제출 대상으로 승격하지 않고, 실제 배포는 같은 `MARKETING_VERSION`의 별도 `Release/prod` build로 생성함
+build number는 TestFlight와 App Store upload가 공유하는 App Store Connect build number 공간에서 자동 증가함
 
 - TestFlight build: `bundle exec fastlane testflight_build_only`
 - TestFlight upload: `bundle exec fastlane deploy_testflight`

--- a/README.md
+++ b/README.md
@@ -174,13 +174,14 @@ Application/DevLogApp/Sources/Resource/
 └── GoogleService-Info.plist
 ```
 
-Firestore database는 기본값으로 `staging`을 사용함
+Firestore database는 build configuration 기준으로 분리함
 
 ```text
-FIRESTORE_DATABASE_ID = staging
+Debug, Staging -> staging
+Release -> prod
 ```
 
-App Store 실제 서비스 배포용 archive는 `Config.xcconfig`에서 `prod`로 override함
+TestFlight archive는 `Staging`, App Store 실제 서비스 archive는 `Release` configuration을 사용함
 
 ### 3. Xcode 워크스페이스 생성
 

--- a/README.md
+++ b/README.md
@@ -183,6 +183,11 @@ Release -> prod
 
 TestFlight archive는 `Staging`, App Store 실제 서비스 archive는 `Release` configuration을 사용함
 
+- TestFlight build: `bundle exec fastlane testflight_build_only`
+- TestFlight upload: `bundle exec fastlane deploy_testflight`
+- App Store build: `bundle exec fastlane appstore_build_only`
+- App Store upload: `bundle exec fastlane deploy_appstore`
+
 ### 3. Xcode 워크스페이스 생성
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Release -> prod
 ```
 
 TestFlight archive는 `Staging`, App Store 실제 서비스 archive는 `Release` configuration을 사용함
+GitHub Actions 배포 workflow는 PR label 기반 자동 실행 없이 수동 실행함
 
 - TestFlight build: `bundle exec fastlane testflight_build_only`
 - TestFlight upload: `bundle exec fastlane deploy_testflight`

--- a/README.md
+++ b/README.md
@@ -174,6 +174,14 @@ Application/DevLogApp/Sources/Resource/
 └── GoogleService-Info.plist
 ```
 
+Firestore database는 기본값으로 `staging`을 사용함
+
+```text
+FIRESTORE_DATABASE_ID = staging
+```
+
+App Store 실제 서비스 배포용 archive는 `Config.xcconfig`에서 `prod`로 override함
+
 ### 3. Xcode 워크스페이스 생성
 
 ```bash

--- a/Tuist/ProjectDescriptionHelpers/Project+Settings.swift
+++ b/Tuist/ProjectDescriptionHelpers/Project+Settings.swift
@@ -9,6 +9,7 @@ public extension Settings {
         versionXcconfigPath: Path? = nil,
         base: SettingsDictionary = [:],
         debug: SettingsDictionary = [:],
+        staging: SettingsDictionary = [:],
         release: SettingsDictionary = [:],
         defaultSettings: DefaultSettings = .recommended
     ) -> Settings {
@@ -26,6 +27,7 @@ public extension Settings {
                 base: commonBase,
                 configurations: [
                     .debug(name: "Debug", settings: debug, xcconfig: versionXcconfigPath),
+                    .release(name: "Staging", settings: staging, xcconfig: versionXcconfigPath),
                     .release(name: "Release", settings: release, xcconfig: versionXcconfigPath),
                 ],
                 defaultSettings: defaultSettings
@@ -36,6 +38,7 @@ public extension Settings {
             base: commonBase,
             configurations: [
                 .debug(name: "Debug", settings: debug),
+                .release(name: "Staging", settings: staging),
                 .release(name: "Release", settings: release),
             ],
             defaultSettings: defaultSettings

--- a/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
+++ b/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
@@ -34,6 +34,9 @@ public extension Project {
                     debug: [
                         "DEBUG_INFORMATION_FORMAT": "dwarf",
                     ],
+                    staging: [
+                        "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
+                    ],
                     release: [
                         "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
                     ]

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -7,8 +7,11 @@ APP_IDENTIFIERS = [APP_IDENTIFIER, WIDGET_IDENTIFIER]
 TARGET_NAME = "DevLogApp"
 WIDGET_TARGET_NAME = "DevLogWidgetExtension"
 APP_PRODUCT_NAME = "DevLog"
+TESTFLIGHT_CONFIGURATION = "Staging"
+APPSTORE_CONFIGURATION = "Release"
 TESTFLIGHT_BUILD_OUTPUT_DIRECTORY = File.expand_path("testflight_build", __dir__)
 TESTFLIGHT_IPA_OUTPUT_PATH = File.join(TESTFLIGHT_BUILD_OUTPUT_DIRECTORY, "#{APP_PRODUCT_NAME}.ipa")
+APPSTORE_BUILD_OUTPUT_DIRECTORY = File.expand_path("appstore_build", __dir__)
 
 default_platform(:ios)
 
@@ -51,7 +54,10 @@ platform :ios do
     )
   end
 
-  private_lane :build_for_store do
+  private_lane :build_for_store do |options|
+    configuration = options[:configuration] || TESTFLIGHT_CONFIGURATION
+    output_directory = options[:output_directory] || TESTFLIGHT_BUILD_OUTPUT_DIRECTORY
+
     if ENV["FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT"].to_s.strip.empty?
       ENV["FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT"] = "30"
     end
@@ -118,7 +124,7 @@ platform :ios do
           sdk: "iphoneos*",
           team_id: ENV["APP_STORE_TEAM_ID"],
           targets: [target_name],
-          build_configurations: ["Release"],
+          build_configurations: [configuration],
           code_sign_identity: "Apple Distribution",
           profile_name: provisioning_profile_specifier
         )
@@ -128,8 +134,9 @@ platform :ios do
     build_app(
       workspace: XCODE_WORKSPACE,
       scheme: TARGET_NAME,
+      configuration: configuration,
       export_method: "app-store",
-      output_directory: TESTFLIGHT_BUILD_OUTPUT_DIRECTORY,
+      output_directory: output_directory,
       output_name: "#{APP_PRODUCT_NAME}.ipa",
       include_symbols: true,
       xcargs: "-skipPackagePluginValidation -skipMacroValidation"
@@ -144,13 +151,20 @@ platform :ios do
   end
 
   lane :deploy_testflight do
-    build_for_store
+    build_for_store(configuration: TESTFLIGHT_CONFIGURATION)
 
     upload_testflight_build
   end
 
   lane :testflight_build_only do
-    build_for_store
+    build_for_store(configuration: TESTFLIGHT_CONFIGURATION)
+  end
+
+  lane :appstore_build_only do
+    build_for_store(
+      configuration: APPSTORE_CONFIGURATION,
+      output_directory: APPSTORE_BUILD_OUTPUT_DIRECTORY
+    )
   end
 
   lane :sync_appstore_profiles do

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -57,6 +57,31 @@ platform :ios do
     )
   end
 
+  private_lane :verify_store_configuration do |options|
+    configuration = options[:configuration].to_s.strip
+    database_id = options[:database_id].to_s.strip
+
+    expected_database_id =
+      case configuration
+      when TESTFLIGHT_CONFIGURATION
+        TESTFLIGHT_DATABASE_ID
+      when APPSTORE_CONFIGURATION
+        APPSTORE_DATABASE_ID
+      else
+        UI.user_error!("Unsupported store configuration: #{configuration}")
+      end
+
+    UI.user_error!("Missing Firestore database ID for #{configuration}") if database_id.empty?
+
+    if database_id != expected_database_id
+      UI.user_error!(
+        "Invalid store configuration: #{configuration} must use FIRESTORE_DATABASE_ID=#{expected_database_id}, got #{database_id}"
+      )
+    end
+
+    UI.message("Verified store configuration: #{configuration}/#{database_id}")
+  end
+
   private_lane :verify_firestore_database_id do |options|
     require "shellwords"
     require "tmpdir"
@@ -94,6 +119,11 @@ platform :ios do
     output_directory = options[:output_directory] || TESTFLIGHT_BUILD_OUTPUT_DIRECTORY
     expected_database_id = options[:database_id] ||
       (configuration == APPSTORE_CONFIGURATION ? APPSTORE_DATABASE_ID : TESTFLIGHT_DATABASE_ID)
+
+    verify_store_configuration(
+      configuration: configuration,
+      database_id: expected_database_id
+    )
 
     if ENV["FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT"].to_s.strip.empty?
       ENV["FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT"] = "30"
@@ -249,6 +279,11 @@ platform :ios do
     ipa_output_path = TESTFLIGHT_IPA_OUTPUT_PATH if ipa_output_path.empty?
 
     UI.user_error!("Missing built ipa at #{ipa_output_path}") if !File.exist?(ipa_output_path)
+
+    verify_firestore_database_id(
+      ipa: ipa_output_path,
+      database_id: TESTFLIGHT_DATABASE_ID
+    )
 
     upload_to_testflight(
       api_key: api_key,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -19,7 +19,7 @@ APPSTORE_IPA_OUTPUT_PATH = File.join(APPSTORE_BUILD_OUTPUT_DIRECTORY, "#{APP_PRO
 default_platform(:ios)
 
 platform :ios do
-  private_lane :fetch_latest_testflight_build_number do |options|
+  private_lane :fetch_latest_app_store_connect_build_number do |options|
     require "spaceship"
 
     api_key = options[:api_key]
@@ -110,23 +110,23 @@ platform :ios do
       target: TARGET_NAME
     )
 
-    latest_testflight_build_number = fetch_latest_testflight_build_number(
+    latest_build_number = fetch_latest_app_store_connect_build_number(
       api_key: api_key,
       version: version_number
     )
 
     setup_ci if ENV["CI"]
 
-    testflight_build_number = latest_testflight_build_number + 1
+    next_build_number = latest_build_number + 1
 
     increment_build_number(
       xcodeproj: XCODE_PROJ,
-      build_number: testflight_build_number
+      build_number: next_build_number
     )
 
     increment_build_number(
       xcodeproj: WIDGET_XCODE_PROJ,
-      build_number: testflight_build_number
+      build_number: next_build_number
     )
 
     match(

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -9,6 +9,8 @@ WIDGET_TARGET_NAME = "DevLogWidgetExtension"
 APP_PRODUCT_NAME = "DevLog"
 TESTFLIGHT_CONFIGURATION = "Staging"
 APPSTORE_CONFIGURATION = "Release"
+TESTFLIGHT_DATABASE_ID = "staging"
+APPSTORE_DATABASE_ID = "prod"
 TESTFLIGHT_BUILD_OUTPUT_DIRECTORY = File.expand_path("testflight_build", __dir__)
 TESTFLIGHT_IPA_OUTPUT_PATH = File.join(TESTFLIGHT_BUILD_OUTPUT_DIRECTORY, "#{APP_PRODUCT_NAME}.ipa")
 APPSTORE_BUILD_OUTPUT_DIRECTORY = File.expand_path("appstore_build", __dir__)
@@ -54,9 +56,43 @@ platform :ios do
     )
   end
 
+  private_lane :verify_firestore_database_id do |options|
+    require "shellwords"
+    require "tmpdir"
+
+    ipa_path = options[:ipa]
+    expected_database_id = options[:database_id]
+
+    UI.user_error!("Missing IPA path") if ipa_path.to_s.strip.empty?
+    UI.user_error!("Missing expected Firestore database ID") if expected_database_id.to_s.strip.empty?
+    UI.user_error!("Missing built ipa at #{ipa_path}") if !File.exist?(ipa_path)
+
+    Dir.mktmpdir("devlog-ipa") do |tmpdir|
+      sh("unzip -q #{Shellwords.escape(ipa_path)} -d #{Shellwords.escape(tmpdir)}")
+
+      plist_path = File.join(tmpdir, "Payload", "#{APP_PRODUCT_NAME}.app", "Info.plist")
+      UI.user_error!("Missing app Info.plist in ipa") if !File.exist?(plist_path)
+
+      actual_database_id = sh(
+        "/usr/libexec/PlistBuddy -c 'Print :FIRESTORE_DATABASE_ID' #{Shellwords.escape(plist_path)}",
+        log: false
+      ).strip
+
+      if actual_database_id != expected_database_id
+        UI.user_error!(
+          "Unexpected FIRESTORE_DATABASE_ID: expected #{expected_database_id}, got #{actual_database_id}"
+        )
+      end
+
+      UI.message("Verified FIRESTORE_DATABASE_ID=#{actual_database_id}")
+    end
+  end
+
   private_lane :build_for_store do |options|
     configuration = options[:configuration] || TESTFLIGHT_CONFIGURATION
     output_directory = options[:output_directory] || TESTFLIGHT_BUILD_OUTPUT_DIRECTORY
+    expected_database_id = options[:database_id] ||
+      (configuration == APPSTORE_CONFIGURATION ? APPSTORE_DATABASE_ID : TESTFLIGHT_DATABASE_ID)
 
     if ENV["FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT"].to_s.strip.empty?
       ENV["FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT"] = "30"
@@ -142,6 +178,14 @@ platform :ios do
       xcargs: "-skipPackagePluginValidation -skipMacroValidation"
     )
 
+    ipa_output_path = lane_context[SharedValues::IPA_OUTPUT_PATH].to_s
+    ipa_output_path = File.join(output_directory, "#{APP_PRODUCT_NAME}.ipa") if ipa_output_path.empty?
+
+    verify_firestore_database_id(
+      ipa: ipa_output_path,
+      database_id: expected_database_id
+    )
+
     dsym_output_path = lane_context[SharedValues::DSYM_OUTPUT_PATH]
     archive_path = lane_context[SharedValues::XCODEBUILD_ARCHIVE]
     UI.message("dSYM output path: #{dsym_output_path}") unless dsym_output_path.to_s.empty?
@@ -151,19 +195,26 @@ platform :ios do
   end
 
   lane :deploy_testflight do
-    build_for_store(configuration: TESTFLIGHT_CONFIGURATION)
+    build_for_store(
+      configuration: TESTFLIGHT_CONFIGURATION,
+      database_id: TESTFLIGHT_DATABASE_ID
+    )
 
     upload_testflight_build
   end
 
   lane :testflight_build_only do
-    build_for_store(configuration: TESTFLIGHT_CONFIGURATION)
+    build_for_store(
+      configuration: TESTFLIGHT_CONFIGURATION,
+      database_id: TESTFLIGHT_DATABASE_ID
+    )
   end
 
   lane :appstore_build_only do
     build_for_store(
       configuration: APPSTORE_CONFIGURATION,
-      output_directory: APPSTORE_BUILD_OUTPUT_DIRECTORY
+      output_directory: APPSTORE_BUILD_OUTPUT_DIRECTORY,
+      database_id: APPSTORE_DATABASE_ID
     )
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -14,6 +14,7 @@ APPSTORE_DATABASE_ID = "prod"
 TESTFLIGHT_BUILD_OUTPUT_DIRECTORY = File.expand_path("testflight_build", __dir__)
 TESTFLIGHT_IPA_OUTPUT_PATH = File.join(TESTFLIGHT_BUILD_OUTPUT_DIRECTORY, "#{APP_PRODUCT_NAME}.ipa")
 APPSTORE_BUILD_OUTPUT_DIRECTORY = File.expand_path("appstore_build", __dir__)
+APPSTORE_IPA_OUTPUT_PATH = File.join(APPSTORE_BUILD_OUTPUT_DIRECTORY, "#{APP_PRODUCT_NAME}.ipa")
 
 default_platform(:ios)
 
@@ -218,6 +219,16 @@ platform :ios do
     )
   end
 
+  lane :deploy_appstore do
+    build_for_store(
+      configuration: APPSTORE_CONFIGURATION,
+      output_directory: APPSTORE_BUILD_OUTPUT_DIRECTORY,
+      database_id: APPSTORE_DATABASE_ID
+    )
+
+    upload_appstore_build
+  end
+
   lane :sync_appstore_profiles do
     api_key = asc_api_key
     match_force = ENV.fetch("MATCH_FORCE", "false") == "true"
@@ -243,6 +254,30 @@ platform :ios do
       api_key: api_key,
       ipa: ipa_output_path,
       skip_waiting_for_build_processing: true
+    )
+  end
+
+  lane :upload_appstore_build do
+    api_key = asc_api_key
+    # lane_context는 같은 fastlane 실행 내에서만 유지되므로, 별도 CI step에서는 고정 ipa 경로를 사용한다.
+    ipa_output_path = lane_context[SharedValues::IPA_OUTPUT_PATH].to_s
+    ipa_output_path = APPSTORE_IPA_OUTPUT_PATH if ipa_output_path.empty?
+
+    UI.user_error!("Missing built ipa at #{ipa_output_path}") if !File.exist?(ipa_output_path)
+
+    verify_firestore_database_id(
+      ipa: ipa_output_path,
+      database_id: APPSTORE_DATABASE_ID
+    )
+
+    upload_to_app_store(
+      api_key: api_key,
+      ipa: ipa_output_path,
+      skip_metadata: true,
+      skip_screenshots: true,
+      submit_for_review: false,
+      automatic_release: false,
+      force: true
     )
   end
 


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #628

## 🎯 의도

- Firebase Firestore database를 개발/QA용 staging과 실제 서비스용 prod로 분리하기 위한 iOS 앱 설정 정리
- TestFlight는 QA용 staging 환경으로 유지하고 App Store 배포 산출물은 prod 환경으로 생성되도록 배포 경로 명확화
- Callable Functions 환경 분리는 후속 REST API 전환 작업으로 이관

## 📝 작업 내용

### 📌 요약

- Firestore database ID 런타임 설정 추가
- `Debug`, `Staging`, `Release` build configuration별 Firestore database 분리
- TestFlight와 App Store fastlane lane 및 GitHub Actions workflow 분리
- IPA 내부 `FIRESTORE_DATABASE_ID` 검증 추가
- 배포 환경 조합 guard 추가
- callable Functions의 `databaseID` payload 주입 제거

### 🔍 상세

- `FirebaseConfiguration`을 추가해 direct Firestore instance의 database ID 선택 경로 일원화
- `FIRESTORE_DATABASE_ID` 환경변수 override를 먼저 확인하고, 이후 app bundle `Info.plist` 값을 사용하도록 처리
- `Debug`, `Staging`은 `staging`, `Release`는 `prod` database를 사용하도록 build setting 구성
- TestFlight archive는 `Staging/staging`, App Store archive는 `Release/prod` 조합으로 분리
- TestFlight workflow를 수동 실행 전용으로 변경하고 기존 `qa`, `qa-local` label 기반 CD 제거
- App Store workflow를 별도로 추가해 Release/prod archive 및 App Store Connect upload 경로 분리
- build number는 App Store Connect 전체 upload 기준으로 자동 증가하도록 네이밍 정리
- archive 전 `Staging -> staging`, `Release -> prod` 조합 검증 추가
- TestFlight/App Store upload 전 IPA 내부 Firestore database ID 재검증 추가
- callable Functions는 기존 endpoint 호출을 유지하고, staging/prod endpoint 분리는 후속 REST API 전환 작업에서 처리하도록 정리

## 📸 영상 / 이미지 (Optional)
