### PR TITLE
[#690] CI에 App 레이어 테스트를 추가한다

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,6 +222,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - name: App
+            schemes: "App"
           - name: Domain-Data
             schemes: "Domain Data"
           - name: Persistence


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #690

## 🎯 의도
PR CI에서 `AppTests`가 누락되지 않도록 `App` scheme 테스트를 `test` job matrix에 포함

## 📝 작업 내용

### 📌 요약
- `.github/workflows/ci.yml`의 test matrix에 `App` 그룹 추가

### 🔍 상세
- `Test (App)` 체크가 생성되도록 `App` scheme을 matrix에 추가
- 기존 테스트 스크립트의 `Application/App/Tests` 감지 흐름을 그대로 재사용
- App 레이어 테스트 실패 시 기존 report job의 실패 scheme 집계 대상에 포함

## 📸 영상 / 이미지 (Optional)
없음
