### PR TITLE
[#651] REST API 실패 응답의 status code와 body를 Crashlytics에 기록하도록 개선한다

### DIFF
--- a/Application/DevLogInfra/Sources/Common/FirebaseCrashlyticsHelper.swift
+++ b/Application/DevLogInfra/Sources/Common/FirebaseCrashlyticsHelper.swift
@@ -7,6 +7,7 @@
 
 import FirebaseCrashlytics
 import Foundation
+import Nexa
 
 enum FirebaseCrashlyticsHelper {
     static func record(
@@ -39,6 +40,11 @@ private extension FirebaseCrashlyticsHelper {
         case underlyingCode
     }
 
+    enum RESTKey: String {
+        case statusCode = "restStatusCode"
+        case errorMessage = "restErrorMessage"
+    }
+
     static func userInfo(
         for nsError: NSError,
         error: Error,
@@ -51,10 +57,43 @@ private extension FirebaseCrashlyticsHelper {
             Key.underlyingCode.rawValue: nsError.code
         ]
 
+        restMetadata(for: error).forEach {
+            userInfo[$0.key] = $0.value
+        }
+
         metadata.forEach {
             userInfo[$0.key] = $0.value
         }
 
         return userInfo
+    }
+
+    static func restMetadata(for error: Error) -> [String: String] {
+        guard let error = error as? NXError else { return [:] }
+
+        switch error {
+        case let .invalidStatus(statusCode, data),
+             let .server(statusCode, data, underlying: _):
+            var metadata = [
+                RESTKey.statusCode.rawValue: String(statusCode)
+            ]
+
+            if let message = restErrorMessage(from: data) {
+                metadata[RESTKey.errorMessage.rawValue] = message
+            }
+
+            return metadata
+        default:
+            return [:]
+        }
+    }
+
+    private static func restErrorMessage(from data: Data?) -> String? {
+        struct RESTErrorBody: Decodable {
+            let message: String?
+        }
+
+        guard let data else { return nil }
+        return try? JSONDecoder().decode(RESTErrorBody.self, from: data).message
     }
 }


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #651

## 🎯 의도

REST API 실패 시 Crashlytics non-fatal 로그에서 서버 응답의 status code와 에러 메시지를 확인할 수 있도록 개선

## 📝 작업 내용

### 📌 요약

- `FirebaseCrashlyticsHelper`에서 `NXError` 기반 REST 실패 응답 메타데이터 추출
- Crashlytics `userInfo`에 `restStatusCode`, `restErrorMessage` 추가
- REST 응답 body 파싱 범위를 에러 메시지로 제한

### 🔍 상세

- `NXError.invalidStatus`, `NXError.server`에서 HTTP status code와 response data 추출
- 서버 응답 body의 `message` 값을 디코딩해 Crashlytics 메타데이터로 기록
- 기존 service별 `record` 호출부와 `FunctionAPIClient` 에러 전파 흐름은 유지

## 📸 영상 / 이미지 (Optional)