### PR TITLE
[#683] timeZone 동기화 요청을 사용자와 timeZone 기준으로 제한한다

### DIFF
--- a/Application/App/Sources/App/Assembler/AppLayerAssembler.swift
+++ b/Application/App/Sources/App/Assembler/AppLayerAssembler.swift
@@ -19,6 +19,7 @@ final class AppLayerAssembler: Assembler {
         }
         container.register(UserTimeZoneSyncHandler.self) {
             UserTimeZoneSyncHandler(
+                authService: container.resolve(AuthService.self),
                 userService: container.resolve(UserService.self)
             )
         }

--- a/Application/App/Sources/App/Delegate/AppDelegate.swift
+++ b/Application/App/Sources/App/Delegate/AppDelegate.swift
@@ -38,6 +38,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             name: .didRequestRemoteNotificationRegistration,
             object: nil
         )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(requestUserTimeZoneSync),
+            name: UIApplication.willEnterForegroundNotification,
+            object: nil
+        )
 
         // 알림 권한 요청
         UNUserNotificationCenter.current().delegate = self
@@ -75,6 +81,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func applicationWillEnterForeground(_ application: UIApplication) {
         NotificationCenter.default.post(name: .didRequestAPNsRegistration, object: nil)
+    }
+
+    @objc private func requestUserTimeZoneSync() {
+        NotificationCenter.default.post(name: .didRequestUserTimeZoneSync, object: nil)
     }
 
     // APNs 등록 성공

--- a/Application/App/Sources/App/Handler/UserTimeZoneSyncHandler.swift
+++ b/Application/App/Sources/App/Handler/UserTimeZoneSyncHandler.swift
@@ -8,30 +8,79 @@
 import Combine
 import Core
 import Data
