### PR TITLE
[#637] regular ui에서 Todo가 삭제 혹은 수정되었을 때 HomeView의 최근 섹션 탭이 깜빡이는 현상을 해결한다

### DIFF
--- a/Application/DevLogPresentation/Sources/Home/Home/HomeView.swift
+++ b/Application/DevLogPresentation/Sources/Home/Home/HomeView.swift
@@ -72,7 +72,7 @@ struct HomeView: View {
 
     private var recentTodoSection: some View {
         Section {
-            if store.isRecentTodosLoading {
+            if store.isRecentTodosLoading && store.recentTodos.isEmpty {
                 LoadingView()
             } else if store.recentTodos.isEmpty {
                 HStack {


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #637

## 🎯 의도

- regular UI에서 Todo detail 수정 후 HomeView의 최근 수정 섹션이 로딩 뷰로 교체되며 깜빡이는 현상 방지

## 📝 작업 내용

### 📌 요약

- 최근 수정 목록이 비어 있을 때만 LoadingView 표시
- 기존 최근 수정 row가 있는 refresh 중에는 현재 row 유지

### 🔍 상세

- `isRecentTodosLoading` 상태에서도 `recentTodos`가 비어 있지 않으면 기존 row 렌더링 유지
- detail 수정 후 mutation event로 최근 수정 목록을 다시 받아오는 기존 데이터 흐름 유지
- fetch 완료 시 `ForEach(id: \.id)` 기준으로 변경된 row만 SwiftUI diff에 따라 반영

## 📸 영상 / 이미지 (Optional)
