### PR TITLE
[#702] 베타 테스트 참여 항목을 prod에서만 노출한다

### DIFF
--- a/Application/Presentation/ProfileTab/Sources/Settings/SettingsFeature.swift
+++ b/Application/Presentation/ProfileTab/Sources/Settings/SettingsFeature.swift
@@ -34,11 +34,26 @@ struct SettingsFeature {
         var loading = LoadingFeature.State()
         var alertType: Action.AlertType?
         var appVersion = Self.appVersion()
-        var appstoreUrl = Bundle.main.object(forInfoDictionaryKey: "TESTFLIGHT_URL") as? String
+        var betaTestURL = Self.betaTestURL()
         var policyURL = Bundle.main.object(forInfoDictionaryKey: "PRIVACY_POLICY_URL") as? String
 
         var isLoading: Bool {
             loading.isLoading
+        }
+
+        private static func betaTestURL() -> URL? {
+            let databaseID = Bundle.main.object(forInfoDictionaryKey: "FIRESTORE_DATABASE_ID") as? String
+            guard databaseID?.trimmingCharacters(in: .whitespacesAndNewlines) == "prod",
+                  let rawValue = Bundle.main.object(forInfoDictionaryKey: "TESTFLIGHT_URL") as? String else {
+                return nil
+            }
+
+            let urlString = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !urlString.isEmpty, !urlString.hasPrefix("$(") else {
+                return nil
+            }
+
+            return URL(string: urlString)
         }
 
         private static func appVersion() -> String? {

--- a/Application/Presentation/ProfileTab/Sources/Settings/SettingsFeature.swift
+++ b/Application/Presentation/ProfileTab/Sources/Settings/SettingsFeature.swift
@@ -34,17 +34,19 @@ struct SettingsFeature {
         var loading = LoadingFeature.State()
         var alertType: Action.AlertType?
         var appVersion = Self.appVersion()
-        var betaTestURL = Self.betaTestURL()
+        var betaTestURL = Self.betaTestURL(
+            databaseID: Bundle.main.object(forInfoDictionaryKey: "FIRESTORE_DATABASE_ID") as? String,
+            testFlightURL: Bundle.main.object(forInfoDictionaryKey: "TESTFLIGHT_URL") as? String
+        )
         var policyURL = Bundle.main.object(forInfoDictionaryKey: "PRIVACY_POLICY_URL") as? String
 
         var isLoading: Bool {
             loading.isLoading
         }
 
-        private static func betaTestURL() -> URL? {
-            let databaseID = Bundle.main.object(forInfoDictionaryKey: "FIRESTORE_DATABASE_ID") as? String
+        static func betaTestURL(databaseID: String?, testFlightURL: String?) -> URL? {
             guard databaseID?.trimmingCharacters(in: .whitespacesAndNewlines) == "prod",
-                  let rawValue = Bundle.main.object(forInfoDictionaryKey: "TESTFLIGHT_URL") as? String else {
+                  let rawValue = testFlightURL else {
                 return nil
             }
 

--- a/Application/Presentation/ProfileTab/Sources/Settings/SettingsView.swift
+++ b/Application/Presentation/ProfileTab/Sources/Settings/SettingsView.swift
@@ -72,11 +72,10 @@ struct SettingsView: View {
                     }
                 }
                 if let betaTestURL = store.betaTestURL {
-                    Button {
-                        UIApplication.shared.open(betaTestURL)
-                    } label: {
+                    Link(destination: betaTestURL) {
                         VStack(alignment: .leading) {
                             Text(String(localized: "settings_join_beta"))
+                                .foregroundStyle(Color.primary)
                             Text(String(localized: "settings_join_beta_subtitle"))
                                 .foregroundStyle(Color.gray)
                                 .font(.caption)

--- a/Application/Presentation/ProfileTab/Sources/Settings/SettingsView.swift
+++ b/Application/Presentation/ProfileTab/Sources/Settings/SettingsView.swift
@@ -71,17 +71,16 @@ struct SettingsView: View {
                             .foregroundColor(Color.blue)
                     }
                 }
-                Button(action: {
-                    if let appStoreString = store.appstoreUrl,
-                       let url = URL(string: appStoreString) {
-                        UIApplication.shared.open(url)
-                    }
-                }) {
-                    VStack(alignment: .leading) {
-                        Text(String(localized: "settings_join_beta"))
-                        Text(String(localized: "settings_join_beta_subtitle"))
-                            .foregroundStyle(Color.gray)
-                            .font(.caption)
+                if let betaTestURL = store.betaTestURL {
+                    Button {
+                        UIApplication.shared.open(betaTestURL)
+                    } label: {
+                        VStack(alignment: .leading) {
+                            Text(String(localized: "settings_join_beta"))
+                            Text(String(localized: "settings_join_beta_subtitle"))
+                                .foregroundStyle(Color.gray)
+                                .font(.caption)
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #702

## 🎯 의도
- `Debug` / `Staging` 빌드에서 `베타 테스트 참여` 항목이 노출되지 않도록 Settings 화면 조건 정리
- `Release` / `prod` 빌드에서만 유효한 `TESTFLIGHT_URL` 기반 베타 참여 링크 제공

## 📝 작업 내용

### 📌 요약
- `FIRESTORE_DATABASE_ID == "prod"` 조건 기반 `betaTestURL` 계산 추가
- `SettingsView`의 베타 참여 항목을 `betaTestURL` 존재 여부로 조건부 렌더링

### 🔍 상세
- `SettingsFeature.State`에서 `FIRESTORE_DATABASE_ID`와 `TESTFLIGHT_URL`을 `Bundle.main`으로 조회하도록 변경
- `TESTFLIGHT_URL`이 비어 있거나 placeholder 상태이면 베타 참여 항목 미노출
- 기존 버전, 개인정보 처리방침, 계정 설정 흐름 유지

## 📸 영상 / 이미지 (Optional)
- 없음