-import UIKit
+import Foundation
 
 final class UserTimeZoneSyncHandler {
+    private struct SyncKey: Equatable {
+        let uid: String
+        let timeZoneIdentifier: String
+    }
+
+    private let authService: AuthService
     private let userService: UserService
     private let logger = Logger(category: "UserTimeZoneSyncHandler")
+    private var lastSyncedKey: SyncKey?
     private var cancellables = Set<AnyCancellable>()
 
     init(
+        authService: AuthService,
         userService: UserService,
         notificationCenter: NotificationCenter = .default
     ) {
+        self.authService = authService
         self.userService = userService
 
-        notificationCenter.publisher(for: .didRequestUserTimeZoneSync)
-            .merge(with: notificationCenter.publisher(for: UIApplication.willEnterForegroundNotification))
-            .sink { [weak self] _ in
-                Task {
-                    do {
-                        try await self?.userService.updateUserTimeZone()
-                    } catch {
-                        self?.logger.error("Failed to sync user timeZone", error: error)
-                    }
-                }
+        authService.observeSignedIn()
+            .sink { [weak self] isSignedIn in
+                self?.handleSessionUpdate(isSignedIn: isSignedIn)
             }
             .store(in: &cancellables)
+
+        notificationCenter.publisher(for: .didRequestUserTimeZoneSync)
+            .sink { [weak self] _ in
+                self?.requestUserTimeZoneSync()
+            }
+            .store(in: &cancellables)
+    }
+}
+
+private extension UserTimeZoneSyncHandler {
+    func handleSessionUpdate(isSignedIn: Bool) {
+        guard isSignedIn else {
+            lastSyncedKey = nil
+            return
+        }
+
+        requestUserTimeZoneSync()
+    }
+
+    func requestUserTimeZoneSync() {
+        Task { [weak self] in
+            await self?.syncUserTimeZoneIfNeeded()
+        }
+    }
+
+    func syncUserTimeZoneIfNeeded() async {
+        guard let uid = authService.uid else {
+            logger.info("Skipping timeZone update because no authenticated user exists")
+            return
+        }
+
+        let key = SyncKey(
+            uid: uid,
+            timeZoneIdentifier: TimeZone.autoupdatingCurrent.identifier
+        )
+
+        guard lastSyncedKey != key else {
+            logger.info("Skipping timeZone update because the current user timeZone is already synced")
+            return
+        }
+
+        do {
+            try await userService.updateUserTimeZone()
+            lastSyncedKey = key
+        } catch {
+            logger.error("Failed to sync user timeZone", error: error)
+        }
     }
 }

--- a/Application/App/Tests/UserTimeZone/UserTimeZoneSyncHandlerTests.swift
+++ b/Application/App/Tests/UserTimeZone/UserTimeZoneSyncHandlerTests.swift
@@ -1,0 +1,215 @@
+//
+//  UserTimeZoneSyncHandlerTests.swift
+//  AppTests
+//
+//  Created by opfic on 7/3/26.
+//
+
+import Combine
+import Foundation
+import Testing
+import Data
+@testable import App
+
+struct UserTimeZoneSyncHandlerTests {
+    @Test("로그인 세션 전이 시 현재 timeZone을 저장한다")
+    func 로그인_세션_전이_시_현재_timeZone을_저장한다() async throws {
+        let userService = UserServiceSpy()
+        let authService = AuthServiceSpy(uid: nil)
+        let handler = UserTimeZoneSyncHandler(
+            authService: authService,
+            userService: userService
+        )
+
+        authService.updateSession(uid: "user-id")
+
+        try await waitUntil {
+            await userService.updateUserTimeZoneCallCount == 1
+        }
+        _ = handler
+    }
+
+    @Test("같은 사용자와 같은 timeZone은 중복 저장하지 않는다")
+    func 같은_사용자와_같은_timeZone은_중복_저장하지_않는다() async throws {
+        let userService = UserServiceSpy()
+        let authService = AuthServiceSpy(uid: "user-id")
+        let handler = UserTimeZoneSyncHandler(
+            authService: authService,
+            userService: userService
+        )
+
+        authService.updateSession(uid: "user-id")
+        try await waitUntil {
+            await userService.updateUserTimeZoneCallCount == 1
+        }
+
+        authService.updateSession(uid: "user-id")
+        try await Task.sleep(for: .milliseconds(100))
+        #expect(await userService.updateUserTimeZoneCallCount == 1)
+        _ = handler
+    }
+
+    @Test("foreground 복귀 시 현재 timeZone을 요청하되 같은 사용자와 같은 timeZone은 중복 저장하지 않는다")
+    func foreground_복귀_시_현재_timeZone을_요청하되_같은_사용자와_같은_timeZone은_중복_저장하지_않는다() async throws {
+        let notificationCenter = NotificationCenter()
+        let userService = UserServiceSpy()
+        let authService = AuthServiceSpy(uid: "user-id")
+        let handler = UserTimeZoneSyncHandler(
+            authService: authService,
+            userService: userService,
+            notificationCenter: notificationCenter
+        )
+
+        notificationCenter.post(name: .didRequestUserTimeZoneSync, object: nil)
+        try await waitUntil {
+            await userService.updateUserTimeZoneCallCount == 1
+        }
+
+        notificationCenter.post(name: .didRequestUserTimeZoneSync, object: nil)
+        try await Task.sleep(for: .milliseconds(100))
+        #expect(await userService.updateUserTimeZoneCallCount == 1)
+        _ = handler
+    }
+
+    @Test("같은 timeZone이어도 사용자가 바뀌면 다시 저장한다")
+    func 같은_timeZone이어도_사용자가_바뀌면_다시_저장한다() async throws {
+        let userService = UserServiceSpy()
+        let authService = AuthServiceSpy(uid: "first-user")
+        let handler = UserTimeZoneSyncHandler(
+            authService: authService,
+            userService: userService
+        )
+
+        authService.updateSession(uid: "first-user")
+        try await waitUntil {
+            await userService.updateUserTimeZoneCallCount == 1
+        }
+
+        authService.updateSession(uid: "second-user")
+        try await waitUntil {
+            await userService.updateUserTimeZoneCallCount == 2
+        }
+        _ = handler
+    }
+
+    @Test("로그아웃 상태에서는 timeZone을 저장하지 않고 캐시를 초기화한다")
+    func 로그아웃_상태에서는_timeZone을_저장하지_않고_캐시를_초기화한다() async throws {
+        let userService = UserServiceSpy()
+        let authService = AuthServiceSpy(uid: "user-id")
+        let handler = UserTimeZoneSyncHandler(
+            authService: authService,
+            userService: userService
+        )
+
+        authService.updateSession(uid: "user-id")
+        try await waitUntil {
+            await userService.updateUserTimeZoneCallCount == 1
+        }
+
+        authService.updateSession(uid: nil)
+        try await Task.sleep(for: .milliseconds(100))
+        #expect(await userService.updateUserTimeZoneCallCount == 1)
+
+        authService.updateSession(uid: "user-id")
+        try await waitUntil {
+            await userService.updateUserTimeZoneCallCount == 2
+        }
+        _ = handler
+    }
+
+    @Test("timeZone 저장 실패 시 캐시를 갱신하지 않는다")
+    func timeZone_저장_실패_시_캐시를_갱신하지_않는다() async throws {
+        let userService = UserServiceSpy(updateError: TestError.updateFailed)
+        let authService = AuthServiceSpy(uid: "user-id")
+        let handler = UserTimeZoneSyncHandler(
+            authService: authService,
+            userService: userService
+        )
+
+        authService.updateSession(uid: "user-id")
+        try await waitUntil {
+            await userService.updateUserTimeZoneCallCount == 1
+        }
+
+        await userService.setUpdateError(nil)
+        authService.updateSession(uid: "user-id")
+        try await waitUntil {
+            await userService.updateUserTimeZoneCallCount == 2
+        }
+        _ = handler
+    }
+}
+
+private actor UserServiceSpy: UserService {
+    private var updateError: Error?
+    private(set) var updateUserTimeZoneCallCount = 0
+
+    init(updateError: Error? = nil) {
+        self.updateError = updateError
+    }
+
+    func upsertUser(_ response: AuthDataResponse) async throws { }
+    func fetchUserProfile() async throws -> UserProfileResponse { fatalError() }
+    func upsertStatusMessage(_ message: String) async throws { }
+    func updateFCMToken(_ fcmToken: String) async throws { }
+
+    func updateUserTimeZone() async throws {
+        updateUserTimeZoneCallCount += 1
+        if let updateError {
+            throw updateError
+        }
+    }
+
+    func setUpdateError(_ updateError: Error?) {
+        self.updateError = updateError
+    }
+}
+
+private final class AuthServiceSpy: AuthService {
+    var uid: String?
+    let providerIDs = [String]()
+    let currentUserEmail: String? = nil
+    let providerCount = 0
+    private let subject = PassthroughSubject<Bool, Never>()
+
+    init(uid: String? = "user-id") {
+        self.uid = uid
+    }
+
+    func observeSignedIn() -> AnyPublisher<Bool, Never> {
+        subject.eraseToAnyPublisher()
+    }
+
+    func updateSession(uid: String?) {
+        self.uid = uid
+        subject.send(uid != nil)
+    }
+
+    func beginSignIn() { }
+    func completeSignIn() { }
+    func cancelSignIn() { }
+    func getProviderID() async throws -> String? { nil }
+    func deleteCurrentUser() async throws { }
+    func clearCurrentSession() async throws { }
+}
+
+private enum TestError: Error {
+    case updateFailed
+}
+
+private func waitUntil(
+    timeout: Duration = .seconds(1),
+    pollInterval: Duration = .milliseconds(10),
+    condition: @escaping @Sendable () async -> Bool
+) async throws {
+    let deadline = ContinuousClock.now + timeout
+
+    while ContinuousClock.now < deadline {
+        if await condition() {
+            return
+        }
+        try await Task.sleep(for: pollInterval)
+    }
+
+    Issue.record("조건을 만족하지 못함")
+}


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #683

## 🎯 의도

foreground 복귀와 로그인 세션 전이에서 timeZone 동기화 요청을 유지하되, 동일 `(uid, timeZoneIdentifier)` 조합의 반복 DB write 방지

## 📝 작업 내용

### 📌 요약

- `UserTimeZoneSyncHandler` 동기화 기준을 로그인 세션 이벤트와 App layer timeZone 요청 이벤트로 조정
- 마지막 성공 동기화 기준을 메모리에 캐싱해 동일 사용자/timeZone 반복 write 방지
- foreground 전환 시 AppDelegate에서 timeZone 동기화 요청 이벤트 전달
- `UserTimeZoneSyncHandlerTests` 추가

### 🔍 상세

- `UserTimeZoneSyncHandler`에서 UIKit 의존성 제거
- `AuthService.observeSignedIn()` 관찰 추가
- 로그아웃 시 `lastSyncedKey` 초기화
- `updateUserTimeZone()` 성공 후에만 `(uid, timeZoneIdentifier)` 캐시 갱신
- `AppDelegate`에서 `UIApplication.willEnterForegroundNotification` 수신 후 `.didRequestUserTimeZoneSync` 전달
- 로그인 세션 전이, foreground 요청, 중복 skip, 사용자 변경, 로그아웃 초기화, 실패 시 캐시 미갱신 테스트 추가

검증

- production 변경 파일 SwiftLint 통과
- test 변경 파일 SwiftLint 통과
- `build_sim`은 기존 `ComposableArchitecture.Scope.init` linker 오류로 실패

## 📸 영상 / 이미지 (Optional)

없음