### PR TITLE
[#654] 스토어 배포 빌드에서 FUNCTION_API_BASE_URL 설정을 검증한다

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -263,7 +263,8 @@ platform :ios do
   lane :deploy_testflight do
     build_for_store(
       configuration: TESTFLIGHT_CONFIGURATION,
-      database_id: TESTFLIGHT_DATABASE_ID
+      database_id: TESTFLIGHT_DATABASE_ID,
+      function_api_base_url: TESTFLIGHT_FUNCTION_API_BASE_URL
     )
 
     upload_testflight_build
@@ -272,7 +273,8 @@ platform :ios do
   lane :testflight_build_only do
     build_for_store(
       configuration: TESTFLIGHT_CONFIGURATION,
-      database_id: TESTFLIGHT_DATABASE_ID
+      database_id: TESTFLIGHT_DATABASE_ID,
+      function_api_base_url: TESTFLIGHT_FUNCTION_API_BASE_URL
     )
   end
 
@@ -280,7 +282,8 @@ platform :ios do
     build_for_store(
       configuration: APPSTORE_CONFIGURATION,
       output_directory: APPSTORE_BUILD_OUTPUT_DIRECTORY,
-      database_id: APPSTORE_DATABASE_ID
+      database_id: APPSTORE_DATABASE_ID,
+      function_api_base_url: APPSTORE_FUNCTION_API_BASE_URL
     )
   end
 
@@ -288,7 +291,8 @@ platform :ios do
     build_for_store(
       configuration: APPSTORE_CONFIGURATION,
       output_directory: APPSTORE_BUILD_OUTPUT_DIRECTORY,
-      database_id: APPSTORE_DATABASE_ID
+      database_id: APPSTORE_DATABASE_ID,
+      function_api_base_url: APPSTORE_FUNCTION_API_BASE_URL
     )
 
     upload_appstore_build

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -11,6 +11,8 @@ TESTFLIGHT_CONFIGURATION = "Staging"
 APPSTORE_CONFIGURATION = "Release"
 TESTFLIGHT_DATABASE_ID = "staging"
 APPSTORE_DATABASE_ID = "prod"
+TESTFLIGHT_FUNCTION_API_BASE_URL = "https://asia-northeast3-devlog-c87b6.cloudfunctions.net/stagingApi/api"
+APPSTORE_FUNCTION_API_BASE_URL = "https://asia-northeast3-devlog-c87b6.cloudfunctions.net/prodApi/api"
 TESTFLIGHT_BUILD_OUTPUT_DIRECTORY = File.expand_path("testflight_build", __dir__)
 TESTFLIGHT_IPA_OUTPUT_PATH = File.join(TESTFLIGHT_BUILD_OUTPUT_DIRECTORY, "#{APP_PRODUCT_NAME}.ipa")
 APPSTORE_BUILD_OUTPUT_DIRECTORY = File.expand_path("appstore_build", __dir__)
@@ -60,37 +62,53 @@ platform :ios do
   private_lane :verify_store_configuration do |options|
     configuration = options[:configuration].to_s.strip
     database_id = options[:database_id].to_s.strip
+    function_api_base_url = options[:function_api_base_url].to_s.strip
 
-    expected_database_id =
+    expected_configuration =
       case configuration
       when TESTFLIGHT_CONFIGURATION
-        TESTFLIGHT_DATABASE_ID
+        {
+          database_id: TESTFLIGHT_DATABASE_ID,
+          function_api_base_url: TESTFLIGHT_FUNCTION_API_BASE_URL
+        }
       when APPSTORE_CONFIGURATION
-        APPSTORE_DATABASE_ID
+        {
+          database_id: APPSTORE_DATABASE_ID,
+          function_api_base_url: APPSTORE_FUNCTION_API_BASE_URL
+        }
       else
         UI.user_error!("Unsupported store configuration: #{configuration}")
       end
 
     UI.user_error!("Missing Firestore database ID for #{configuration}") if database_id.empty?
+    UI.user_error!("Missing Function API base URL for #{configuration}") if function_api_base_url.empty?
 
-    if database_id != expected_database_id
+    if database_id != expected_configuration[:database_id]
       UI.user_error!(
-        "Invalid store configuration: #{configuration} must use FIRESTORE_DATABASE_ID=#{expected_database_id}, got #{database_id}"
+        "Invalid store configuration: #{configuration} must use FIRESTORE_DATABASE_ID=#{expected_configuration[:database_id]}, got #{database_id}"
       )
     end
 
-    UI.message("Verified store configuration: #{configuration}/#{database_id}")
+    if function_api_base_url != expected_configuration[:function_api_base_url]
+      UI.user_error!(
+        "Invalid store configuration: #{configuration} must use FUNCTION_API_BASE_URL=#{expected_configuration[:function_api_base_url]}, got #{function_api_base_url}"
+      )
+    end
+
+    UI.message("Verified store configuration: #{configuration}/#{database_id}/#{function_api_base_url}")
   end
 
-  private_lane :verify_firestore_database_id do |options|
+  private_lane :verify_store_info_plist do |options|
     require "shellwords"
     require "tmpdir"
 
     ipa_path = options[:ipa]
     expected_database_id = options[:database_id]
+    expected_function_api_base_url = options[:function_api_base_url]
 
     UI.user_error!("Missing IPA path") if ipa_path.to_s.strip.empty?
     UI.user_error!("Missing expected Firestore database ID") if expected_database_id.to_s.strip.empty?
+    UI.user_error!("Missing expected Function API base URL") if expected_function_api_base_url.to_s.strip.empty?
     UI.user_error!("Missing built ipa at #{ipa_path}") if !File.exist?(ipa_path)
 
     Dir.mktmpdir("devlog-ipa") do |tmpdir|
@@ -111,6 +129,19 @@ platform :ios do
       end
 
       UI.message("Verified FIRESTORE_DATABASE_ID=#{actual_database_id}")
+
+      actual_function_api_base_url = sh(
+        "/usr/libexec/PlistBuddy -c 'Print :FUNCTION_API_BASE_URL' #{Shellwords.escape(plist_path)}",
+        log: false
+      ).strip
+
+      if actual_function_api_base_url != expected_function_api_base_url
+        UI.user_error!(
+          "Unexpected FUNCTION_API_BASE_URL: expected #{expected_function_api_base_url}, got #{actual_function_api_base_url}"
+        )
+      end
+
+      UI.message("Verified FUNCTION_API_BASE_URL=#{actual_function_api_base_url}")
     end
   end
 
@@ -119,10 +150,13 @@ platform :ios do
     output_directory = options[:output_directory] || TESTFLIGHT_BUILD_OUTPUT_DIRECTORY
     expected_database_id = options[:database_id] ||
       (configuration == APPSTORE_CONFIGURATION ? APPSTORE_DATABASE_ID : TESTFLIGHT_DATABASE_ID)
+    expected_function_api_base_url = options[:function_api_base_url] ||
+      (configuration == APPSTORE_CONFIGURATION ? APPSTORE_FUNCTION_API_BASE_URL : TESTFLIGHT_FUNCTION_API_BASE_URL)
 
     verify_store_configuration(
       configuration: configuration,
-      database_id: expected_database_id
+      database_id: expected_database_id,
+      function_api_base_url: expected_function_api_base_url
     )
 
     if ENV["FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT"].to_s.strip.empty?
@@ -212,9 +246,10 @@ platform :ios do
     ipa_output_path = lane_context[SharedValues::IPA_OUTPUT_PATH].to_s
     ipa_output_path = File.join(output_directory, "#{APP_PRODUCT_NAME}.ipa") if ipa_output_path.empty?
 
-    verify_firestore_database_id(
+    verify_store_info_plist(
       ipa: ipa_output_path,
-      database_id: expected_database_id
+      database_id: expected_database_id,
+      function_api_base_url: expected_function_api_base_url
     )
 
     dsym_output_path = lane_context[SharedValues::DSYM_OUTPUT_PATH]

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -315,9 +315,10 @@ platform :ios do
 
     UI.user_error!("Missing built ipa at #{ipa_output_path}") if !File.exist?(ipa_output_path)
 
-    verify_firestore_database_id(
+    verify_store_info_plist(
       ipa: ipa_output_path,
-      database_id: TESTFLIGHT_DATABASE_ID
+      database_id: TESTFLIGHT_DATABASE_ID,
+      function_api_base_url: TESTFLIGHT_FUNCTION_API_BASE_URL
     )
 
     upload_to_testflight(
@@ -335,9 +336,10 @@ platform :ios do
 
     UI.user_error!("Missing built ipa at #{ipa_output_path}") if !File.exist?(ipa_output_path)
 
-    verify_firestore_database_id(
+    verify_store_info_plist(
       ipa: ipa_output_path,
-      database_id: APPSTORE_DATABASE_ID
+      database_id: APPSTORE_DATABASE_ID,
+      function_api_base_url: APPSTORE_FUNCTION_API_BASE_URL
     )
 
     upload_to_app_store(


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #654

## 🎯 의도

- 스토어 배포 빌드에서 `FUNCTION_API_BASE_URL` 설정 누락 또는 오설정을 빌드 단계에서 감지하도록 개선

## 📝 작업 내용

### 📌 요약

- TestFlight / App Store 배포 환경별 Function API base URL 기대값 추가
- IPA `Info.plist` 검증 범위를 `FIRESTORE_DATABASE_ID`에서 `FUNCTION_API_BASE_URL`까지 확장
- 배포 설정 사전 검증에서도 Function API base URL 일치 여부 확인

### 🔍 상세

- TestFlight 빌드는 staging Function API URL을 기대값으로 검증
- App Store 빌드는 prod Function API URL을 기대값으로 검증
- 빌드된 IPA의 `Info.plist`에서 `FUNCTION_API_BASE_URL`을 읽어 기대값과 다르면 fastlane lane 실패 처리
- 기존 `FIRESTORE_DATABASE_ID` 검증 흐름은 유지하면서 스토어 설정 검증 lane으로 확장

## 📸 영상 / 이미지 (Optional)
