### PR TITLE
[#659] CategoryManage 시트 흐름을 parent-owned TCA presentation으로 정리한다

### DIFF
--- a/Application/Presentation/Sources/Home/Category/CategoryManageFeature.swift
+++ b/Application/Presentation/Sources/Home/Category/CategoryManageFeature.swift
@@ -88,9 +88,10 @@ struct CategoryManageFeature {
         }
     }
 
-    enum Action {
+    enum Action: Equatable {
         case alert(PresentationAction<Alert>)
         case categorySheet(PresentationAction<CategorySheet>)
+        case delegate(Delegate)
         case tapAddUserCategory
         case moveItem(from: IndexSet, target: Int)
         case tapItem(TodoCategoryItem)
@@ -101,6 +102,10 @@ struct CategoryManageFeature {
 
         enum Alert: Equatable {
             case confirmDeleteUserCategory(TodoCategoryItem)
+        }
+
+        enum Delegate: Equatable {
+            case done([TodoCategoryItem])
         }
 
         enum CategorySheet: BindableAction, Equatable {
@@ -119,6 +124,8 @@ struct CategoryManageFeature {
                     state.preferences.remove(at: index)
                 }
             case .alert:
+                break
+            case .delegate:
                 break
             case .categorySheet(.dismiss):
                 state.categorySheet = nil
@@ -166,7 +173,7 @@ struct CategoryManageFeature {
                     state.alert = Self.deleteAlertState(for: item)
                 }
             case .tapDoneButton:
-                break
+                return .send(.delegate(.done(state.preferences)))
             case .setCategorySheet(let sheet):
                 state.categorySheet = sheet
             }

--- a/Application/Presentation/Sources/Home/Category/CategoryManageView.swift
+++ b/Application/Presentation/Sources/Home/Category/CategoryManageView.swift
@@ -7,23 +7,9 @@
 
 import SwiftUI
 import ComposableArchitecture
-import Domain
 
 struct CategoryManageView: View {
-    @State private var store: StoreOf<CategoryManageFeature>
-    var onDismiss: (([TodoCategoryItem]) -> Void)?
-
-    init(
-        preferences: [TodoCategoryItem],
-        onDismiss: (([TodoCategoryItem]) -> Void)?
-    ) {
-        self._store = State(initialValue: Store(
-            initialState: CategoryManageFeature.State(preferences: preferences)
-        ) {
-            CategoryManageFeature()
-        })
-        self.onDismiss = onDismiss
-    }
+    @Bindable var store: StoreOf<CategoryManageFeature>
 
     var body: some View {
         NavigationStack {
@@ -81,8 +67,7 @@ struct CategoryManageView: View {
 
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button {
-                        store.send(.tapDoneButton)
-                        onDismiss?(store.preferences)
+                        store.send(.tapDoneButton, animation: .default)
                     } label: {
                         Text(String(localized: "profile_done"))
                     }

--- a/Application/Presentation/Sources/Home/Home/HomeFeature.swift
+++ b/Application/Presentation/Sources/Home/Home/HomeFeature.swift
@@ -67,8 +67,8 @@ struct HomeFeature {
             case refreshRecentTodos
             case refreshWebPages
             case finishDeleteWebPageToast(String)
+            case tapManageTodoCategory
             case tapTodoCategory(TodoCategory)
-            case orderTodoCategory([TodoCategoryItem])
             case updateWebPageURLInput(String)
             case addWebPage
             case deleteWebPage(WebPageItem)
@@ -106,8 +106,19 @@ struct HomeFeature {
     @ObservableState
     @CasePathable
     enum SheetState: Equatable {
-        case reorderTodo
+        case reorderTodo(CategoryManageFeature.State)
         case contentPicker(ContentPickerState)
+
+        var categoryManageState: CategoryManageFeature.State? {
+            get {
+                guard case .reorderTodo(let state) = self else { return nil }
+                return state
+            }
+            set {
+                guard let newValue else { return }
+                self = .reorderTodo(newValue)
+            }
+        }
 
         var contentPickerState: ContentPickerState? {
             get {
@@ -124,6 +135,7 @@ struct HomeFeature {
     @CasePathable
     enum Sheet: Equatable {
         case tapCloseButton
+        case categoryManage(CategoryManageFeature.Action)
         case contentPicker(ContentPicker)
 
         @CasePathable
@@ -219,6 +231,8 @@ struct HomeFeature {
                 break
             case .sheet(.dismiss), .sheet(.presented(.tapCloseButton)):
                 state.sheet = nil
+            case .sheet(.presented(.categoryManage(.delegate(.done(let preferences))))):
+                return orderTodoCategory(preferences, state: &state)
             case .sheet:
                 break
             case .view(let action):
@@ -276,15 +290,12 @@ private extension HomeFeature {
             if state.deletedWebPage?.urlString == urlString {
                 state.deletedWebPage = nil
             }
+        case .tapManageTodoCategory:
+            state.sheet = .reorderTodo(CategoryManageFeature.State(preferences: state.preferences))
         case .tapTodoCategory(let category):
             state.selectedTodoCategory = category
             state.sheet = nil
             return delayedTodoEditorEffect()
-        case .orderTodoCategory(let preferences):
-            state.preferences = preferences
-            state.recentTodos = Self.syncRecentTodos(state.recentTodos, preferences: preferences)
-            state.sheet = nil
-            return updateTodoCategoryPreferencesEffect(preferences)
         case .updateWebPageURLInput(let text):
             state.webPageURLInput = text
         case .addWebPage:
@@ -314,6 +325,16 @@ private extension HomeFeature {
         }
 
         return .none
+    }
+
+    func orderTodoCategory(
+        _ preferences: [TodoCategoryItem],
+        state: inout State
+    ) -> Effect<Action> {
+        state.preferences = preferences
+        state.recentTodos = Self.syncRecentTodos(state.recentTodos, preferences: preferences)
+        state.sheet = nil
+        return updateTodoCategoryPreferencesEffect(preferences)
     }
 
     func reduce(
@@ -359,6 +380,9 @@ private struct HomeSheetFeature: Reducer {
 
     var body: some ReducerOf<Self> {
         EmptyReducer()
+        .ifCaseLet(\.reorderTodo, action: \.categoryManage) {
+            CategoryManageFeature()
+        }
         .ifCaseLet(\.contentPicker, action: \.contentPicker) {
             HomeContentPickerFeature()
         }

--- a/Application/Presentation/Sources/Home/Home/HomeFeature.swift
+++ b/Application/Presentation/Sources/Home/Home/HomeFeature.swift
@@ -70,7 +70,6 @@ struct HomeFeature {
             case finishDeleteWebPageToast(String)
             case tapManageTodoCategory
             case tapTodoCategory(TodoCategory)
-            case updateWebPageURLInput(String)
             case addWebPage
             case deleteWebPage(WebPageItem)
             case undoDeleteWebPage
@@ -300,8 +299,6 @@ private extension HomeFeature {
             state.selectedTodoCategory = category
             state.sheet = nil
             return delayedTodoEditorEffect()
-        case .updateWebPageURLInput(let text):
-            state.webPageURLInput = text
         case .addWebPage:
             guard let normalizedURL = Self.normalizedWebPageURL(state.webPageURLInput) else {
                 Self.setAlert(&state, isPresented: true, type: .invalidURL)

--- a/Application/Presentation/Sources/Home/Home/HomeFeature.swift
+++ b/Application/Presentation/Sources/Home/Home/HomeFeature.swift
@@ -53,10 +53,11 @@ struct HomeFeature {
         let urlString: String
     }
 
-    enum Action: Equatable {
+    enum Action: BindableAction, Equatable {
         case alert(PresentationAction<Never>)
         case sheet(PresentationAction<Sheet>)
         case fullScreenCover(PresentationAction<FullScreenCover>)
+        case binding(BindingAction<State>)
         case view(ViewAction)
         case store(StoreAction)
         case loading(LoadingFeature.Action)
@@ -213,6 +214,7 @@ struct HomeFeature {
         Scope(state: \.loading, action: \.loading) {
             LoadingFeature()
         }
+        BindingReducer()
         Reduce { state, action in
             switch action {
             case .alert:
@@ -234,6 +236,8 @@ struct HomeFeature {
             case .sheet(.presented(.categoryManage(.delegate(.done(let preferences))))):
                 return orderTodoCategory(preferences, state: &state)
             case .sheet:
+                break
+            case .binding:
                 break
             case .view(let action):
                 return reduce(action, state: &state)

--- a/Application/Presentation/Sources/Home/Home/HomeView.swift
+++ b/Application/Presentation/Sources/Home/Home/HomeView.swift
@@ -214,10 +214,7 @@ struct HomeView: View {
                         Section {
                             TextField(
                                 "https://",
-                                text: Binding(
-                                    get: { store.webPageURLInput },
-                                    set: { store.send(.view(.updateWebPageURLInput($0))) }
-                                )
+                                text: $store.webPageURLInput
                             )
                             .textInputAutocapitalization(.never)
                             .keyboardType(.URL)

--- a/Application/Presentation/Sources/Home/Home/HomeView.swift
+++ b/Application/Presentation/Sources/Home/Home/HomeView.swift
@@ -59,7 +59,7 @@ struct HomeView: View {
                     .bold()
                 Spacer()
                 Button(action: {
-                    store.send(.store(.setSheet(.reorderTodo)))
+                    store.send(.view(.tapManageTodoCategory))
                 }) {
                     Image(systemName: "ellipsis")
                         .font(.title2)
@@ -258,13 +258,8 @@ struct HomeView: View {
                     }
                 }
             }
-        } else {
-            CategoryManageView(
-                preferences: store.preferences,
-                onDismiss: { array in
-                    store.send(.view(.orderTodoCategory(array)), animation: .default)
-                }
-            )
+        } else if let store = sheetStore.scope(state: \.categoryManageState, action: \.categoryManage) {
+            CategoryManageView(store: store)
         }
     }
 

--- a/Application/Presentation/Sources/Home/Home/HomeView.swift
+++ b/Application/Presentation/Sources/Home/Home/HomeView.swift
@@ -164,8 +164,8 @@ struct HomeView: View {
 
     @ViewBuilder
     private func sheetContent(_ sheetStore: Store<HomeFeature.SheetState, HomeFeature.Sheet>) -> some View {
-        if let contentPickerStore = sheetStore.scope(state: \.contentPickerState, action: \.contentPicker) {
-            @Bindable var contentPickerStore = contentPickerStore
+        if let pickerStore = sheetStore.scope(state: \.contentPickerState, action: \.contentPicker) {
+            @Bindable var pickerStore = pickerStore
             NavigationStack {
                 List {
                     Section {
@@ -193,7 +193,7 @@ struct HomeView: View {
 
                     Section {
                         Button {
-                            contentPickerStore.send(.tapWebPageInput)
+                            pickerStore.send(.tapWebPageInput)
                         } label: {
                             labelImage(
                                 text: "URL",
@@ -208,7 +208,7 @@ struct HomeView: View {
                     }
                 }
                 .navigationDestination(
-                    item: $contentPickerStore.scope(state: \.webPageInput, action: \.webPageInput)
+                    item: $pickerStore.scope(state: \.webPageInput, action: \.webPageInput)
                 ) { _ in
                     Form {
                         Section {

--- a/Application/Presentation/Tests/Home/CategoryManageFeatureTests.swift
+++ b/Application/Presentation/Tests/Home/CategoryManageFeatureTests.swift
@@ -164,6 +164,19 @@ struct CategoryManageFeatureTests {
 
         #expect(driver.categorySheet == nil)
     }
+
+    @Test("완료 버튼을 누르면 현재 preferences를 delegate로 전달한다")
+    func 완료_버튼을_누르면_현재_preferences를_delegate로_전달한다() async {
+        let item = TodoCategoryItem(from: .system(.issue))
+        let store = TestStore(
+            initialState: CategoryManageFeature.State(preferences: [item])
+        ) {
+            CategoryManageFeature()
+        }
+
+        await store.send(.tapDoneButton)
+        await store.receive(.delegate(.done([item])))
+    }
 }
 
 @MainActor

--- a/Application/Presentation/Tests/Home/HomeFeatureTestAssertions.swift
+++ b/Application/Presentation/Tests/Home/HomeFeatureTestAssertions.swift
@@ -87,11 +87,16 @@ func verifyHomeOrderTodoCategory(
         TodoCategoryItem(from: .system(.feature))
     ]
 
+    await adapter.tapManageTodoCategory()
+
+    #expect(adapter.showCategoryManage)
+
     await adapter.orderTodoCategory(items)
 
     #expect(adapter.preferences == items)
     #expect(adapter.recentTodos.last?.category == updatedCategory.category)
     #expect(updatePreferencesUseCaseSpy.updates == [items.map(\.preference)])
+    #expect(!adapter.showCategoryManage)
 }
 
 @MainActor

--- a/Application/Presentation/Tests/Home/HomeFeatureTestSupport.swift
+++ b/Application/Presentation/Tests/Home/HomeFeatureTestSupport.swift
@@ -23,6 +23,9 @@ struct HomeStoreTestAdapter {
     var webPages: [WebPageItem] { store.state.webPages }
     var isNetworkConnected: Bool { store.state.isNetworkConnected }
     var showContentPicker: Bool { store.state.showContentPicker }
+    var showCategoryManage: Bool {
+        store.state.sheet?.categoryManageState != nil
+    }
     var showWebPageInputNavigation: Bool {
         store.state.sheet?.contentPickerState?.webPageInput != nil
     }
@@ -113,8 +116,13 @@ struct HomeStoreTestAdapter {
         await drainReceivedActions()
     }
 
+    func tapManageTodoCategory() async {
+        await store.send(.view(.tapManageTodoCategory))
+        await drainReceivedActions()
+    }
+
     func orderTodoCategory(_ items: [TodoCategoryItem]) async {
-        await store.send(.view(.orderTodoCategory(items)))
+        await store.send(.sheet(.presented(.categoryManage(.delegate(.done(items))))))
         await drainReceivedActions()
     }
 

--- a/Application/Presentation/Tests/Home/HomeFeatureTestSupport.swift
+++ b/Application/Presentation/Tests/Home/HomeFeatureTestSupport.swift
@@ -127,7 +127,7 @@ struct HomeStoreTestAdapter {
     }
 
     func updateWebPageURLInput(_ input: String) async {
-        await store.send(.view(.updateWebPageURLInput(input)))
+        await store.send(.binding(.set(\.webPageURLInput, input)))
     }
 
     func addWebPage() async {


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #659

## 🎯 의도

- `CategoryManage` 완료 결과 전달을 View callback 기반 흐름에서 TCA delegate action 기반 흐름으로 전환

## 📝 작업 내용

### 📌 요약

- `CategoryManageFeature`에 완료 delegate action 추가
- `HomeFeature`가 `CategoryManageFeature` presentation state와 lifecycle을 소유하도록 변경
- `CategoryManageView` 내부 Store 생성 및 `onDismiss` callback 제거
- Home URL 입력을 Store binding 기반으로 정리
- CategoryManage delegate 흐름에 대한 TestStore 검증 추가

### 🔍 상세

- `CategoryManageFeature.Action.Delegate.done` 추가
- `tapDoneButton` 처리 시 현재 `preferences`를 delegate action으로 전달
- `HomeFeature.SheetState.reorderTodo`가 `CategoryManageFeature.State`를 보유하도록 변경
- `HomeFeature.Sheet.categoryManage` 경로를 통해 child action 수신
- delegate 수신 시 기존 카테고리 순서 저장 및 `recentTodos` category 동기화 흐름 재사용
- `CategoryManageView`가 parent에서 전달받은 scoped Store를 사용하도록 변경
- `HomeFeature`에 `BindingReducer`를 추가해 `webPageURLInput`을 `$store.webPageURLInput`으로 바인딩
- `CategoryManageFeatureTests`와 `HomeFeatureTests`에서 delegate 전달 및 parent 반영 흐름 검증

## 📸 영상 / 이미지 (Optional)

- 없음