### PR TITLE
[#671] AppStore Lane이 실패하는 현상을 해결한다

### DIFF
--- a/.github/workflows/appstore.yml
+++ b/.github/workflows/appstore.yml
@@ -76,6 +76,16 @@ jobs:
           install: true
           cache: true
 
+      - name: Install SwiftLint
+        env:
+          HOMEBREW_REQUIRE_TAP_TRUST: "1"
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          brew list swiftlint >/dev/null 2>&1 || brew install swiftlint
+          swiftlint version
+
       - name: Generate Xcode workspace with Tuist
         shell: bash
         run: |

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -353,6 +353,7 @@ platform :ios do
       skip_screenshots: true,
       submit_for_review: false,
       automatic_release: false,
+      precheck_include_in_app_purchases: false,
       force: true
     )
   end


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #671

## 🎯 의도

- App Store CD가 빌드 업로드 이후 실패로 처리되는 문제를 해결

## 📝 작업 내용

### 📌 요약

- App Store workflow에 SwiftLint 설치 단계 추가
- App Store 업로드 이후 fastlane precheck에서 In-App Purchase 검사를 제외하도록 수정

### 🔍 상세

- App Store archive 중 SwiftLint Run Script가 실행되므로, TestFlight workflow와 동일하게 `brew install swiftlint` 단계를 추가
- `upload_to_app_store`가 App Store Connect API Key 인증으로 실행될 때 In-App Purchase precheck를 수행하지 않도록 `precheck_include_in_app_purchases: false` 설정
- App Store Connect 빌드 업로드는 성공했지만 precheck 단계에서 CD가 실패로 표시되던 흐름 보정

## 📸 영상 / 이미지 (Optional)