### PR TITLE
[#687] UserTimeZone 동기화 요청을 중복 제한한다

### DIFF
--- a/Application/App/Sources/App/Delegate/AppDelegate.swift
+++ b/Application/App/Sources/App/Delegate/AppDelegate.swift
@@ -62,9 +62,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             }
         }
 
-        // 앱이 온그라운드로 되었을 때, 로그인 세션이 존재한다면 현재 유저의 timeZone 저장
-        NotificationCenter.default.post(name: .didRequestUserTimeZoneSync, object: nil)
-
         // Firebase Messaging 설정
         container.resolve(PushMessagingService.self).setDelegate(self)
 

--- a/Application/App/Sources/App/Handler/UserTimeZoneSyncHandler.swift
+++ b/Application/App/Sources/App/Handler/UserTimeZoneSyncHandler.swift
@@ -16,9 +16,16 @@ final class UserTimeZoneSyncHandler {
         let timeZoneIdentifier: String
     }
 
+    private enum SyncStartResult {
+        case started
+        case alreadySynced
+        case alreadySyncing
+    }
+
     private let authService: AuthService
     private let userService: UserService
     private let logger = Logger(category: "UserTimeZoneSyncHandler")
+    private let lock = NSLock()
     private var lastSyncedKey: SyncKey?
     private var syncingKeys = Set<SyncKey>()
     private var cancellables = Set<AnyCancellable>()
