### PR TITLE
[#679] 해결된 테스트 실패 로그가 잔여 파일로 인해 반복 노출되는 현상을 해결한다

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -528,15 +528,6 @@ jobs:
                 }
               }
 
-              if (selectedLines.length <= 0) {
-                for (const line of lines.slice(-25)) {
-                  const cleanedLine = cleanLine(line);
-                  if (!cleanedLine || seenLines.has(cleanedLine)) continue;
-                  seenLines.add(cleanedLine);
-                  selectedLines.push(cleanedLine);
-                }
-              }
-
               return selectedLines.slice(0, 30).join('\n');
             }
 
@@ -640,6 +631,8 @@ jobs:
                 section += `- ${summary.scheme} (${summary.artifactName})\n`;
                 if (summary.snippet) {
                   section += '\n```text\n' + summary.snippet + '\n```\n\n';
+                } else {
+                  section += '\nNo concise failure diagnostic was found in this scheme log.\n\n';
                 }
               }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -455,17 +455,57 @@ jobs:
     name: Report
     runs-on: ubuntu-latest
     needs: [build, test]
-    if: always() && (needs.build.result == 'failure' || needs.test.result == 'failure') && github.event.pull_request.head.repo.fork == false
+    if: |
+      always()
+      && github.event.pull_request.head.repo.fork == false
+      && (
+        needs.build.result == 'failure'
+        || needs.test.result == 'failure'
+        || (needs.build.result == 'success' && needs.test.result == 'success')
+      )
     steps:
       - uses: actions/checkout@v5
 
       - name: Download CI logs
+        if: needs.build.result == 'failure' || needs.test.result == 'failure'
         uses: actions/download-artifact@v7
         continue-on-error: true
         with:
           path: test-artifacts
 
+      - name: Delete resolved CI failure comments
+        if: needs.build.result == 'success' && needs.test.result == 'success'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            if (!context.payload.pull_request) {
+              core.info('No PR context; skipping comment cleanup.');
+              return;
+            }
+
+            const issueNumber = context.payload.pull_request.number;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              per_page: 100,
+            });
+
+            const failureComments = comments.filter((comment) => {
+              return comment.user?.type === 'Bot'
+                && comment.body?.startsWith('❌ iOS CI failed.');
+            });
+
+            for (const comment of failureComments) {
+              await github.rest.issues.deleteComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: comment.id,
+              });
+            }
+
       - name: Comment CI failure on PR
+        if: needs.build.result == 'failure' || needs.test.result == 'failure'
         uses: actions/github-script@v8
         env:
           BUILD_RESULT: ${{ needs.build.result }}

--- a/Application/Presentation/HomeTab/Sources/Home/Home/HomeFeature.swift
+++ b/Application/Presentation/HomeTab/Sources/Home/Home/HomeFeature.swift
@@ -7,7 +7,7 @@
 
 import Domain
 import Foundation
-import PresentationShared
+import PresentationShare
 
 @Reducer
 struct HomeFeature {

--- a/Application/Presentation/HomeTab/Sources/Home/Home/HomeFeature.swift
+++ b/Application/Presentation/HomeTab/Sources/Home/Home/HomeFeature.swift
@@ -7,7 +7,7 @@
 
 import Domain
 import Foundation
-import PresentationShare
+import PresentationShared
 
 @Reducer
 struct HomeFeature {


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #679

## 🎯 의도

- CI 실패 원인이 해결된 뒤에도 이전 실패 로그가 PR 스레드에 반복 노출되는 혼선 제거

## 📝 작업 내용

### 📌 요약

- CI 실패 댓글의 테스트 로그 요약 fallback 제거
- 요약 가능한 실패 진단이 없을 때 명시 문구 표시
- CI가 성공하면 이전 CI 실패 댓글을 자동 삭제하도록 `Report` job 정리

### 🔍 상세

- 테스트 로그에서 명확한 실패 패턴을 찾지 못한 경우 마지막 25줄을 실패 로그처럼 붙이던 fallback 제거
- `swiftmodulesreport`, SwiftLint note 같은 로그 꼬리 정보가 실패 원인처럼 표시되지 않도록 변경
- 실패 scheme은 유지하되, 간결한 진단을 찾지 못한 경우 artifact 확인 안내 문구 표시
- build/test가 모두 성공한 경우 기존 `❌ iOS CI failed.` bot 댓글을 찾아 삭제하도록 cleanup step 추가
- 실패한 경우에만 로그 artifact를 다운로드하고 실패 댓글을 작성하도록 step 조건 분리

## 📸 영상 / 이미지 (Optional)

- 없음