### PR TITLE
[#712] GitHub 이메일 변경으로 인한 계정 연결 충돌 안내를 추가한다

### DIFF
--- a/AGENT_ROLES.md
+++ b/AGENT_ROLES.md
@@ -44,6 +44,15 @@ Default role-to-model assignment:
 
 Do not assign `Spark` as the only model for production Swift implementation, target dependency changes, DI assembly, repository/service contract changes, Firebase or SDK placement, Widget data-flow changes, StorePattern responsibility changes, commits, pushes, PR creation, or final integration.
 
+### Model dispatch requirements
+
+- A model tier assignment is an execution requirement, not a label for work the main agent already performed.
+- When a role is assigned to `Spark` or `Fast`, and tooling can select that model, the main agent must dispatch that role through a separate model or sub-agent call before using its result.
+- Do not satisfy a `Spark` or `Fast` role by completing the role directly in `Primary` and describing it as delegated work.
+- If the assigned model cannot be called because the model or model-selecting tool is unavailable, apply the fallback policy and report which role was not dispatched to its default tier.
+- If the assigned model is available but current tool policy requires explicit user permission before dispatch, missing permission is not fallback. Stop and ask for permission before continuing the required role.
+- `Primary` must integrate and verify delegated output, but must not skip the delegated role when the workflow requires it and the assigned model is available.
+
 ### Fallback policy
 
 - If `gpt-5.3-codex-spark` is unavailable, assign `Spark` roles to the fastest available read-only capable coding model.
@@ -123,6 +132,7 @@ Rules:
 - Stay inside the role permissions.
 - Do not edit files if this is a read-only role.
 - Do not run, launch, install, boot, or open the app or Simulator.
+- Perform this role in the assigned model context. Do not return work copied from a different model context as this role's own result.
 - Stop and report if the task packet conflicts with `AGENTS.md`.
 - Return only the output format defined for `<Role Name>`.
 ```

--- a/AGENT_WORKFLOWS.md
+++ b/AGENT_WORKFLOWS.md
@@ -17,12 +17,14 @@ The main agent must run every workflow with this protocol.
 3. Create the task packet.
 4. Assign only the roles required by the selected workflow.
 5. Assign each role a model tier from `AGENT_ROLES.md`.
-6. Dispatch read-only `Spark` or `Fast` roles in parallel only when they do not depend on unfinished edits.
-7. Keep `Primary` editing roles sequential unless the files and ownership boundaries are disjoint.
-8. Integrate role outputs.
-9. Escalate any `Spark` or `Fast` blocker to a `Primary` model before editing.
-10. Run completion gates.
-11. Report changed files, architecture decision, verification result, and unresolved decisions.
+6. Dispatch each `Spark` or `Fast` role through a separate model or sub-agent call when tooling can select that assigned model.
+7. Dispatch read-only `Spark` or `Fast` roles in parallel only when they do not depend on unfinished edits.
+8. Do not complete a required `Spark` or `Fast` role directly in `Primary` unless the model or model-selecting tool is unavailable and the fallback policy in `AGENT_ROLES.md` applies.
+9. Keep `Primary` editing roles sequential unless the files and ownership boundaries are disjoint.
+10. Integrate role outputs.
+11. Escalate any `Spark` or `Fast` blocker to a `Primary` model before editing.
+12. Run completion gates.
+13. Report changed files, architecture decision, verification result, delegated roles, model tiers used, and unresolved decisions.
 
 Do not skip the task packet. The task packet is the contract between models.
 
@@ -33,6 +35,7 @@ Stop and ask the user before editing when:
 - The task packet conflicts with `AGENTS.md`.
 - The requested fix requires relaxing a layer boundary.
 - A role needs to run, launch, install, boot, or open the app or Simulator.
+- A required `Spark` or `Fast` role needs a separate model or sub-agent call, but current tool policy requires user permission that has not been granted.
 - The current issue or PR scope is unclear after live GitHub inspection.
 - Two editing roles would touch the same file.
 - A read-only role reports `Block` or `Needs Owner Decision`.
@@ -236,6 +239,9 @@ Use for PR body, issue text, release note, README wording, review reply draft, o
 ### Execution
 
 - Documentation Writer must inspect the actual diff before writing PR or release text.
+- When the Documentation Writer role is required and `Spark` is available, the main agent must dispatch the draft to `gpt-5.3-codex-spark` or the configured `Spark` fallback before writing the final response.
+- If dispatch requires explicit user permission and it has not been granted, ask before drafting, returning, or posting the Documentation Writer output.
+- `Primary` must review the Documentation Writer output against the template, issue scope, and diff before returning or posting it.
 - Do not write AI workflow documents under `docs/`.
 - If the user asks only for text, return text directly and do not create files.
 - If documentation files are changed, keep the change scoped to the requested document.

--- a/Application/App/Sources/Resource/Localizable.xcstrings
+++ b/Application/App/Sources/Resource/Localizable.xcstrings
@@ -139,6 +139,40 @@
         }
       }
     },
+    "account_alert_github_email_conflict_message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A GitHub email change caused a conflict during the linking process. To protect existing data, linking cannot be completed."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GitHub 이메일 변경으로 연결 과정에서 충돌이 발생했습니다. 기존 데이터를 보호하기 위해 연결을 진행할 수 없습니다."
+          }
+        }
+      }
+    },
+    "account_alert_github_email_conflict_title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unable to Link Account"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "계정을 연결할 수 없음"
+          }
+        }
+      }
+    },
     "account_connect" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Application/Data/Sources/Common/DataLayerError.swift
+++ b/Application/Data/Sources/Common/DataLayerError.swift
@@ -12,17 +12,6 @@ public enum EmailError: Error, Equatable {
     case notFound
     case mismatch
     case githubEmailConflict
-
-    public var code: String {
-        switch self {
-        case .mismatch:
-            "email_mismatch"
-        case .notFound:
-            "email_not_found"
-        case .githubEmailConflict:
-            "github-email-changed-account-conflict"
-        }
-    }
 }
 
 public enum DataLayerError: Error {

--- a/Application/Data/Sources/Common/DataLayerError.swift
+++ b/Application/Data/Sources/Common/DataLayerError.swift
@@ -11,6 +11,7 @@ import Core
 public enum EmailError: Error, Equatable {
     case notFound
     case mismatch
+    case githubEmailConflict
 
     public var code: String {
         switch self {
@@ -18,6 +19,8 @@ public enum EmailError: Error, Equatable {
             "email_mismatch"
         case .notFound:
             "email_not_found"
+        case .githubEmailConflict:
+            "github-email-changed-account-conflict"
         }
     }
 }

--- a/Application/Data/Sources/Common/DataLayerError.swift
+++ b/Application/Data/Sources/Common/DataLayerError.swift
@@ -8,31 +8,33 @@
 import Foundation
 import Core
 
-public enum EmailFetchError: Error, Equatable {
-    case emailNotFound
-    case emailMismatch
+public enum EmailError: Error, Equatable {
+    case notFound
+    case mismatch
 
     public var code: String {
         switch self {
-        case .emailMismatch:
+        case .mismatch:
             "email_mismatch"
-        case .emailNotFound:
+        case .notFound:
             "email_not_found"
         }
     }
 }
 
-public enum DataError: Error {
+public enum DataLayerError: Error {
+    case notAuthenticated
+    case linkCredentialAlreadyInUse
     case invalidData(context: String)
 
-    private static let logger = Logger(category: "DataError")
+    private static let logger = Logger(category: "DataLayerError")
 
     public static func invalidData(
         _ context: String,
         file: String = #file,
         function: String = #function,
         line: Int = #line
-    ) -> DataError {
+    ) -> DataLayerError {
         logger.error(
             "Invalid data: \(context)",
             file: file,
@@ -41,9 +43,4 @@ public enum DataError: Error {
         )
         return .invalidData(context: context)
     }
-}
-
-public enum DataLayerError: Error {
-    case notAuthenticated
-    case linkCredentialAlreadyInUse
 }

--- a/Application/Data/Sources/Mapper/ErrorMapping.swift
+++ b/Application/Data/Sources/Mapper/ErrorMapping.swift
@@ -14,6 +14,8 @@ extension Error {
             return AuthError.notAuthenticated
         case .linkCredentialAlreadyInUse:
             return AuthError.linkCredentialAlreadyInUse
+        case .invalidData(let context):
+            return DomainLayerError.invalidData(context: context)
         case .none:
             return self
         }

--- a/Application/Data/Sources/Mapper/PushNotificationMapping.swift
+++ b/Application/Data/Sources/Mapper/PushNotificationMapping.swift
@@ -15,7 +15,7 @@ public extension PushNotificationResponse {
         case .decoded(let category):
             todoCategory = category
         case .raw(let category):
-            throw DataError.invalidData(
+            throw DataLayerError.invalidData(
                 "PushNotificationResponse.todoCategory must be resolved before toDomain(): \(category)"
             )
         }

--- a/Application/Data/Sources/Mapper/TodoMapping.swift
+++ b/Application/Data/Sources/Mapper/TodoMapping.swift
@@ -54,7 +54,7 @@ public extension TodoResponse {
         case .decoded(let category):
             todoCategory = category
         case .raw(let category):
-            throw DataError.invalidData("TodoResponse.category must be resolved before toDomain(): \(category)")
+            throw DataLayerError.invalidData("TodoResponse.category must be resolved before toDomain(): \(category)")
         }
 
         return Todo(

--- a/Application/Data/Sources/Mapper/WebPageMapping.swift
+++ b/Application/Data/Sources/Mapper/WebPageMapping.swift
@@ -11,10 +11,10 @@ import Domain
 public extension WebPageResponse {
     func toDomain() throws -> WebPage {
         guard let url = URL(string: url) else {
-            throw DataError.invalidData("WebPageResponse.url is invalid: \(url)")
+            throw DataLayerError.invalidData("WebPageResponse.url is invalid: \(url)")
         }
         guard let displayURL = URL(string: displayURL) else {
-            throw DataError.invalidData("WebPageResponse.displayURL is invalid: \(displayURL)")
+            throw DataLayerError.invalidData("WebPageResponse.displayURL is invalid: \(displayURL)")
         }
         let imageURL: URL?
         if !self.imageURL.isEmpty {

--- a/Application/Data/Sources/Repository/AuthDataRepositoryImpl.swift
+++ b/Application/Data/Sources/Repository/AuthDataRepositoryImpl.swift
@@ -91,6 +91,8 @@ private extension AuthDataRepositoryImpl {
                 return AuthError.linkEmailNotFound
             case .mismatch:
                 return AuthError.linkEmailMismatch
+            case .githubEmailConflict:
+                return AuthError.githubEmailConflict
             }
         }
 

--- a/Application/Data/Sources/Repository/AuthDataRepositoryImpl.swift
+++ b/Application/Data/Sources/Repository/AuthDataRepositoryImpl.swift
@@ -85,11 +85,11 @@ final class AuthDataRepositoryImpl: AuthDataRepository {
 
 private extension AuthDataRepositoryImpl {
     func mapLinkError(_ error: Error) -> Error {
-        if let emailFetchError = error as? EmailFetchError {
-            switch emailFetchError {
-            case .emailNotFound:
+        if let emailError = error as? EmailError {
+            switch emailError {
+            case .notFound:
                 return AuthError.linkEmailNotFound
-            case .emailMismatch:
+            case .mismatch:
                 return AuthError.linkEmailMismatch
             }
         }

--- a/Application/Data/Sources/Repository/AuthenticationRepositoryImpl.swift
+++ b/Application/Data/Sources/Repository/AuthenticationRepositoryImpl.swift
@@ -128,8 +128,8 @@ final class AuthenticationRepositoryImpl: AuthenticationRepository {
 
 private extension AuthenticationRepositoryImpl {
     func mapSignInError(_ error: Error) -> Error {
-        if let emailFetchError = error as? EmailFetchError,
-           emailFetchError == .emailNotFound {
+        if let emailError = error as? EmailError,
+           emailError == .notFound {
             return AuthError.emailNotFound
         }
 

--- a/Application/Data/Sources/Repository/PushNotificationRepositoryImpl.swift
+++ b/Application/Data/Sources/Repository/PushNotificationRepositoryImpl.swift
@@ -208,7 +208,7 @@ private extension PushNotificationRepositoryImpl {
         }) {
             todoCategory = .user(userTodoCategory)
         } else {
-            throw DataError.invalidData("PushNotificationResponse.todoCategory is invalid: \(id)")
+            throw DataLayerError.invalidData("PushNotificationResponse.todoCategory is invalid: \(id)")
         }
 
         return PushNotificationResponse(

--- a/Application/Data/Sources/Repository/TodoRepositoryImpl.swift
+++ b/Application/Data/Sources/Repository/TodoRepositoryImpl.swift
@@ -115,7 +115,7 @@ final class TodoRepositoryImpl: TodoRepository {
             return try responses.reduce(into: [Int: TodoReference]()) { partialResult, pair in
                 let response = try resolve(pair.value, userTodoCategories: userTodoCategories)
                 guard case let .decoded(category) = response.category else {
-                    throw DataError.invalidData("TodoReferenceResponse.category must be resolved before use")
+                    throw DataLayerError.invalidData("TodoReferenceResponse.category must be resolved before use")
                 }
 
                 partialResult[pair.key] = TodoReference(
@@ -208,7 +208,7 @@ private extension TodoRepositoryImpl {
         }) {
             category = .user(userTodoCategory)
         } else {
-            throw DataError.invalidData("TodoResponse.category is invalid: \(id)")
+            throw DataLayerError.invalidData("TodoResponse.category is invalid: \(id)")
         }
 
         return TodoResponse(
@@ -249,7 +249,7 @@ private extension TodoRepositoryImpl {
         }) {
             category = .user(userTodoCategory)
         } else {
-            throw DataError.invalidData("TodoReferenceResponse.category is invalid: \(categoryId)")
+            throw DataLayerError.invalidData("TodoReferenceResponse.category is invalid: \(categoryId)")
         }
 
         return TodoReferenceResponse(

--- a/Application/Domain/Sources/Entity/AuthError.swift
+++ b/Application/Domain/Sources/Entity/AuthError.swift
@@ -12,5 +12,6 @@ public enum AuthError: Error {
     case linkEmailNotFound
     case linkEmailMismatch
     case linkCredentialAlreadyInUse
+    case githubEmailConflict
     case unsupportedProvider
 }

--- a/Application/Domain/Sources/Entity/DomainLayerError.swift
+++ b/Application/Domain/Sources/Entity/DomainLayerError.swift
@@ -1,0 +1,10 @@
+//
+//  DomainLayerError.swift
+//  Domain
+//
+//  Created by opfic on 7/10/26.
+//
+
+public enum DomainLayerError: Error {
+    case invalidData(context: String)
+}

--- a/Application/Infra/Sources/Service/FunctionAPIClient.swift
+++ b/Application/Infra/Sources/Service/FunctionAPIClient.swift
@@ -128,6 +128,8 @@ private struct FunctionAPIServerErrorDecoder: NXServerErrorDecoder {
             return EmailError.notFound
         case EmailError.mismatch.code:
             return EmailError.mismatch
+        case EmailError.githubEmailConflict.code:
+            return EmailError.githubEmailConflict
         default:
             return nil
         }

--- a/Application/Infra/Sources/Service/FunctionAPIClient.swift
+++ b/Application/Infra/Sources/Service/FunctionAPIClient.swift
@@ -124,10 +124,10 @@ private struct FunctionAPIServerErrorDecoder: NXServerErrorDecoder {
         ) else { return nil }
 
         switch body.code {
-        case EmailFetchError.emailNotFound.code:
-            return EmailFetchError.emailNotFound
-        case EmailFetchError.emailMismatch.code:
-            return EmailFetchError.emailMismatch
+        case EmailError.notFound.code:
+            return EmailError.notFound
+        case EmailError.mismatch.code:
+            return EmailError.mismatch
         default:
             return nil
         }
@@ -145,7 +145,7 @@ private actor FirebaseAuthTokenProvider: NXAuthTokenProvider {
 }
 
 extension Error {
-    var apiEmailFetchError: EmailFetchError? {
+    var apiEmailError: EmailError? {
         guard let error = self as? NXError,
               case let .server(
             statusCode: _,
@@ -153,6 +153,6 @@ extension Error {
             underlying: underlying
         ) = error else { return nil }
 
-        return underlying as? EmailFetchError
+        return underlying as? EmailError
     }
 }

--- a/Application/Infra/Sources/Service/FunctionAPIClient.swift
+++ b/Application/Infra/Sources/Service/FunctionAPIClient.swift
@@ -112,6 +112,12 @@ private struct FunctionAPIErrorBody: Decodable {
     let message: String?
 }
 
+private enum FunctionAPIErrorCode: String {
+    case emailNotFound = "email-not-found"
+    case emailMismatch = "email-mismatch"
+    case githubEmailConflict = "github-email-changed-account-conflict"
+}
+
 private struct FunctionAPIServerErrorDecoder: NXServerErrorDecoder {
     func decodeServerError(
         data: Data,
@@ -121,17 +127,15 @@ private struct FunctionAPIServerErrorDecoder: NXServerErrorDecoder {
         guard let body = try? decoder.decode(
             FunctionAPIErrorBody.self,
             from: data
-        ) else { return nil }
+        ), let code = FunctionAPIErrorCode(rawValue: body.code) else { return nil }
 
-        switch body.code {
-        case EmailError.notFound.code:
+        switch code {
+        case .emailNotFound:
             return EmailError.notFound
-        case EmailError.mismatch.code:
+        case .emailMismatch:
             return EmailError.mismatch
-        case EmailError.githubEmailConflict.code:
+        case .githubEmailConflict:
             return EmailError.githubEmailConflict
-        default:
-            return nil
         }
     }
 }

--- a/Application/Infra/Sources/Service/FunctionAPIEndpoint.swift
+++ b/Application/Infra/Sources/Service/FunctionAPIEndpoint.swift
@@ -42,6 +42,7 @@ extension FunctionAPIEndpoint where Response == FunctionAPIResponse {
     static let requestAppleCustomToken = Self(method: .post, path: "/auth/apple/custom-token")
     static let refreshAppleAccessToken = Self(method: .post, path: "/auth/apple/access-token")
     static let requestAppleRefreshToken = Self(method: .post, path: "/auth/apple/refresh-token")
+    static let linkGithubProvider = Self(method: .post, path: "/auth/github/link")
     static let requestGithubTokens = Self(method: .post, path: "/auth/github/tokens")
 }
 

--- a/Application/Infra/Sources/Service/SocialLogin/AppleAuthenticationServiceImpl.swift
+++ b/Application/Infra/Sources/Service/SocialLogin/AppleAuthenticationServiceImpl.swift
@@ -150,12 +150,12 @@ final class AppleAuthenticationServiceImpl: AuthenticationService {
 
             guard let appleEmail = credential.email else {
                 try await revokeAppleAccessToken(token: refreshToken)
-                throw EmailFetchError.emailNotFound
+                throw EmailError.notFound
             }
 
             if appleEmail != email {
                 try await revokeAppleAccessToken(token: refreshToken)
-                throw EmailFetchError.emailMismatch
+                throw EmailError.mismatch
             }
 
             let appleCredential = OAuthProvider.credential(

--- a/Application/Infra/Sources/Service/SocialLogin/GithubAuthenticationServiceImpl.swift
+++ b/Application/Infra/Sources/Service/SocialLogin/GithubAuthenticationServiceImpl.swift
@@ -135,13 +135,13 @@ final class GithubAuthenticationServiceImpl: NSObject, AuthenticationService {
             guard let githubEmail = githubUser.email else {
                 logger.error("GitHub email not found")
                 try await revokeAccessToken(accessToken: accessToken)
-                throw EmailFetchError.emailNotFound
+                throw EmailError.notFound
             }
 
             if githubEmail != email {
                 logger.error("Email mismatch - Expected: \(email), Got: \(githubEmail)")
                 try await revokeAccessToken(accessToken: accessToken)
-                throw EmailFetchError.emailMismatch
+                throw EmailError.mismatch
             }
 
             try await tokensRef.setData(["githubAccessToken": accessToken], merge: true)
@@ -310,8 +310,8 @@ final class GithubAuthenticationServiceImpl: NSObject, AuthenticationService {
     }
 
     private func mapRequestTokensError(_ error: Error) -> Error {
-        if let emailFetchError = error.apiEmailFetchError {
-            return emailFetchError
+        if let emailError = error.apiEmailError {
+            return emailError
         }
 
         return error

--- a/Application/Infra/Sources/Service/SocialLogin/GithubAuthenticationServiceImpl.swift
+++ b/Application/Infra/Sources/Service/SocialLogin/GithubAuthenticationServiceImpl.swift
@@ -122,32 +122,16 @@ final class GithubAuthenticationServiceImpl: NSObject, AuthenticationService {
         }
     }
 
-    func link(uid: String, email: String) async throws -> Bool {
+    func link(uid: String, email _: String) async throws -> Bool {
         logger.info("Linking GitHub account for user: \(uid)")
         
         do {
             let tokensRef = store.document(FirestorePath.userData(uid, document: .tokens))
             let authorizationCode = try await requestAuthorizationCode()
-            let (accessToken, _) = try await requestTokens(authorizationCode: authorizationCode)
-
-            let githubUser = try await requestUserProfile(accessToken: accessToken)
-
-            guard let githubEmail = githubUser.email else {
-                logger.error("GitHub email not found")
-                try await revokeAccessToken(accessToken: accessToken)
-                throw EmailError.notFound
-            }
-
-            if githubEmail != email {
-                logger.error("Email mismatch - Expected: \(email), Got: \(githubEmail)")
-                try await revokeAccessToken(accessToken: accessToken)
-                throw EmailError.mismatch
-            }
+            let accessToken = try await requestProviderLink(authorizationCode: authorizationCode)
 
             try await tokensRef.setData(["githubAccessToken": accessToken], merge: true)
-
-            let credential = OAuthProvider.credential(providerID: providerID, accessToken: accessToken)
-            try await user?.link(with: credential)
+            try await user?.reload()
             
             logger.info("Successfully linked GitHub account")
             return true
@@ -257,7 +241,24 @@ final class GithubAuthenticationServiceImpl: NSObject, AuthenticationService {
             }
             throw TokenError.invalidResponse
         } catch {
-            throw mapRequestTokensError(error)
+            throw mapAPIEmailError(error)
+        }
+    }
+
+    private func requestProviderLink(authorizationCode: String) async throws -> String {
+        do {
+            let response = try await FunctionAPIClient.shared.send(
+                .linkGithubProvider,
+                payload: ["code": authorizationCode],
+                requiresAuthentication: true
+            )
+
+            guard let accessToken = response.accessToken else {
+                throw TokenError.invalidResponse
+            }
+            return accessToken
+        } catch {
+            throw mapAPIEmailError(error)
         }
     }
     
@@ -309,7 +310,7 @@ final class GithubAuthenticationServiceImpl: NSObject, AuthenticationService {
         return gitHubEmails.first(where: { $0.verified })?.email
     }
 
-    private func mapRequestTokensError(_ error: Error) -> Error {
+    private func mapAPIEmailError(_ error: Error) -> Error {
         if let emailError = error.apiEmailError {
             return emailError
         }

--- a/Application/Infra/Sources/Service/SocialLogin/GoogleAuthenticationServiceImpl.swift
+++ b/Application/Infra/Sources/Service/SocialLogin/GoogleAuthenticationServiceImpl.swift
@@ -123,11 +123,11 @@ final class GoogleAuthenticationServiceImpl: AuthenticationService {
             let signIn = try await GIDSignIn.sharedInstance.signIn(withPresenting: topViewController)
 
             guard let googleEmail = signIn.user.profile?.email else {
-                throw EmailFetchError.emailNotFound
+                throw EmailError.notFound
             }
 
             if googleEmail != email {
-                throw EmailFetchError.emailMismatch
+                throw EmailError.mismatch
             }
 
             guard let idToken = signIn.user.idToken?.tokenString else {

--- a/Application/Infra/Tests/Service/FunctionAPIEndpointTests.swift
+++ b/Application/Infra/Tests/Service/FunctionAPIEndpointTests.swift
@@ -1,0 +1,19 @@
+//
+//  FunctionAPIEndpointTests.swift
+//  InfraTests
+//
+//  Created by opfic on 7/10/26.
+//
+
+import Testing
+@testable import Infra
+
+struct FunctionAPIEndpointTests {
+    @Test("GitHub provider 연결 endpoint는 인증 link 경로를 사용한다")
+    func 깃허브_provider_연결_endpoint는_인증_link_경로를_사용한다() {
+        let endpoint = FunctionAPIEndpoint<FunctionAPIResponse>.linkGithubProvider
+
+        #expect(endpoint.method.rawValue == "POST")
+        #expect(endpoint.path == "/auth/github/link")
+    }
+}

--- a/Application/Presentation/ProfileTab/Sources/Settings/AccountFeature.swift
+++ b/Application/Presentation/ProfileTab/Sources/Settings/AccountFeature.swift
@@ -39,6 +39,7 @@ struct AccountFeature {
         case linkEmailNotFound
         case linkEmailMismatch
         case linkCredentialAlreadyInUse
+        case githubEmailConflict
         case error
     }
 
@@ -201,6 +202,8 @@ private extension AccountFeature {
             return .linkEmailMismatch
         case .linkCredentialAlreadyInUse:
             return .linkCredentialAlreadyInUse
+        case .githubEmailConflict:
+            return .githubEmailConflict
         case .notAuthenticated, .failedToUnlinkLastProvider, .emailNotFound, .unsupportedProvider:
             return .error
         }
@@ -220,6 +223,9 @@ private extension AccountFeature {
         case .linkCredentialAlreadyInUse:
             title = String(localized: "account_alert_already_linked_title")
             message = String(localized: "account_alert_already_linked_message")
+        case .githubEmailConflict:
+            title = String(localized: "account_alert_github_email_conflict_title")
+            message = String(localized: "account_alert_github_email_conflict_message")
         case .error:
             title = String(localized: "common_error_title")
             message = String(localized: "common_error_message")

--- a/Application/Presentation/ProfileTab/Tests/Settings/AccountFeatureTests.swift
+++ b/Application/Presentation/ProfileTab/Tests/Settings/AccountFeatureTests.swift
@@ -173,6 +173,11 @@ struct AccountFeatureTests {
                 message: String(localized: "account_alert_already_linked_message")
             ),
             AccountLinkFailureScenario(
+                error: AuthError.githubEmailChangedAccountConflict,
+                title: String(localized: "account_alert_github_email_conflict_title"),
+                message: String(localized: "account_alert_github_email_conflict_message")
+            ),
+            AccountLinkFailureScenario(
                 error: AccountTestError.failure,
                 title: String(localized: "common_error_title"),
                 message: String(localized: "common_error_message")

--- a/Application/Presentation/ProfileTab/Tests/Settings/AccountFeatureTests.swift
+++ b/Application/Presentation/ProfileTab/Tests/Settings/AccountFeatureTests.swift
@@ -173,7 +173,7 @@ struct AccountFeatureTests {
                 message: String(localized: "account_alert_already_linked_message")
             ),
             AccountLinkFailureScenario(
-                error: AuthError.githubEmailChangedAccountConflict,
+                error: AuthError.githubEmailConflict,
                 title: String(localized: "account_alert_github_email_conflict_title"),
                 message: String(localized: "account_alert_github_email_conflict_message")
             ),


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
## 🔗 연관된 이슈
- closed #712

## 🎯 의도
GitHub 이메일 변경으로 발생하는 provider 연결 충돌을 일반 가입 충돌과 분리하고, 기존 데이터를 보호하는 전용 안내 흐름 제공

## 📝 작업 내용

### 📌 요약
- GitHub provider 연결 요청을 `/auth/github/link` REST endpoint로 전환
- GitHub 이메일 변경 충돌을 위한 오류 계약과 전용 alert 추가
- Data·Domain·Infra 계층의 오류 타입 및 소유권 정리
- endpoint 경로와 alert 분기 테스트 추가
- AI workflow 모델 위임 및 문서 작성 규칙 보강

### 🔍 상세
- 클라이언트의 Firebase credential 직접 연결을 서버의 GitHub provider link 요청으로 전환
- `github-email-changed-account-conflict`를 `FunctionAPIErrorCode`에서 해석하고 `EmailError.githubEmailConflict`로 변환
- Data와 Domain 매핑을 거쳐 `AuthError.githubEmailConflict`까지 충돌 오류 전달
- 기존 `linkCredentialAlreadyInUse` 안내와 GitHub 이메일 변경 충돌 안내 분리
- 충돌 발생 시 전용 alert 표시와 `닫기` 동작 제공
- 자동 로그아웃, 계정 전환, provider 강제 연결, 데이터 병합 동작 미추가
- `EmailFetchError`를 `EmailError`로 정리하고 `DataError`를 `DataLayerError`로 통합
- `invalidData` 오류의 Domain 소유권을 `DomainLayerError`로 분리
- `FunctionAPIEndpointTests`에서 GitHub provider link 요청의 `POST` method와 경로 검증
- `AccountFeatureTests`에서 `AuthError.githubEmailConflict`의 전용 alert 분기 검증
- `Localizable.xcstrings`에 GitHub 이메일 충돌 안내의 한국어·영어 문구 추가
- `AGENT_ROLES.md`와 `AGENT_WORKFLOWS.md`에 모델 위임 fallback 및 문서 작성 workflow 규칙 추가

## 📸 영상 / 이미지 (Optional)
해당 없음