### PR TITLE
[#658] TodoEditor 저장 결과 전달을 TCA delegate action으로 전환한다

### DIFF
--- a/Application/Presentation/Sources/Home/Detail/TodoDetailFeature.swift
+++ b/Application/Presentation/Sources/Home/Detail/TodoDetailFeature.swift
@@ -57,18 +57,26 @@ struct TodoDetailFeature {
     @ObservableState
     struct FullScreenCoverState: Equatable {
         var destination: Destination
+        var todoEditor: TodoEditorFeature.State?
 
         enum Destination: Equatable {
             case editor
         }
 
         static let editor = Self(destination: .editor)
+
+        static func editor(_ todo: Todo) -> Self {
+            Self(
+                destination: .editor,
+                todoEditor: TodoEditorFeature.State(todo: todo)
+            )
+        }
     }
 
     enum Action {
         case alert(PresentationAction<Never>)
         case sheet(PresentationAction<Sheet>)
-        case fullScreenCover(PresentationAction<Never>)
+        case fullScreenCover(PresentationAction<FullScreenCover>)
         case onAppear
         case fetchFailed
         case setSheet(SheetState?)
@@ -81,6 +89,11 @@ struct TodoDetailFeature {
         enum Sheet {
             case tapCloseButton
             case todo(TodoDetailFeature.Action)
+        }
+
+        @CasePathable
+        enum FullScreenCover {
+            case todoEditor(TodoEditorFeature.Action)
         }
     }
 
@@ -101,6 +114,11 @@ struct TodoDetailFeature {
                 state.sheet = nil
             case .sheet:
                 break
+            case .fullScreenCover(.presented(.todoEditor(.delegate(.updated(let todo))))):
+                state.fullScreenCover = nil
+                state.todo = todo
+                state.referenceItems = [:]
+                return resolveMarkdownEffect(content: todo.content)
             case .fullScreenCover(.dismiss):
                 state.fullScreenCover = nil
             case .fullScreenCover:
@@ -112,7 +130,12 @@ struct TodoDetailFeature {
             case .setSheet(let sheet):
                 state.sheet = sheet
             case .setFullScreenCover(let cover):
-                state.fullScreenCover = cover
+                if cover?.destination == .editor,
+                   let todo = state.todo {
+                    state.fullScreenCover = .editor(todo)
+                } else {
+                    state.fullScreenCover = nil
+                }
             case .setTodo(let todo):
                 state.todo = todo
                 state.referenceItems = [:]
@@ -129,6 +152,21 @@ struct TodoDetailFeature {
         .ifLet(\.$sheet, action: \.sheet) {
             TodoDetailSheetFeature()
         }
+        .ifLet(\.$fullScreenCover, action: \.fullScreenCover) {
+            TodoDetailFullScreenCoverFeature()
+        }
+    }
+}
+
+private struct TodoDetailFullScreenCoverFeature: Reducer {
+    typealias State = TodoDetailFeature.FullScreenCoverState
+    typealias Action = TodoDetailFeature.Action.FullScreenCover
+
+    var body: some ReducerOf<Self> {
+        EmptyReducer()
+            .ifLet(\.todoEditor, action: \.todoEditor) {
+                TodoEditorFeature()
+            }
     }
 }
 

--- a/Application/Presentation/Sources/Home/Detail/TodoDetailView.swift
+++ b/Application/Presentation/Sources/Home/Detail/TodoDetailView.swift
@@ -82,26 +82,12 @@ struct TodoDetailView: View {
 
     @ViewBuilder
     private func fullScreenCoverContent(
-        _ coverStore: Store<TodoDetailFeature.FullScreenCoverState, Never>
+        _ coverStore: Store<TodoDetailFeature.FullScreenCoverState, TodoDetailFeature.Action.FullScreenCover>
     ) -> some View {
         switch coverStore.destination {
         case .editor:
-            if let todo = store.todo {
-                TodoEditorView(
-                    store: Store(initialState: TodoEditorFeature.State(todo: todo)) {
-                        TodoEditorFeature()
-                    } withDependencies: {
-                        $0.fetchTodoCategoryPreferencesUseCase = container.resolve(
-                            FetchTodoCategoryPreferencesUseCase.self
-                        )
-                        $0.fetchReferenceItemsUseCase = container.resolve(FetchReferenceItemsUseCase.self)
-                        $0.upsertTodoUseCase = container.resolve(UpsertTodoUseCase.self)
-                    },
-                    onUpdateSuccess: { todo in
-                        store.send(.setFullScreenCover(nil))
-                        store.send(.setTodo(todo))
-                    }
-                )
+            if let todoEditorStore = coverStore.scope(state: \.todoEditor, action: \.todoEditor) {
+                TodoEditorView(store: todoEditorStore)
             }
         }
     }

--- a/Application/Presentation/Sources/Home/Editor/TodoEditorFeature.swift
+++ b/Application/Presentation/Sources/Home/Editor/TodoEditorFeature.swift
@@ -141,7 +141,6 @@ struct TodoEditorFeature {
     @Dependency(\.fetchTodoCategoryPreferencesUseCase) var fetchPreferencesUseCase
     @Dependency(\.fetchReferenceItemsUseCase) var fetchReferenceItemsUseCase
     @Dependency(\.upsertTodoUseCase) var upsertTodoUseCase
-    @Dependency(\.trackAnalyticsEventUseCase) var trackAnalyticsEventUseCase
 
     var body: some ReducerOf<Self> {
         Scope(state: \.loading, action: \.loading) {
@@ -308,11 +307,10 @@ private extension TodoEditorFeature {
     }
 
     func createTodoEffect(_ draft: TodoDraft) -> Effect<Action> {
-        .run { [trackAnalyticsEventUseCase, upsertTodoUseCase] send in
+        .run { [upsertTodoUseCase] send in
             await send(.loading(.begin(target: .default, mode: .immediate)))
             do {
                 try await upsertTodoUseCase.execute(draft)
-                trackAnalyticsEventUseCase.execute(.todoCreate)
                 await send(.createSucceeded)
                 await send(.delegate(.created))
             } catch {

--- a/Application/Presentation/Sources/Home/Editor/TodoEditorFeature.swift
+++ b/Application/Presentation/Sources/Home/Editor/TodoEditorFeature.swift
@@ -111,6 +111,7 @@ struct TodoEditorFeature {
         case alert(PresentationAction<Never>)
         case sheet(PresentationAction<Sheet>)
         case binding(BindingAction<State>)
+        case delegate(Delegate)
         case onAppear
         case addTag(String)
         case removeTag(String)
@@ -124,6 +125,11 @@ struct TodoEditorFeature {
 
         enum Sheet: Equatable {
             case tapCloseButton
+        }
+
+        enum Delegate: Equatable {
+            case created
+            case updated(Todo)
         }
     }
 
@@ -168,6 +174,8 @@ struct TodoEditorFeature {
                     return resolveMarkdownEffect(content: state.content)
                 }
             case .binding:
+                break
+            case .delegate:
                 break
             case .onAppear:
                 return fetchCategoriesEffect()
@@ -306,6 +314,7 @@ private extension TodoEditorFeature {
                 try await upsertTodoUseCase.execute(draft)
                 trackAnalyticsEventUseCase.execute(.todoCreate)
                 await send(.createSucceeded)
+                await send(.delegate(.created))
             } catch {
                 await send(.saveFailed)
             }
@@ -319,6 +328,7 @@ private extension TodoEditorFeature {
             do {
                 try await upsertTodoUseCase.execute(todo)
                 await send(.updateSucceeded(todo))
+                await send(.delegate(.updated(todo)))
             } catch {
                 await send(.saveFailed)
             }

--- a/Application/Presentation/Sources/Home/Home/HomeFeature+Effects.swift
+++ b/Application/Presentation/Sources/Home/Home/HomeFeature+Effects.swift
@@ -84,6 +84,12 @@ extension HomeFeature {
         }
     }
 
+    func trackTodoCreateEffect() -> Effect<Action> {
+        .run { [trackAnalyticsEventUseCase] _ in
+            trackAnalyticsEventUseCase.execute(.todoCreate)
+        }
+    }
+
     func deleteWebPageEffect(_ page: WebPageItem) -> Effect<Action> {
         .run { [deleteWebPageUseCase] send in
             do {

--- a/Application/Presentation/Sources/Home/Home/HomeFeature.swift
+++ b/Application/Presentation/Sources/Home/Home/HomeFeature.swift
@@ -28,8 +28,7 @@ struct HomeFeature {
 
         var showContentPicker: Bool { sheet?.contentPickerState != nil }
         var showTodoEditor: Bool {
-            guard case .todoEditor = fullScreenCover?.destination else { return false }
-            return true
+            fullScreenCover?.destination == .todoEditor
         }
 
         var isPreferencesLoading: Bool {

--- a/Application/Presentation/Sources/Home/Home/HomeFeature.swift
+++ b/Application/Presentation/Sources/Home/Home/HomeFeature.swift
@@ -208,7 +208,10 @@ struct HomeFeature {
             case .fullScreenCover(.presented(.todoEditor(.delegate(.created)))):
                 state.fullScreenCover = nil
                 state.selectedTodoCategory = nil
-                return .send(.view(.fetchData))
+                return .merge(
+                    trackTodoCreateEffect(),
+                    .send(.view(.fetchData))
+                )
             case .fullScreenCover(.dismiss):
                 state.fullScreenCover = nil
                 state.selectedTodoCategory = nil

--- a/Application/Presentation/Sources/Home/Home/HomeFeature.swift
+++ b/Application/Presentation/Sources/Home/Home/HomeFeature.swift
@@ -27,7 +27,10 @@ struct HomeFeature {
         var loading = LoadingFeature.State()
 
         var showContentPicker: Bool { sheet?.contentPickerState != nil }
-        var showTodoEditor: Bool { fullScreenCover?.destination == .todoEditor }
+        var showTodoEditor: Bool {
+            guard case .todoEditor = fullScreenCover?.destination else { return false }
+            return true
+        }
 
         var isPreferencesLoading: Bool {
             loading.visibleTargets.contains(LoadingTarget.preferences.target)
@@ -54,7 +57,7 @@ struct HomeFeature {
     enum Action: Equatable {
         case alert(PresentationAction<Never>)
         case sheet(PresentationAction<Sheet>)
-        case fullScreenCover(PresentationAction<Never>)
+        case fullScreenCover(PresentationAction<FullScreenCover>)
         case view(ViewAction)
         case store(StoreAction)
         case loading(LoadingFeature.Action)
@@ -135,6 +138,7 @@ struct HomeFeature {
     struct FullScreenCoverState: Equatable {
         var destination: Destination
         var selectedTodoCategory: TodoCategory?
+        var todoEditor: TodoEditorFeature.State?
 
         enum Destination: Equatable {
             case todoEditor
@@ -142,10 +146,19 @@ struct HomeFeature {
         }
 
         static func todoEditor(_ category: TodoCategory) -> Self {
-            Self(destination: .todoEditor, selectedTodoCategory: category)
+            Self(
+                destination: .todoEditor,
+                selectedTodoCategory: category,
+                todoEditor: TodoEditorFeature.State(category: category)
+            )
         }
 
         static let search = Self(destination: .search)
+    }
+
+    @CasePathable
+    enum FullScreenCover: Equatable {
+        case todoEditor(TodoEditorFeature.Action)
     }
 
     enum Presentation: Equatable {
@@ -193,6 +206,10 @@ struct HomeFeature {
             switch action {
             case .alert:
                 break
+            case .fullScreenCover(.presented(.todoEditor(.delegate(.created)))):
+                state.fullScreenCover = nil
+                state.selectedTodoCategory = nil
+                return .send(.view(.fetchData))
             case .fullScreenCover(.dismiss):
                 state.fullScreenCover = nil
                 state.selectedTodoCategory = nil
@@ -216,6 +233,21 @@ struct HomeFeature {
         .ifLet(\.$sheet, action: \.sheet) {
             HomeSheetFeature()
         }
+        .ifLet(\.$fullScreenCover, action: \.fullScreenCover) {
+            HomeFullScreenCoverFeature()
+        }
+    }
+}
+
+private struct HomeFullScreenCoverFeature: Reducer {
+    typealias State = HomeFeature.FullScreenCoverState
+    typealias Action = HomeFeature.FullScreenCover
+
+    var body: some ReducerOf<Self> {
+        EmptyReducer()
+            .ifLet(\.todoEditor, action: \.todoEditor) {
+                TodoEditorFeature()
+            }
     }
 }
 

--- a/Application/Presentation/Sources/Home/Home/HomeView.swift
+++ b/Application/Presentation/Sources/Home/Home/HomeView.swift
@@ -269,17 +269,13 @@ struct HomeView: View {
     }
 
     @ViewBuilder
-    private func coverContent(_ coverStore: Store<HomeFeature.FullScreenCoverState, Never>) -> some View {
+    private func coverContent(
+        _ coverStore: Store<HomeFeature.FullScreenCoverState, HomeFeature.FullScreenCover>
+    ) -> some View {
         switch coverStore.destination {
         case .todoEditor:
-            if let selectedCategory = coverStore.selectedTodoCategory {
-                TodoEditorView(
-                    store: coordinator.makeTodoEditorStore(category: selectedCategory),
-                    onCreateSuccess: {
-                        store.send(.store(.setPresentation(.todoEditor, false)))
-                        store.send(.view(.fetchData))
-                    }
-                )
+            if let todoEditorStore = coverStore.scope(state: \.todoEditor, action: \.todoEditor) {
+                TodoEditorView(store: todoEditorStore)
             }
         case .search:
             SearchView(store: coordinator.makeSearchStore())

--- a/Application/Presentation/Sources/Home/Home/HomeViewCoordinator.swift
+++ b/Application/Presentation/Sources/Home/Home/HomeViewCoordinator.swift
@@ -39,6 +39,8 @@ final class HomeViewCoordinator {
             $0.homeFetchTodosUseCase = container.resolve(FetchTodosUseCase.self)
             $0.homeFetchWebPagesUseCase = container.resolve(FetchWebPagesUseCase.self)
             $0.networkConnectivityUseCase = container.resolve(ObserveNetworkConnectivityUseCase.self)
+            $0.fetchReferenceItemsUseCase = container.resolve(FetchReferenceItemsUseCase.self)
+            $0.upsertTodoUseCase = container.resolve(UpsertTodoUseCase.self)
             $0.trackAnalyticsEventUseCase = container.resolve(TrackAnalyticsEventUseCase.self)
         }
         self.store.send(.view(.startObserving))
@@ -80,17 +82,6 @@ final class HomeViewCoordinator {
                 self?.store.send(.view(.fetchData))
             }
             .store(in: &cancellables)
-    }
-
-    func makeTodoEditorStore(category: TodoCategory) -> StoreOf<TodoEditorFeature> {
-        Store(initialState: TodoEditorFeature.State(category: category)) {
-            TodoEditorFeature()
-        } withDependencies: {
-            $0.fetchTodoCategoryPreferencesUseCase = self.container.resolve(FetchTodoCategoryPreferencesUseCase.self)
-            $0.fetchReferenceItemsUseCase = self.container.resolve(FetchReferenceItemsUseCase.self)
-            $0.upsertTodoUseCase = self.container.resolve(UpsertTodoUseCase.self)
-            $0.trackAnalyticsEventUseCase = self.container.resolve(TrackAnalyticsEventUseCase.self)
-        }
     }
 
     func makeSearchStore() -> StoreOf<SearchFeature> {

--- a/Application/Presentation/Sources/Home/List/TodoListFeature+Effects.swift
+++ b/Application/Presentation/Sources/Home/List/TodoListFeature+Effects.swift
@@ -61,6 +61,12 @@ extension TodoListFeature {
         )
     }
 
+    func trackTodoCreateEffect() -> Effect<Action> {
+        .run { [trackAnalyticsEventUseCase] _ in
+            trackAnalyticsEventUseCase.execute(.todoCreate)
+        }
+    }
+
     func togglePinnedEffect(_ item: TodoListItem) -> Effect<Action> {
         .concatenate(
             .send(.loading(.begin(target: .default, mode: .delayed))),

--- a/Application/Presentation/Sources/Home/List/TodoListFeature.swift
+++ b/Application/Presentation/Sources/Home/List/TodoListFeature.swift
@@ -51,21 +51,34 @@ struct TodoListFeature {
     @ObservableState
     struct FullScreenCoverState: Equatable {
         var destination: Destination
+        var todoEditor: TodoEditorFeature.State?
 
         enum Destination: Equatable {
             case editor
         }
 
         static let editor = Self(destination: .editor)
+
+        static func editor(_ category: TodoCategory) -> Self {
+            Self(
+                destination: .editor,
+                todoEditor: TodoEditorFeature.State(category: category)
+            )
+        }
     }
 
     enum Action: BindableAction {
         case alert(PresentationAction<Never>)
-        case fullScreenCover(PresentationAction<Never>)
+        case fullScreenCover(PresentationAction<FullScreenCover>)
         case binding(BindingAction<State>)
         case view(ViewAction)
         case store(StoreAction)
         case loading(LoadingFeature.Action)
+
+        @CasePathable
+        enum FullScreenCover: Equatable {
+            case todoEditor(TodoEditorFeature.Action)
+        }
 
         enum ViewAction: Equatable {
             case refresh
@@ -118,6 +131,9 @@ struct TodoListFeature {
             switch action {
             case .alert:
                 break
+            case .fullScreenCover(.presented(.todoEditor(.delegate(.created)))):
+                state.fullScreenCover = nil
+                return fetchEffect(query: state.query, cursor: nil, showsIndicator: false)
             case .fullScreenCover(.dismiss):
                 state.fullScreenCover = nil
             case .fullScreenCover:
@@ -147,6 +163,21 @@ struct TodoListFeature {
             return .none
         }
         .ifLet(\.$alert, action: \.alert)
+        .ifLet(\.$fullScreenCover, action: \.fullScreenCover) {
+            TodoListFullScreenCoverFeature()
+        }
+    }
+}
+
+private struct TodoListFullScreenCoverFeature: Reducer {
+    typealias State = TodoListFeature.FullScreenCoverState
+    typealias Action = TodoListFeature.Action.FullScreenCover
+
+    var body: some ReducerOf<Self> {
+        EmptyReducer()
+            .ifLet(\.todoEditor, action: \.todoEditor) {
+                TodoEditorFeature()
+            }
     }
 }
 
@@ -321,7 +352,7 @@ private extension TodoListFeature {
     ) -> Effect<Action> {
         switch action {
         case .setFullScreenCover(let cover):
-            state.fullScreenCover = cover
+            state.fullScreenCover = cover?.destination == .editor ? .editor(state.category) : nil
         case .setAlert(let value):
             Self.setAlert(&state, isPresented: value)
         case .applySearchQuery(let query):

--- a/Application/Presentation/Sources/Home/List/TodoListFeature.swift
+++ b/Application/Presentation/Sources/Home/List/TodoListFeature.swift
@@ -133,7 +133,10 @@ struct TodoListFeature {
                 break
             case .fullScreenCover(.presented(.todoEditor(.delegate(.created)))):
                 state.fullScreenCover = nil
-                return fetchEffect(query: state.query, cursor: nil, showsIndicator: false)
+                return .merge(
+                    trackTodoCreateEffect(),
+                    fetchEffect(query: state.query, cursor: nil, showsIndicator: false)
+                )
             case .fullScreenCover(.dismiss):
                 state.fullScreenCover = nil
             case .fullScreenCover:

--- a/Application/Presentation/Sources/Home/List/TodoListView.swift
+++ b/Application/Presentation/Sources/Home/List/TodoListView.swift
@@ -12,7 +12,6 @@ import Domain
 
 struct TodoListView: View {
     @Environment(NavigationRouter<HomeRoute>.self) private var router
-    @Environment(\.diContainer) var container: DIContainer
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.openWindow) private var openWindow
     @Environment(\.isiOSAppOnMac) private var isiOSAppOnMac
@@ -198,24 +197,15 @@ struct TodoListView: View {
 
     @ViewBuilder
     private func fullScreenCoverContent(
-        _ coverStore: Store<TodoListFeature.FullScreenCoverState, Never>
+        _ coverStore: Store<
+        TodoListFeature.FullScreenCoverState,
+        TodoListFeature.Action.FullScreenCover>
     ) -> some View {
         switch coverStore.destination {
         case .editor:
-            TodoEditorView(
-                store: Store(initialState: TodoEditorFeature.State(category: store.category)) {
-                    TodoEditorFeature()
-                } withDependencies: {
-                    $0.fetchTodoCategoryPreferencesUseCase = container.resolve(FetchTodoCategoryPreferencesUseCase.self)
-                    $0.fetchReferenceItemsUseCase = container.resolve(FetchReferenceItemsUseCase.self)
-                    $0.upsertTodoUseCase = container.resolve(UpsertTodoUseCase.self)
-                    $0.trackAnalyticsEventUseCase = container.resolve(TrackAnalyticsEventUseCase.self)
-                },
-                onCreateSuccess: {
-                    store.send(.store(.setFullScreenCover(nil)))
-                    store.send(.view(.refresh))
-                }
-            )
+            if let todoEditorStore = coverStore.scope(state: \.todoEditor, action: \.todoEditor) {
+                TodoEditorView(store: todoEditorStore)
+            }
         }
     }
 

--- a/Application/Presentation/Sources/Search/SearchView.swift
+++ b/Application/Presentation/Sources/Search/SearchView.swift
@@ -27,8 +27,12 @@ struct SearchView: View {
                         ) {
                             TodoDetailFeature()
                         } withDependencies: {
+                            $0.fetchTodoCategoryPreferencesUseCase = container.resolve(
+                                FetchTodoCategoryPreferencesUseCase.self
+                            )
                             $0.fetchTodoByIdUseCase = container.resolve(FetchTodoByIdUseCase.self)
                             $0.fetchReferenceItemsUseCase = container.resolve(FetchReferenceItemsUseCase.self)
+                            $0.upsertTodoUseCase = container.resolve(UpsertTodoUseCase.self)
                         })
                     case .web(let page):
                         WebView(url: page.url)

--- a/Application/Presentation/Sources/WindowGroup/TodoEditorWindowView.swift
+++ b/Application/Presentation/Sources/WindowGroup/TodoEditorWindowView.swift
@@ -37,7 +37,6 @@ public struct TodoEditorWindowView: View {
                         )
                         $0.fetchReferenceItemsUseCase = container.resolve(FetchReferenceItemsUseCase.self)
                         $0.upsertTodoUseCase = container.resolve(UpsertTodoUseCase.self)
-                        $0.trackAnalyticsEventUseCase = container.resolve(TrackAnalyticsEventUseCase.self)
                     },
                     onCreateSuccess: create,
                     onClose: closeWindow

--- a/Application/Presentation/Sources/WindowGroup/TodoWindowCoordinator.swift
+++ b/Application/Presentation/Sources/WindowGroup/TodoWindowCoordinator.swift
@@ -86,6 +86,7 @@ final class TodoWindowCoordinator {
     private func handleTodoEditorSubmit(_ submit: TodoEditorWindowSubmit) {
         switch submit {
         case .create(let value):
+            container.resolve(TrackAnalyticsEventUseCase.self).execute(.todoCreate)
             if let listStore,
                value.matchesCreate(category: listStore.category, source: .list) {
                 listStore.send(.view(.refresh))

--- a/Application/Presentation/Sources/WindowGroup/TodoWindowCoordinator.swift
+++ b/Application/Presentation/Sources/WindowGroup/TodoWindowCoordinator.swift
@@ -74,8 +74,10 @@ final class TodoWindowCoordinator {
         ) {
             TodoDetailFeature()
         } withDependencies: {
+            $0.fetchTodoCategoryPreferencesUseCase = self.container.resolve(FetchTodoCategoryPreferencesUseCase.self)
             $0.fetchTodoByIdUseCase = self.container.resolve(FetchTodoByIdUseCase.self)
             $0.fetchReferenceItemsUseCase = self.container.resolve(FetchReferenceItemsUseCase.self)
+            $0.upsertTodoUseCase = self.container.resolve(UpsertTodoUseCase.self)
         }
         self.detailStore = detailStore
         return detailStore

--- a/Application/Presentation/Sources/WindowGroup/TodoWindowCoordinator.swift
+++ b/Application/Presentation/Sources/WindowGroup/TodoWindowCoordinator.swift
@@ -44,6 +44,8 @@ final class TodoWindowCoordinator {
         let listStore = Store(initialState: TodoListFeature.State(category: category)) {
             TodoListFeature()
         } withDependencies: {
+            $0.fetchTodoCategoryPreferencesUseCase = self.container.resolve(FetchTodoCategoryPreferencesUseCase.self)
+            $0.fetchReferenceItemsUseCase = self.container.resolve(FetchReferenceItemsUseCase.self)
             $0.todoListFetchTodosUseCase = self.container.resolve(FetchTodosUseCase.self)
             $0.fetchTodoByIdUseCase = self.container.resolve(FetchTodoByIdUseCase.self)
             $0.upsertTodoUseCase = self.container.resolve(UpsertTodoUseCase.self)

--- a/Application/Presentation/Tests/Home/HomeFeatureTestSupport.swift
+++ b/Application/Presentation/Tests/Home/HomeFeatureTestSupport.swift
@@ -155,6 +155,12 @@ struct HomeStoreTestAdapter {
 
 final class HomeTrackAnalyticsEventUseCaseSpy: TrackAnalyticsEventUseCase {
     private(set) var events = [AnalyticsEvent]()
+    var hasTrackedTodoCreate: Bool {
+        events.contains {
+            guard case .todoCreate = $0 else { return false }
+            return true
+        }
+    }
 
     func execute(_ event: AnalyticsEvent) {
         events.append(event)

--- a/Application/Presentation/Tests/Home/HomeFeatureTestSupport.swift
+++ b/Application/Presentation/Tests/Home/HomeFeatureTestSupport.swift
@@ -108,6 +108,11 @@ struct HomeStoreTestAdapter {
         await settle()
     }
 
+    func todoEditorCreated() async {
+        await store.send(.fullScreenCover(.presented(.todoEditor(.delegate(.created)))))
+        await drainReceivedActions()
+    }
+
     func orderTodoCategory(_ items: [TodoCategoryItem]) async {
         await store.send(.view(.orderTodoCategory(items)))
         await drainReceivedActions()

--- a/Application/Presentation/Tests/Home/HomeFeatureTests.swift
+++ b/Application/Presentation/Tests/Home/HomeFeatureTests.swift
@@ -42,6 +42,28 @@ struct HomeFeatureTests {
         try await verifyHomeTapTodoCategory(adapter: adapter)
     }
 
+    @Test("TodoEditor 생성 delegate는 editor를 닫고 홈 데이터를 다시 조회한다")
+    func TodoEditor_생성_delegate는_editor를_닫고_홈_데이터를_다시_조회한다() async throws {
+        let context = makeHomeFetchDataContext()
+        let adapter = HomeStoreTestAdapter(
+            fetchPreferencesUseCase: context.fetchPreferencesUseCaseSpy,
+            fetchTodosUseCase: context.fetchTodosUseCaseSpy,
+            fetchWebPagesUseCase: context.fetchWebPagesUseCaseSpy
+        )
+
+        await adapter.tapTodoCategory(.system(.feature))
+        await adapter.todoEditorCreated()
+
+        await waitUntil {
+            context.fetchTodosUseCaseSpy.queries.count == 1
+                && context.fetchWebPagesUseCaseSpy.calledQueries == [""]
+        }
+
+        #expect(!adapter.showTodoEditor)
+        #expect(adapter.recentTodos.map(\.id) == ["todo-1", "todo-2"])
+        #expect(adapter.webPages.map(\.url.absoluteString) == ["https://openai.com"])
+    }
+
     @Test("HomeFeature orderTodoCategory는 recentTodos category를 동기화하고 저장한다")
     func HomeFeature_orderTodoCategory는_recentTodos_category를_동기화하고_저장한다() async throws {
         let context = makeHomeOrderContext()

--- a/Application/Presentation/Tests/Home/HomeFeatureTests.swift
+++ b/Application/Presentation/Tests/Home/HomeFeatureTests.swift
@@ -45,10 +45,12 @@ struct HomeFeatureTests {
     @Test("TodoEditor 생성 delegate는 editor를 닫고 홈 데이터를 다시 조회한다")
     func TodoEditor_생성_delegate는_editor를_닫고_홈_데이터를_다시_조회한다() async throws {
         let context = makeHomeFetchDataContext()
+        let trackSpy = HomeTrackAnalyticsEventUseCaseSpy()
         let adapter = HomeStoreTestAdapter(
             fetchPreferencesUseCase: context.fetchPreferencesUseCaseSpy,
             fetchTodosUseCase: context.fetchTodosUseCaseSpy,
-            fetchWebPagesUseCase: context.fetchWebPagesUseCaseSpy
+            fetchWebPagesUseCase: context.fetchWebPagesUseCaseSpy,
+            trackAnalyticsEventUseCase: trackSpy
         )
 
         await adapter.tapTodoCategory(.system(.feature))
@@ -57,6 +59,7 @@ struct HomeFeatureTests {
         await waitUntil {
             context.fetchTodosUseCaseSpy.queries.count == 1
                 && context.fetchWebPagesUseCaseSpy.calledQueries == [""]
+                && trackSpy.hasTrackedTodoCreate
         }
 
         #expect(!adapter.showTodoEditor)

--- a/Application/Presentation/Tests/Home/TodoDetailFeatureTests.swift
+++ b/Application/Presentation/Tests/Home/TodoDetailFeatureTests.swift
@@ -165,11 +165,12 @@ struct TodoDetailFeatureTests {
             showEditButton: false
         )
 
+        adapter.setTodo(makeTodo(id: "todo-edit"))
         adapter.setSheet(.info)
         adapter.setFullScreenCover(.editor)
 
         #expect(adapter.sheet == .info)
-        #expect(adapter.fullScreenCover == .editor)
+        #expect(adapter.fullScreenCoverDestination == .editor)
         #expect(!adapter.showEditButton)
 
         adapter.setSheet(.todo(TodoIdItem(id: "todo-2")))
@@ -193,6 +194,36 @@ struct TodoDetailFeatureTests {
         #expect(adapter.sheet == nil)
         #expect(adapter.fullScreenCover == nil)
     }
+
+    @Test("TodoEditor 수정 delegate는 editor를 닫고 Todo 상세 상태를 갱신한다")
+    func TodoEditor_수정_delegate는_editor를_닫고_Todo_상세_상태를_갱신한다() async {
+        let reference = makeTodoReference(id: "todo-7", title: "Reference 7")
+        let referenceSpy = FetchReferenceItemsUseCaseSpy(references: [7: reference])
+        let adapter = TodoDetailStoreTestAdapter(
+            fetchUseCase: FetchTodoByIdUseCaseSpy(todo: makeTodo()),
+            referenceUseCase: referenceSpy,
+            todoId: "todo-1"
+        )
+        let updatedTodo = makeTodo(
+            id: "todo-1",
+            title: "Updated",
+            content: "- refs #7"
+        )
+
+        adapter.setTodo(makeTodo(id: "todo-1"))
+        adapter.setFullScreenCover(.editor)
+        adapter.todoEditorUpdated(updatedTodo)
+
+        #expect(adapter.fullScreenCover == nil)
+        #expect(adapter.todo == updatedTodo)
+        #expect(adapter.referenceItems.isEmpty)
+
+        await waitUntil {
+            adapter.referenceItems[7] == TodoReferenceItem(from: reference)
+        }
+
+        #expect(referenceSpy.numbers == [[7]])
+    }
 }
 
 @MainActor
@@ -205,6 +236,7 @@ private protocol TodoDetailTestAdapter {
     var alert: AlertState<Never>? { get }
     var sheet: TodoDetailFeature.SheetState? { get }
     var fullScreenCover: TodoDetailFeature.FullScreenCoverState? { get }
+    var fullScreenCoverDestination: TodoDetailFeature.FullScreenCoverState.Destination? { get }
 
     func onAppear()
     func onSheetTodoAppear()
@@ -212,6 +244,7 @@ private protocol TodoDetailTestAdapter {
     func dismissSheet()
     func setFullScreenCover(_ cover: TodoDetailFeature.FullScreenCoverState?)
     func dismissFullScreenCover()
+    func todoEditorUpdated(_ todo: Todo)
     func setTodo(_ todo: Todo)
     func setReferenceItems(_ items: [Int: TodoReferenceItem])
 }
@@ -228,6 +261,9 @@ private struct TodoDetailStoreTestAdapter: TodoDetailTestAdapter {
     var alert: AlertState<Never>? { store.alert }
     var sheet: TodoDetailFeature.SheetState? { store.sheet }
     var fullScreenCover: TodoDetailFeature.FullScreenCoverState? { store.fullScreenCover }
+    var fullScreenCoverDestination: TodoDetailFeature.FullScreenCoverState.Destination? {
+        store.fullScreenCover?.destination
+    }
 
     init(
         fetchUseCase: FetchTodoByIdUseCase,
@@ -271,6 +307,10 @@ private struct TodoDetailStoreTestAdapter: TodoDetailTestAdapter {
 
     func dismissFullScreenCover() {
         store.send(.fullScreenCover(.dismiss))
+    }
+
+    func todoEditorUpdated(_ todo: Todo) {
+        store.send(.fullScreenCover(.presented(.todoEditor(.delegate(.updated(todo))))))
     }
 
     func setTodo(_ todo: Todo) {

--- a/Application/Presentation/Tests/Home/TodoEditorFeatureTestDoubles.swift
+++ b/Application/Presentation/Tests/Home/TodoEditorFeatureTestDoubles.swift
@@ -165,6 +165,26 @@ final class TodoEditorStoreTestAdapter {
         await receiveBeginLoading()
     }
 
+    func receiveCreateSucceeded() async {
+        await store.receive(.createSucceeded) {
+            $0.saveResult = .created
+        }
+    }
+
+    func receiveCreatedDelegate() async {
+        await store.receive(.delegate(.created))
+    }
+
+    func receiveUpdateSucceeded(_ todo: Todo) async {
+        await store.receive(.updateSucceeded(todo)) {
+            $0.saveResult = .updated(todo)
+        }
+    }
+
+    func receiveUpdatedDelegate(_ todo: Todo) async {
+        await store.receive(.delegate(.updated(todo)))
+    }
+
     func drainReceivedActions() async {
         await store.skipReceivedActions(strict: false)
         await store.skipReceivedActions(strict: false)

--- a/Application/Presentation/Tests/Home/TodoEditorFeatureTestDoubles.swift
+++ b/Application/Presentation/Tests/Home/TodoEditorFeatureTestDoubles.swift
@@ -40,8 +40,7 @@ final class TodoEditorStoreTestAdapter {
         now: Date = todoEditorNow,
         fetchPreferencesUseCase: FetchTodoCategoryPreferencesUseCase = TodoEditorFetchPreferencesUseCaseSpy(),
         fetchReferenceItemsUseCase: FetchReferenceItemsUseCase = TodoEditorFetchReferenceItemsUseCaseSpy(),
-        upsertTodoUseCase: UpsertTodoUseCase = TodoEditorUpsertTodoUseCaseSpy(),
-        trackAnalyticsEventUseCase: TrackAnalyticsEventUseCase = TodoEditorTrackAnalyticsEventUseCaseSpy()
+        upsertTodoUseCase: UpsertTodoUseCase = TodoEditorUpsertTodoUseCaseSpy()
     ) {
         self.now = now
         store = TestStore(
@@ -53,7 +52,6 @@ final class TodoEditorStoreTestAdapter {
             $0.fetchTodoCategoryPreferencesUseCase = fetchPreferencesUseCase
             $0.fetchReferenceItemsUseCase = fetchReferenceItemsUseCase
             $0.upsertTodoUseCase = upsertTodoUseCase
-            $0.trackAnalyticsEventUseCase = trackAnalyticsEventUseCase
         }
         store.exhaustivity = .off(showSkippedAssertions: false)
     }
@@ -297,20 +295,6 @@ final class TodoEditorUpsertTodoUseCaseSpy: UpsertTodoUseCase {
                 self.continuation = continuation
             }
         }
-    }
-}
-
-final class TodoEditorTrackAnalyticsEventUseCaseSpy: TrackAnalyticsEventUseCase {
-    private(set) var events: [AnalyticsEvent] = []
-    var hasTrackedTodoCreate: Bool {
-        events.contains {
-            guard case .todoCreate = $0 else { return false }
-            return true
-        }
-    }
-
-    func execute(_ event: AnalyticsEvent) {
-        events.append(event)
     }
 }
 

--- a/Application/Presentation/Tests/Home/TodoEditorFeatureTests.swift
+++ b/Application/Presentation/Tests/Home/TodoEditorFeatureTests.swift
@@ -165,8 +165,8 @@ struct TodoEditorFeatureTests {
         #expect(adapter.sheet == nil)
     }
 
-    @Test("새 Todo 저장 성공은 draft를 저장하고 생성 완료 상태를 남긴다")
-    func 새_Todo_저장_성공은_draft를_저장하고_생성_완료_상태를_남긴다() async {
+    @Test("새 Todo 저장 성공은 draft를 저장하고 생성 delegate를 전송한다")
+    func 새_Todo_저장_성공은_draft를_저장하고_생성_delegate를_전송한다() async {
         let upsertSpy = TodoEditorUpsertTodoUseCaseSpy()
         upsertSpy.shouldSuspend = true
         let analyticsSpy = TodoEditorTrackAnalyticsEventUseCaseSpy()
@@ -193,6 +193,8 @@ struct TodoEditorFeatureTests {
         #expect(upsertSpy.todoDrafts.first?.category == .system(.doc))
 
         upsertSpy.resume()
+        await adapter.receiveCreateSucceeded()
+        await adapter.receiveCreatedDelegate()
         await adapter.drainReceivedActions()
 
         #expect(adapter.saveResult == .created)
@@ -200,9 +202,10 @@ struct TodoEditorFeatureTests {
         #expect(analyticsSpy.hasTrackedTodoCreate)
     }
 
-    @Test("기존 Todo 저장 성공은 수정 Todo를 저장하고 수정 완료 상태를 남긴다")
-    func 기존_Todo_저장_성공은_수정_Todo를_저장하고_수정_완료_상태를_남긴다() async throws {
+    @Test("기존 Todo 저장 성공은 수정 Todo를 저장하고 수정 delegate를 전송한다")
+    func 기존_Todo_저장_성공은_수정_Todo를_저장하고_수정_delegate를_전송한다() async throws {
         let upsertSpy = TodoEditorUpsertTodoUseCaseSpy()
+        upsertSpy.shouldSuspend = true
         let todo = makeTodoEditorTodo(
             id: "todo-1",
             number: 7,
@@ -216,9 +219,13 @@ struct TodoEditorFeatureTests {
         await adapter.setTitle("Changed")
         await adapter.setContent("Changed body")
         await adapter.upsertTodo()
-        await adapter.drainReceivedActions()
 
         let updated = try #require(upsertSpy.todos.first)
+
+        upsertSpy.resume()
+        await adapter.receiveUpdateSucceeded(updated)
+        await adapter.receiveUpdatedDelegate(updated)
+        await adapter.drainReceivedActions()
 
         #expect(updated.id == "todo-1")
         #expect(updated.number == 7)

--- a/Application/Presentation/Tests/Home/TodoEditorFeatureTests.swift
+++ b/Application/Presentation/Tests/Home/TodoEditorFeatureTests.swift
@@ -169,11 +169,9 @@ struct TodoEditorFeatureTests {
     func 새_Todo_저장_성공은_draft를_저장하고_생성_delegate를_전송한다() async {
         let upsertSpy = TodoEditorUpsertTodoUseCaseSpy()
         upsertSpy.shouldSuspend = true
-        let analyticsSpy = TodoEditorTrackAnalyticsEventUseCaseSpy()
         let adapter = TodoEditorStoreTestAdapter(
             category: .system(.doc),
-            upsertTodoUseCase: upsertSpy,
-            trackAnalyticsEventUseCase: analyticsSpy
+            upsertTodoUseCase: upsertSpy
         )
         let dueDate = Date(timeIntervalSince1970: 4_102_444_800)
 
@@ -199,7 +197,6 @@ struct TodoEditorFeatureTests {
 
         #expect(adapter.saveResult == .created)
         #expect(adapter.isLoading == false)
-        #expect(analyticsSpy.hasTrackedTodoCreate)
     }
 
     @Test("기존 Todo 저장 성공은 수정 Todo를 저장하고 수정 delegate를 전송한다")

--- a/Application/Presentation/Tests/Home/TodoListFeatureTestDoubles.swift
+++ b/Application/Presentation/Tests/Home/TodoListFeatureTestDoubles.swift
@@ -25,6 +25,9 @@ final class TodoListStoreTestAdapter {
     var hasMore: Bool { store.state.hasMore }
     var alert: AlertState<Never>? { store.state.alert }
     var fullScreenCover: TodoListFeature.FullScreenCoverState? { store.state.fullScreenCover }
+    var fullScreenCoverDestination: TodoListFeature.FullScreenCoverState.Destination? {
+        store.state.fullScreenCover?.destination
+    }
     var showAlert: Bool { store.state.alert != nil }
     var appliedFilterCount: Int { store.state.appliedFilterCount }
 
@@ -122,6 +125,11 @@ final class TodoListStoreTestAdapter {
 
     func dismissFullScreenCover() async {
         await store.send(.fullScreenCover(.dismiss))
+    }
+
+    func todoEditorCreated() async {
+        await store.send(.fullScreenCover(.presented(.todoEditor(.delegate(.created)))))
+        await drainReceivedActions()
     }
 
     func swipeTodo(_ todo: TodoListItem) async {

--- a/Application/Presentation/Tests/Home/TodoListFeatureTestDoubles.swift
+++ b/Application/Presentation/Tests/Home/TodoListFeatureTestDoubles.swift
@@ -315,6 +315,12 @@ final class TodoListUndoDeleteTodoUseCaseSpy: UndoDeleteTodoUseCase {
 
 final class TodoListTrackAnalyticsEventUseCaseSpy: TrackAnalyticsEventUseCase {
     private(set) var events = [AnalyticsEvent]()
+    var hasTrackedTodoCreate: Bool {
+        events.contains {
+            guard case .todoCreate = $0 else { return false }
+            return true
+        }
+    }
     var hasTrackedTodoComplete: Bool {
         events.contains {
             guard case .todoComplete = $0 else { return false }

--- a/Application/Presentation/Tests/Home/TodoListFeatureTests.swift
+++ b/Application/Presentation/Tests/Home/TodoListFeatureTests.swift
@@ -165,13 +165,17 @@ struct TodoListFeatureTests {
     @Test("TodoEditor 생성 delegate는 editor를 닫고 목록을 새로 조회한다")
     func TodoEditor_생성_delegate는_editor를_닫고_목록을_새로_조회한다() async {
         let fetchSpy = TodoListFetchTodosUseCaseSpy()
-        let adapter = TodoListStoreTestAdapter(fetchUseCase: fetchSpy)
+        let trackSpy = TodoListTrackAnalyticsEventUseCaseSpy()
+        let adapter = TodoListStoreTestAdapter(
+            fetchUseCase: fetchSpy,
+            trackAnalyticsEventUseCase: trackSpy
+        )
 
         await adapter.setFullScreenCover(.editor)
         await adapter.todoEditorCreated()
 
         await waitUntil {
-            fetchSpy.queries.count == 1
+            fetchSpy.queries.count == 1 && trackSpy.hasTrackedTodoCreate
         }
 
         #expect(adapter.fullScreenCover == nil)

--- a/Application/Presentation/Tests/Home/TodoListFeatureTests.swift
+++ b/Application/Presentation/Tests/Home/TodoListFeatureTests.swift
@@ -156,10 +156,27 @@ struct TodoListFeatureTests {
         let adapter = TodoListStoreTestAdapter()
 
         await adapter.setFullScreenCover(.editor)
-        #expect(adapter.fullScreenCover == .editor)
+        #expect(adapter.fullScreenCoverDestination == .editor)
 
         await adapter.dismissFullScreenCover()
         #expect(adapter.fullScreenCover == nil)
+    }
+
+    @Test("TodoEditor 생성 delegate는 editor를 닫고 목록을 새로 조회한다")
+    func TodoEditor_생성_delegate는_editor를_닫고_목록을_새로_조회한다() async {
+        let fetchSpy = TodoListFetchTodosUseCaseSpy()
+        let adapter = TodoListStoreTestAdapter(fetchUseCase: fetchSpy)
+
+        await adapter.setFullScreenCover(.editor)
+        await adapter.todoEditorCreated()
+
+        await waitUntil {
+            fetchSpy.queries.count == 1
+        }
+
+        #expect(adapter.fullScreenCover == nil)
+        #expect(fetchSpy.queries.map(\.categoryId) == ["feature"])
+        #expect(fetchSpy.cursors.map { $0?.documentID } == [nil])
     }
 
     @Test("swipeTodo는 Todo를 숨기고 undoDelete와 finishDeleteToast는 숨김 상태를 되돌리거나 제거한다")


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #658

## 🎯 의도

- `TodoEditorFeature`의 저장 성공 결과를 View callback이 아닌 TCA delegate action으로 전달하여 Home/List/Detail의 후속 처리를 reducer action flow 안에서 추적하고 검증하기 위함

## 📝 작업 내용

### 📌 요약

- `TodoEditorFeature` 저장 성공 이벤트의 delegate action 전환
- Home/List/Detail의 TodoEditor 저장 후속 처리 reducer 이동
- TodoEditor child state/action 소유 구조 적용
- 관련 TestStore 검증 추가

### 🔍 상세

- `TodoEditorFeature.Action.delegate` 추가
- Todo 생성 성공 시 `.delegate(.created)` 전송
- Todo 수정 성공 시 `.delegate(.updated(Todo))` 전송
- `HomeFeature`에서 Todo 생성 delegate 수신 후 editor dismiss 및 홈 데이터 재조회 처리
- `TodoListFeature`에서 Todo 생성 delegate 수신 후 editor dismiss 및 목록 refresh 처리
- `TodoDetailFeature`에서 Todo 수정 delegate 수신 후 editor dismiss 및 상세 Todo 상태 갱신 처리
- `HomeView`, `TodoListView`, `TodoDetailView`의 TodoEditor 저장 성공 callback 의존 제거
- parent reducer가 TodoEditor presentation state/action을 소유하도록 변경
- `SearchView`, `TodoWindowCoordinator`의 TodoDetail/TodoList store 조립 시 TodoEditor child dependency 주입 보강
- TodoEditor delegate 전송, Home/List/Detail parent reducer 후속 처리 TestStore 검증 추가

## 📸 영상 / 이미지 (Optional)

없음
