### PR TITLE
[#608] Mac에서 앱이 온그라운드 상태가 될 때 FCM 토큰이 과도하게 업데이트되는 현상을 해결한다

### DIFF
--- a/Application/App/Sources/App/Assembler/AppLayerAssembler.swift
+++ b/Application/App/Sources/App/Assembler/AppLayerAssembler.swift
@@ -12,8 +12,10 @@ final class AppLayerAssembler: Assembler {
     func assemble(_ container: any DIContainer) {
         container.register(FCMTokenSyncHandler.self) {
             FCMTokenSyncHandler(
+                authService: container.resolve(AuthService.self),
                 messagingService: container.resolve(PushMessagingService.self),
-                userService: container.resolve(UserService.self)
+                userService: container.resolve(UserService.self),
+                store: container.resolve(UserDefaultsStore.self)
             )
         }
         container.register(UserTimeZoneSyncHandler.self) {

--- a/Application/App/Sources/App/Delegate/AppDelegate.swift
+++ b/Application/App/Sources/App/Delegate/AppDelegate.swift
@@ -34,12 +34,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         _ = container.resolve(WidgetSessionSyncHandler.self)
         NotificationCenter.default.addObserver(
             self,
-            selector: #selector(handleSceneDidActivate),
-            name: UIScene.didActivateNotification,
-            object: nil
-        )
-        NotificationCenter.default.addObserver(
-            self,
             selector: #selector(handleRemoteNotificationRegistrationRequest),
             name: .didRequestRemoteNotificationRegistration,
             object: nil
@@ -71,10 +65,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
 
         return true
-    }
-
-    @objc private func handleSceneDidActivate() {
-        NotificationCenter.default.post(name: .didRequestFCMTokenSync, object: nil)
     }
 
     @objc private func handleRemoteNotificationRegistrationRequest() {

--- a/Application/App/Sources/App/Handler/FCMTokenSyncHandler.swift
+++ b/Application/App/Sources/App/Handler/FCMTokenSyncHandler.swift
@@ -7,23 +7,35 @@
 
 import Combine
 import Core
+import CryptoKit
 import Data
 import Foundation
+import Infra
 
 final class FCMTokenSyncHandler {
+    private enum Key {
+        static let fcmTokenHash = "FCMTokenSyncHandler.fcmTokenHash"
+    }
+
+    private let authService: AuthService
     private let messagingService: PushMessagingService
     private let userService: UserService
+    private let store: UserDefaultsStore
     private let notificationCenter: NotificationCenter
     private let logger = Logger(category: "FCMTokenSyncHandler")
     private var cancellables = Set<AnyCancellable>()
 
     init(
+        authService: AuthService,
         messagingService: PushMessagingService,
         userService: UserService,
+        store: UserDefaultsStore,
         notificationCenter: NotificationCenter = .default
     ) {
+        self.authService = authService
         self.messagingService = messagingService
         self.userService = userService
+        self.store = store
         self.notificationCenter = notificationCenter
 
         notificationCenter.publisher(for: .didRefreshFCMToken)
@@ -52,9 +64,7 @@ private extension FCMTokenSyncHandler {
     func requestFCMTokenSync() {
         Task { [weak self] in
             guard let self else { return }
-            guard await messagingService.isNotificationAuthorized() else {
-                return
-            }
+            guard await messagingService.isNotificationAuthorized() else { return }
             notificationCenter.post(name: .didRequestRemoteNotificationRegistration, object: nil)
             await syncCurrentFCMToken()
         }
@@ -69,10 +79,8 @@ private extension FCMTokenSyncHandler {
 
     func syncCurrentFCMToken() async {
         do {
-            guard let fcmToken = try await messagingService.fetchFCMToken() else {
-                return
-            }
-            try await userService.updateFCMToken(fcmToken)
+            guard let fcmToken = try await messagingService.fetchFCMToken() else { return }
+            try await syncFCMTokenIfNeeded(fcmToken)
         } catch {
             logger.error("Failed to sync current FCM token", error: error)
         }
@@ -81,10 +89,33 @@ private extension FCMTokenSyncHandler {
     func syncFCMToken(_ fcmToken: String) {
         Task { [weak self] in
             do {
-                try await self?.userService.updateFCMToken(fcmToken)
+                try await self?.syncFCMTokenIfNeeded(fcmToken)
             } catch {
                 self?.logger.error("Failed to sync refreshed FCM token", error: error)
             }
         }
+    }
+
+    func syncFCMTokenIfNeeded(_ fcmToken: String) async throws {
+        guard let uid = authService.uid else {
+            store.setString(nil, forKey: Key.fcmTokenHash)
+            logger.info("Skipping FCM token update because no authenticated user exists")
+            return
+        }
+
+        let tokenHash = makeTokenHash(uid: uid, fcmToken: fcmToken)
+        guard store.string(forKey: Key.fcmTokenHash) != tokenHash else {
+            logger.info("Skipping FCM token update because token hash is unchanged")
+            return
+        }
+
+        try await userService.updateFCMToken(fcmToken)
+        store.setString(tokenHash, forKey: Key.fcmTokenHash)
+    }
+
+    func makeTokenHash(uid: String, fcmToken: String) -> String {
+        let value = "\(uid)|\(FirebaseConfiguration.databaseID)|\(fcmToken)"
+        let digest = SHA256.hash(data: Data(value.utf8))
+        return digest.map { String(format: "%02x", $0) }.joined()
     }
 }

--- a/Application/App/Sources/App/Handler/FCMTokenSyncHandler.swift
+++ b/Application/App/Sources/App/Handler/FCMTokenSyncHandler.swift
@@ -38,6 +38,13 @@ final class FCMTokenSyncHandler {
         self.store = store
         self.notificationCenter = notificationCenter
 
+        authService.observeSignedIn()
+            .removeDuplicates()
+            .sink { [weak self] isSignedIn in
+                self?.handleSessionUpdate(isSignedIn: isSignedIn)
+            }
+            .store(in: &cancellables)
+
         notificationCenter.publisher(for: .didRefreshFCMToken)
             .compactMap { $0.userInfo?["fcmToken"] as? String }
             .sink { [weak self] fcmToken in
@@ -61,6 +68,15 @@ final class FCMTokenSyncHandler {
 }
 
 private extension FCMTokenSyncHandler {
+    func handleSessionUpdate(isSignedIn: Bool) {
+        guard isSignedIn else {
+            store.setString(nil, forKey: Key.fcmTokenHash)
+            return
+        }
+
+        requestFCMTokenSync()
+    }
+
     func requestFCMTokenSync() {
         Task { [weak self] in
             guard let self else { return }

--- a/Application/App/Tests/PushNotification/FCMTokenSyncHandlerTests.swift
+++ b/Application/App/Tests/PushNotification/FCMTokenSyncHandlerTests.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import Combine
 import Testing
 import Data
 @testable import App
@@ -20,9 +21,13 @@ struct FCMTokenSyncHandlerTests {
         )
         let messagingService = PushMessagingServiceSpy(currentFCMToken: "current-token")
         let userService = UserServiceSpy()
+        let authService = AuthServiceSpy()
+        let store = UserDefaultsStoreSpy()
         let handler = FCMTokenSyncHandler(
+            authService: authService,
             messagingService: messagingService,
             userService: userService,
+            store: store,
             notificationCenter: notificationCenter
         )
 
@@ -40,9 +45,13 @@ struct FCMTokenSyncHandlerTests {
         let notificationCenter = NotificationCenter()
         let messagingService = PushMessagingServiceSpy(currentFCMToken: nil)
         let userService = UserServiceSpy()
+        let authService = AuthServiceSpy()
+        let store = UserDefaultsStoreSpy()
         let handler = FCMTokenSyncHandler(
+            authService: authService,
             messagingService: messagingService,
             userService: userService,
+            store: store,
             notificationCenter: notificationCenter
         )
 
@@ -58,9 +67,13 @@ struct FCMTokenSyncHandlerTests {
         let notificationCenter = NotificationCenter()
         let messagingService = PushMessagingServiceSpy(currentFCMToken: nil)
         let userService = UserServiceSpy()
+        let authService = AuthServiceSpy()
+        let store = UserDefaultsStoreSpy()
         let handler = FCMTokenSyncHandler(
+            authService: authService,
             messagingService: messagingService,
             userService: userService,
+            store: store,
             notificationCenter: notificationCenter
         )
 
@@ -81,9 +94,13 @@ struct FCMTokenSyncHandlerTests {
         let notificationCenter = NotificationCenter()
         let messagingService = PushMessagingServiceSpy(currentFCMToken: "current-token")
         let userService = UserServiceSpy()
+        let authService = AuthServiceSpy()
+        let store = UserDefaultsStoreSpy()
         let handler = FCMTokenSyncHandler(
+            authService: authService,
             messagingService: messagingService,
             userService: userService,
+            store: store,
             notificationCenter: notificationCenter
         )
         let deviceToken = Data([0x01, 0x02, 0x03])
@@ -100,6 +117,62 @@ struct FCMTokenSyncHandlerTests {
         #expect(messagingService.apnsTokens == [deviceToken])
         _ = handler
     }
+
+    @Test("같은 사용자와 같은 FCM token은 한 번만 저장한다")
+    func 같은_사용자와_같은_FCM_token은_한_번만_저장한다() async throws {
+        let notificationCenter = NotificationCenter()
+        let messagingService = PushMessagingServiceSpy(currentFCMToken: "current-token")
+        let userService = UserServiceSpy()
+        let authService = AuthServiceSpy()
+        let store = UserDefaultsStoreSpy()
+        let handler = FCMTokenSyncHandler(
+            authService: authService,
+            messagingService: messagingService,
+            userService: userService,
+            store: store,
+            notificationCenter: notificationCenter
+        )
+
+        notificationCenter.post(name: .didRequestFCMTokenSync, object: nil)
+        try await waitUntil {
+            await userService.updatedFCMTokens == ["current-token"]
+        }
+
+        notificationCenter.post(name: .didRequestFCMTokenSync, object: nil)
+        try await Task.sleep(for: .milliseconds(100))
+
+        #expect(await userService.updatedFCMTokens == ["current-token"])
+        _ = handler
+    }
+
+    @Test("같은 FCM token이어도 사용자가 바뀌면 다시 저장한다")
+    func 같은_FCM_token이어도_사용자가_바뀌면_다시_저장한다() async throws {
+        let notificationCenter = NotificationCenter()
+        let messagingService = PushMessagingServiceSpy(currentFCMToken: "current-token")
+        let userService = UserServiceSpy()
+        let authService = AuthServiceSpy(uid: "first-user")
+        let store = UserDefaultsStoreSpy()
+        let handler = FCMTokenSyncHandler(
+            authService: authService,
+            messagingService: messagingService,
+            userService: userService,
+            store: store,
+            notificationCenter: notificationCenter
+        )
+
+        notificationCenter.post(name: .didRequestFCMTokenSync, object: nil)
+        try await waitUntil {
+            await userService.updatedFCMTokens == ["current-token"]
+        }
+
+        authService.uid = "second-user"
+        notificationCenter.post(name: .didRequestFCMTokenSync, object: nil)
+        try await waitUntil {
+            await userService.updatedFCMTokens == ["current-token", "current-token"]
+        }
+        _ = handler
+    }
+
 }
 
 private actor UserServiceSpy: UserService {
@@ -114,6 +187,34 @@ private actor UserServiceSpy: UserService {
     }
 
     func updateUserTimeZone() async throws { }
+}
+
+private final class AuthServiceSpy: AuthService {
+    var uid: String?
+    let providerIDs = [String]()
+    let currentUserEmail: String? = nil
+    let providerCount = 0
+    private let subject = PassthroughSubject<Bool, Never>()
+
+    init(uid: String? = "user-id") {
+        self.uid = uid
+    }
+
+    func observeSignedIn() -> AnyPublisher<Bool, Never> {
+        subject.eraseToAnyPublisher()
+    }
+
+    func updateSession(uid: String?) {
+        self.uid = uid
+        subject.send(uid != nil)
+    }
+
+    func beginSignIn() { }
+    func completeSignIn() { }
+    func cancelSignIn() { }
+    func getProviderID() async throws -> String? { nil }
+    func deleteCurrentUser() async throws { }
+    func clearCurrentSession() async throws { }
 }
 
 private final class PushMessagingServiceSpy: PushMessagingService {
@@ -133,6 +234,46 @@ private final class PushMessagingServiceSpy: PushMessagingService {
     func fetchFCMToken() async throws -> String? {
         currentFCMToken
     }
+}
+
+private final class UserDefaultsStoreSpy: UserDefaultsStore {
+    private var strings = [String: String]()
+
+    var hasStoredString: Bool {
+        !strings.isEmpty
+    }
+
+    func value<T: Codable>(forKey key: String) -> T? {
+        nil
+    }
+
+    func setValue<T: Codable>(_ value: T?, forKey key: String) { }
+
+    func removeValues(withPrefix prefix: String) {
+        strings.keys
+            .filter { $0.hasPrefix(prefix) }
+            .forEach { strings.removeValue(forKey: $0) }
+    }
+
+    func string(forKey key: String) -> String? {
+        strings[key]
+    }
+
+    func setString(_ value: String?, forKey key: String) {
+        strings[key] = value
+    }
+
+    func stringArray(forKey key: String) -> [String] {
+        []
+    }
+
+    func setStringArray(_ value: [String], forKey key: String) { }
+
+    func bool(forKey key: String) -> Bool {
+        false
+    }
+
+    func setBool(_ value: Bool, forKey key: String) { }
 }
 
 private final class NotificationObserver {

--- a/Application/App/Tests/PushNotification/FCMTokenSyncHandlerTests.swift
+++ b/Application/App/Tests/PushNotification/FCMTokenSyncHandlerTests.swift
@@ -173,6 +173,57 @@ struct FCMTokenSyncHandlerTests {
         _ = handler
     }
 
+    @Test("로그인 세션 전이 시 현재 FCM token을 저장한다")
+    func 로그인_세션_전이_시_현재_FCM_token을_저장한다() async throws {
+        let notificationCenter = NotificationCenter()
+        let messagingService = PushMessagingServiceSpy(currentFCMToken: "current-token")
+        let userService = UserServiceSpy()
+        let authService = AuthServiceSpy(uid: nil)
+        let store = UserDefaultsStoreSpy()
+        let handler = FCMTokenSyncHandler(
+            authService: authService,
+            messagingService: messagingService,
+            userService: userService,
+            store: store,
+            notificationCenter: notificationCenter
+        )
+
+        authService.updateSession(uid: "user-id")
+
+        try await waitUntil {
+            await userService.updatedFCMTokens == ["current-token"]
+        }
+        _ = handler
+    }
+
+    @Test("로그아웃 세션 전이 시 저장된 FCM token hash를 제거한다")
+    func 로그아웃_세션_전이_시_저장된_FCM_token_hash를_제거한다() async throws {
+        let notificationCenter = NotificationCenter()
+        let messagingService = PushMessagingServiceSpy(currentFCMToken: "current-token")
+        let userService = UserServiceSpy()
+        let authService = AuthServiceSpy()
+        let store = UserDefaultsStoreSpy()
+        let handler = FCMTokenSyncHandler(
+            authService: authService,
+            messagingService: messagingService,
+            userService: userService,
+            store: store,
+            notificationCenter: notificationCenter
+        )
+
+        notificationCenter.post(name: .didRequestFCMTokenSync, object: nil)
+        try await waitUntil {
+            store.hasStoredString
+        }
+
+        authService.updateSession(uid: nil)
+
+        try await waitUntil {
+            !store.hasStoredString
+        }
+        _ = handler
+    }
+
 }
 
 private actor UserServiceSpy: UserService {

--- a/Application/Infra/Sources/Common/FirebaseConfiguration.swift
+++ b/Application/Infra/Sources/Common/FirebaseConfiguration.swift
@@ -8,7 +8,7 @@
 import FirebaseFirestore
 import Foundation
 
-enum FirebaseConfiguration {
+public enum FirebaseConfiguration {
     private enum InfoKey {
         static let databaseID = "FIRESTORE_DATABASE_ID"
         static let functionAPIBaseURL = "FUNCTION_API_BASE_URL"
@@ -16,7 +16,7 @@ enum FirebaseConfiguration {
 
     static let defaultDatabaseID = "staging"
 
-    static var databaseID: String {
+    public static var databaseID: String {
         let environmentValue = ProcessInfo.processInfo.environment[InfoKey.databaseID]?
             .trimmingCharacters(in: .whitespacesAndNewlines)
         if let environmentValue, !environmentValue.isEmpty {

--- a/Application/Presentation/Tests/Home/TodoListFeatureTestDoubles.swift
+++ b/Application/Presentation/Tests/Home/TodoListFeatureTestDoubles.swift
@@ -240,6 +240,26 @@ actor TodoListDelayedFirstFetchTodosUseCaseSpy: FetchTodosUseCase {
         cursors
     }
 
+    func waitForCallCount(_ count: Int, timeout: Duration = .seconds(2)) async {
+        let clock = ContinuousClock()
+        let deadline = clock.now + timeout
+
+        while queries.count < count && clock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(20))
+        }
+    }
+
+    func waitForCancelledCalls(_ expected: [Int], timeout: Duration = .seconds(2)) async -> [Int] {
+        let clock = ContinuousClock()
+        let deadline = clock.now + timeout
+
+        while cancelledCallIndices != expected && clock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(20))
+        }
+
+        return cancelledCallIndices
+    }
+
     func cancelledCalls() -> [Int] {
         cancelledCallIndices
     }

--- a/Application/Presentation/Tests/Home/TodoListFeatureTests.swift
+++ b/Application/Presentation/Tests/Home/TodoListFeatureTests.swift
@@ -74,6 +74,7 @@ struct TodoListFeatureTests {
         let adapter = TodoListStoreTestAdapter(fetchUseCase: fetchSpy)
 
         await adapter.onAppear()
+        await fetchSpy.waitForCallCount(1)
         await adapter.setSortTarget(.updatedAt)
 
         await waitUntil(timeout: .seconds(2)) {
@@ -81,7 +82,7 @@ struct TodoListFeatureTests {
         }
 
         let queries = await fetchSpy.calledQueries()
-        let cancelledCalls = await fetchSpy.cancelledCalls()
+        let cancelledCalls = await fetchSpy.waitForCancelledCalls([0])
 
         #expect(adapter.todos == [TodoListItem(from: secondTodo)!])
         #expect(queries.map(\.sortTarget) == [.createdAt, .updatedAt])


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #608

## 🎯 의도
FCM token 동기화가 앱 온그라운드 전환마다 반복되면서 Firestore update 요청이 불필요하게 발생하던 문제 해결

## 📝 작업 내용

### 📌 요약
- 온그라운드 전환 기반 FCM token sync 트리거 제거
- 로컬 token hash 비교를 통한 중복 Firestore 저장 방지
- 로그인/로그아웃 세션 전이에 따른 FCM token sync 및 로컬 hash 정리 처리

### 🔍 상세
- `UIScene.didActivateNotification`에서 `.didRequestFCMTokenSync`를 발행하던 흐름 제거
- `uid`, `FirebaseConfiguration.databaseID`, `fcmToken` 기반 hash를 `UserDefaultsStore`에 저장하도록 변경
- 동일 사용자와 동일 FCM token이면 `UserService.updateFCMToken` 호출 생략
- 같은 FCM token이어도 사용자 또는 Firestore database가 달라지면 다시 저장되도록 처리
- 로그인 세션 진입 시 현재 FCM token sync 요청
- 로그아웃 세션 진입 시 로컬 FCM token hash 제거
- FCM token 중복 저장, 사용자 변경, 로그인/로그아웃 세션 전이 테스트 추가

## 📸 영상 / 이미지 (Optional)
없음