@@ -49,8 +56,7 @@ final class UserTimeZoneSyncHandler {
 private extension UserTimeZoneSyncHandler {
     func handleSessionUpdate(isSignedIn: Bool) {
         guard isSignedIn else {
-            lastSyncedKey = nil
-            syncingKeys.removeAll()
+            resetSyncState()
             return
         }
 
@@ -74,22 +80,56 @@ private extension UserTimeZoneSyncHandler {
             timeZoneIdentifier: TimeZone.autoupdatingCurrent.identifier
         )
 
-        guard lastSyncedKey != key else {
+        switch beginSync(for: key) {
+        case .started:
+            break
+        case .alreadySynced:
             logger.info("Skipping timeZone update because the current user timeZone is already synced")
             return
-        }
-        guard !syncingKeys.contains(key) else {
+        case .alreadySyncing:
             logger.info("Skipping timeZone update because the current user timeZone is already syncing")
             return
         }
 
         do {
-            syncingKeys.insert(key)
-            defer { syncingKeys.remove(key) }
             try await userService.updateUserTimeZone()
-            lastSyncedKey = key
+            finishSync(for: key, didSucceed: true)
         } catch {
+            finishSync(for: key, didSucceed: false)
             logger.error("Failed to sync user timeZone", error: error)
+        }
+    }
+
+    private func resetSyncState() {
+        lock.lock()
+        defer { lock.unlock() }
+
+        lastSyncedKey = nil
+        syncingKeys.removeAll()
+    }
+
+    private func beginSync(for key: SyncKey) -> SyncStartResult {
+        lock.lock()
+        defer { lock.unlock() }
+
+        if lastSyncedKey == key {
+            return .alreadySynced
+        }
+        if syncingKeys.contains(key) {
+            return .alreadySyncing
+        }
+
+        syncingKeys.insert(key)
+        return .started
+    }
+
+    private func finishSync(for key: SyncKey, didSucceed: Bool) {
+        lock.lock()
+        defer { lock.unlock() }
+
+        syncingKeys.remove(key)
+        if didSucceed {
+            lastSyncedKey = key
         }
     }
 }

--- a/Application/App/Sources/App/Handler/UserTimeZoneSyncHandler.swift
+++ b/Application/App/Sources/App/Handler/UserTimeZoneSyncHandler.swift
@@ -11,7 +11,7 @@ import Data
 import Foundation
 
 final class UserTimeZoneSyncHandler {
-    private struct SyncKey: Equatable {
+    private struct SyncKey: Hashable {
         let uid: String
         let timeZoneIdentifier: String
     }
@@ -20,6 +20,7 @@ final class UserTimeZoneSyncHandler {
     private let userService: UserService
     private let logger = Logger(category: "UserTimeZoneSyncHandler")
     private var lastSyncedKey: SyncKey?
+    private var syncingKeys = Set<SyncKey>()
     private var cancellables = Set<AnyCancellable>()
 
     init(
@@ -31,6 +32,7 @@ final class UserTimeZoneSyncHandler {
         self.userService = userService
 
         authService.observeSignedIn()
+            .removeDuplicates()
             .sink { [weak self] isSignedIn in
                 self?.handleSessionUpdate(isSignedIn: isSignedIn)
             }
@@ -48,6 +50,7 @@ private extension UserTimeZoneSyncHandler {
     func handleSessionUpdate(isSignedIn: Bool) {
         guard isSignedIn else {
             lastSyncedKey = nil
+            syncingKeys.removeAll()
             return
         }
 
@@ -75,8 +78,14 @@ private extension UserTimeZoneSyncHandler {
             logger.info("Skipping timeZone update because the current user timeZone is already synced")
             return
         }
+        guard !syncingKeys.contains(key) else {
+            logger.info("Skipping timeZone update because the current user timeZone is already syncing")
+            return
+        }
 
         do {
+            syncingKeys.insert(key)
+            defer { syncingKeys.remove(key) }
             try await userService.updateUserTimeZone()
             lastSyncedKey = key
         } catch {

--- a/Application/App/Tests/UserTimeZone/UserTimeZoneSyncHandlerTests.swift
+++ b/Application/App/Tests/UserTimeZone/UserTimeZoneSyncHandlerTests.swift
@@ -113,8 +113,8 @@ struct UserTimeZoneSyncHandlerTests {
         _ = handler
     }
 
-    @Test("같은 timeZone이어도 사용자가 바뀌면 다시 저장한다")
-    func 같은_timeZone이어도_사용자가_바뀌면_다시_저장한다() async throws {
+    @Test("로그아웃 후 다른 사용자로 로그인하면 같은 timeZone이어도 다시 저장한다")
+    func 로그아웃_후_다른_사용자로_로그인하면_같은_timeZone이어도_다시_저장한다() async throws {
         let userService = UserServiceSpy()
         let authService = AuthServiceSpy(uid: "first-user")
         let handler = UserTimeZoneSyncHandler(
@@ -127,6 +127,7 @@ struct UserTimeZoneSyncHandlerTests {
             await userService.updateUserTimeZoneCallCount == 1
         }
 
+        authService.updateSession(uid: nil)
         authService.updateSession(uid: "second-user")
         try await waitUntil {
             await userService.updateUserTimeZoneCallCount == 2
@@ -161,11 +162,13 @@ struct UserTimeZoneSyncHandlerTests {
 
     @Test("timeZone 저장 실패 시 캐시를 갱신하지 않는다")
     func timeZone_저장_실패_시_캐시를_갱신하지_않는다() async throws {
+        let notificationCenter = NotificationCenter()
         let userService = UserServiceSpy(updateError: TestError.updateFailed)
         let authService = AuthServiceSpy(uid: "user-id")
         let handler = UserTimeZoneSyncHandler(
             authService: authService,
-            userService: userService
+            userService: userService,
+            notificationCenter: notificationCenter
         )
 
         authService.updateSession(uid: "user-id")
@@ -174,7 +177,7 @@ struct UserTimeZoneSyncHandlerTests {
         }
 
         await userService.setUpdateError(nil)
-        authService.updateSession(uid: "user-id")
+        notificationCenter.post(name: .didRequestUserTimeZoneSync, object: nil)
         try await waitUntil {
             await userService.updateUserTimeZoneCallCount == 2
         }

--- a/Application/App/Tests/UserTimeZone/UserTimeZoneSyncHandlerTests.swift
+++ b/Application/App/Tests/UserTimeZone/UserTimeZoneSyncHandlerTests.swift
@@ -49,6 +49,26 @@ struct UserTimeZoneSyncHandlerTests {
         _ = handler
     }
 
+    @Test("같은 로그인 상태가 연속 방출되면 현재 timeZone을 한 번만 저장한다")
+    func 같은_로그인_상태가_연속_방출되면_현재_timeZone을_한_번만_저장한다() async throws {
+        let userService = UserServiceSpy(updateDelay: .milliseconds(100))
+        let authService = AuthServiceSpy(uid: "user-id")
+        let handler = UserTimeZoneSyncHandler(
+            authService: authService,
+            userService: userService
+        )
+
+        authService.updateSession(uid: "user-id")
+        authService.updateSession(uid: "user-id")
+
+        try await waitUntil {
+            await userService.updateUserTimeZoneCallCount == 1
+        }
+        try await Task.sleep(for: .milliseconds(150))
+        #expect(await userService.updateUserTimeZoneCallCount == 1)
+        _ = handler
+    }
+
     @Test("foreground 복귀 시 현재 timeZone을 요청하되 같은 사용자와 같은 timeZone은 중복 저장하지 않는다")
     func foreground_복귀_시_현재_timeZone을_요청하되_같은_사용자와_같은_timeZone은_중복_저장하지_않는다() async throws {
         let notificationCenter = NotificationCenter()
@@ -67,6 +87,28 @@ struct UserTimeZoneSyncHandlerTests {
 
         notificationCenter.post(name: .didRequestUserTimeZoneSync, object: nil)
         try await Task.sleep(for: .milliseconds(100))
+        #expect(await userService.updateUserTimeZoneCallCount == 1)
+        _ = handler
+    }
+
+    @Test("현재 timeZone 저장 중 foreground 요청이 들어오면 중복 저장하지 않는다")
+    func 현재_timeZone_저장_중_foreground_요청이_들어오면_중복_저장하지_않는다() async throws {
+        let notificationCenter = NotificationCenter()
+        let userService = UserServiceSpy(updateDelay: .milliseconds(100))
+        let authService = AuthServiceSpy(uid: "user-id")
+        let handler = UserTimeZoneSyncHandler(
+            authService: authService,
+            userService: userService,
+            notificationCenter: notificationCenter
+        )
+
+        authService.updateSession(uid: "user-id")
+        try await waitUntil {
+            await userService.updateUserTimeZoneCallCount == 1
+        }
+
+        notificationCenter.post(name: .didRequestUserTimeZoneSync, object: nil)
+        try await Task.sleep(for: .milliseconds(150))
         #expect(await userService.updateUserTimeZoneCallCount == 1)
         _ = handler
     }
@@ -142,10 +184,12 @@ struct UserTimeZoneSyncHandlerTests {
 
 private actor UserServiceSpy: UserService {
     private var updateError: Error?
+    private let updateDelay: Duration?
     private(set) var updateUserTimeZoneCallCount = 0
 
-    init(updateError: Error? = nil) {
+    init(updateError: Error? = nil, updateDelay: Duration? = nil) {
         self.updateError = updateError
+        self.updateDelay = updateDelay
     }
 
     func upsertUser(_ response: AuthDataResponse) async throws { }
@@ -155,6 +199,9 @@ private actor UserServiceSpy: UserService {
 
     func updateUserTimeZone() async throws {
         updateUserTimeZoneCallCount += 1
+        if let updateDelay {
+            try await Task.sleep(for: updateDelay)
+        }
         if let updateError {
             throw updateError
         }


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #687

## 🎯 의도

- 앱 실행, 인증 상태 방출, foreground 복귀 흐름에서 User timeZone 동기화 요청이 겹칠 수 있어 같은 사용자와 같은 timeZone 조합의 반복 저장을 방지

## 📝 작업 내용

### 📌 요약

- launch 시점의 직접 timeZone 동기화 요청 제거
- `UserTimeZoneSyncHandler`의 로그인 상태 중복 방출 필터링 추가
- 같은 `(uid, timeZoneIdentifier)` 조합의 완료/진행 중 중복 저장 방지 처리
- 동시 foreground 요청과 연속 로그인 상태 방출 테스트 추가

### 🔍 상세

- `didFinishLaunchingWithOptions`에서 `.didRequestUserTimeZoneSync` 직접 post 제거
- `observeSignedIn()`에 `removeDuplicates()` 적용
- `SyncKey`를 `Hashable`로 변경하고 `syncingKeys`로 진행 중인 같은 key 중복 요청 차단
- 로그아웃 상태 전이 시 `lastSyncedKey`와 `syncingKeys` 초기화
- `updateUserTimeZone()` 성공 후에만 `lastSyncedKey` 갱신
- 같은 로그인 상태 연속 방출, 저장 중 foreground 요청, 사용자/timeZone 변경, 실패 후 재시도 케이스 테스트 보강

## 📸 영상 / 이미지 (Optional)