### PR TITLE
[#716] Codex 역할별 서브에이전트 모델 선택을 구성한다

### DIFF
--- a/.codex/agents/architecture_watcher.toml
+++ b/.codex/agents/architecture_watcher.toml
@@ -1,0 +1,12 @@
+name = "architecture_watcher"
+description = "Read-only DevLog architecture boundary reviewer for module ownership, dependencies, DI, SDK placement, Widget flow, and StorePattern changes."
+model = "gpt-5.3-codex-spark"
+model_reasoning_effort = "medium"
+sandbox_mode = "read-only"
+developer_instructions = """
+Read AGENTS.md and AGENT_ROLES.md before reviewing.
+Act only as the Architecture Watcher defined in AGENT_ROLES.md.
+Inspect the requested architecture scope and relevant manifests without editing files or changing GitHub state.
+Do not run, launch, install, boot, or open the app or Simulator.
+Return exactly the Architecture Watch Result format from AGENT_ROLES.md.
+"""

--- a/.codex/agents/code_reviewer.toml
+++ b/.codex/agents/code_reviewer.toml
@@ -1,0 +1,12 @@
+name = "code_reviewer"
+description = "Read-only DevLog code reviewer focused on correctness, regressions, scope drift, and missing verification."
+model = "gpt-5.3-codex-spark"
+model_reasoning_effort = "medium"
+sandbox_mode = "read-only"
+developer_instructions = """
+Read AGENTS.md and AGENT_ROLES.md before reviewing.
+Act only as the Code Reviewer defined in AGENT_ROLES.md.
+Review the assigned diff without editing files, staging changes, committing, pushing, or changing GitHub state.
+Prioritize correctness, regressions, architecture drift, scope drift, and missing tests over style preferences.
+Return exactly the Code Review Result format from AGENT_ROLES.md with file and line references when possible.
+"""

--- a/.codex/agents/documentation_writer.toml
+++ b/.codex/agents/documentation_writer.toml
@@ -1,0 +1,12 @@
+name = "documentation_writer"
+description = "DevLog documentation writer for PR bodies, issue text, review replies, release notes, and repository documentation changes."
+model = "gpt-5.3-codex-spark"
+model_reasoning_effort = "medium"
+sandbox_mode = "workspace-write"
+developer_instructions = """
+Read AGENTS.md and AGENT_ROLES.md before drafting.
+Act only as the Documentation Writer defined in AGENT_ROLES.md.
+Match repository templates, actual diffs, live issue or PR state, and the requested Korean wording rules.
+Edit only documentation files named in the task packet. Do not edit app code or create GitHub content unless the task packet explicitly authorizes that write action.
+Return exactly the Documentation Result format from AGENT_ROLES.md unless the task packet requests direct Markdown draft output.
+"""

--- a/.codex/agents/github_ci_analyst.toml
+++ b/.codex/agents/github_ci_analyst.toml
@@ -1,0 +1,12 @@
+name = "github_ci_analyst"
+description = "Read-only DevLog GitHub and CI analyst for live issues, PR metadata, review threads, and Actions logs."
+model = "gpt-5.3-codex-spark"
+model_reasoning_effort = "medium"
+sandbox_mode = "read-only"
+developer_instructions = """
+Read AGENTS.md and AGENT_ROLES.md before analysis.
+Act only as the GitHub/CI Analyst defined in AGENT_ROLES.md.
+Use live GitHub state as the source of truth and use thread-aware review inspection when resolution state matters.
+Do not edit files, reply, resolve threads, submit reviews, push, or change GitHub state unless the task packet explicitly authorizes that write action.
+Return exactly the GitHub CI Result format from AGENT_ROLES.md.
+"""

--- a/.codex/agents/verification_runner.toml
+++ b/.codex/agents/verification_runner.toml
@@ -1,0 +1,13 @@
+name = "verification_runner"
+description = "DevLog verification runner for changed-file lint, build-only checks, tests that do not launch the app, and diff validation."
+model = "gpt-5.3-codex-spark"
+model_reasoning_effort = "medium"
+sandbox_mode = "workspace-write"
+developer_instructions = """
+Read AGENTS.md and AGENT_ROLES.md before verification.
+Act only as the Verification Runner defined in AGENT_ROLES.md.
+Do not edit source or documentation files, except through an explicitly assigned formatting command.
+Do not run, launch, install, boot, or open the app or Simulator.
+Run only the checks assigned in the task packet and record exact commands, exit status, and evidence.
+Return exactly the Verification Result format from AGENT_ROLES.md.
+"""

--- a/AGENT_ROLES.md
+++ b/AGENT_ROLES.md
@@ -30,17 +30,19 @@ Use these model tiers when assigning work to another LLM.
 | `Lightweight` | Read-only review, checklist validation, log summarization, documentation draft, first-pass architecture preflight | Best available lightweight coding model that is different from the active `Primary` model |
 | `Fast` | Low-risk text cleanup, simple file presence checks, short summaries | Fastest available coding model that is different from the active `Primary` model |
 
-Default role-to-model assignment:
+Default role-to-model and execution assignment:
 
-| Role | Default tier | Escalate to `Primary` when |
-| --- | --- | --- |
-| Planner | `Primary` | Always for live issues, PR scope, architecture scope, or implementation planning |
-| Implementer | `Primary` | Always for Swift production code, tests, target dependencies, DI, SDK placement, or GitHub writes |
-| Architecture Watcher | `Lightweight` for preflight, `Primary` for final boundary verdict | Any finding is `Block` or `Needs Owner Decision`, or the change touches module dependency, SDK placement, Widget flow, StorePattern, or DI |
-| Code Reviewer | `Lightweight` for first pass, `Primary` for final blocking review | Findings involve runtime behavior, concurrency, data loss, architecture, or test strategy |
-| Verification Runner | `Lightweight` | Verification fails, failure cause is unclear, or a fix is needed |
-| GitHub/CI Analyst | `Lightweight` | CI root cause requires code or workflow changes, or review comments conflict |
-| Documentation Writer | `Lightweight` | Text must explain complex architecture, release risk, or PR scope tradeoffs |
+| Role | Execution owner or custom agent | Default tier | Escalate to `Primary` when |
+| --- | --- | --- | --- |
+| Planner | active main agent | `Primary` | Always for live issues, PR scope, architecture scope, or implementation planning |
+| Implementer | active main agent | `Primary` | Always for Swift production code, tests, target dependencies, DI, SDK placement, or GitHub writes |
+| Architecture Watcher | `architecture_watcher` | `Lightweight` for preflight, `Primary` for final boundary verdict | Any finding is `Block` or `Needs Owner Decision`, or the change touches module dependency, SDK placement, Widget flow, StorePattern, or DI |
+| Code Reviewer | `code_reviewer` | `Lightweight` for first pass, `Primary` for final blocking review | Findings involve runtime behavior, concurrency, data loss, architecture, or test strategy |
+| Verification Runner | `verification_runner` | `Lightweight` | Verification fails, failure cause is unclear, or a fix is needed |
+| GitHub/CI Analyst | `github_ci_analyst` | `Lightweight` | CI root cause requires code or workflow changes, or review comments conflict |
+| Documentation Writer | `documentation_writer` | `Lightweight` | Text must explain complex architecture, release risk, CI root cause, or PR scope tradeoffs |
+
+Project-scoped custom agents live in `.codex/agents/`. Their TOML files pin the concrete model and sandbox for spawned sessions; this table is the canonical role-to-agent routing map.
 
 Do not assign `Lightweight` as the only model for production Swift implementation, target dependency changes, DI assembly, repository/service contract changes, Firebase or SDK placement, Widget data-flow changes, StorePattern responsibility changes, commits, pushes, PR creation, or final integration.
 
@@ -49,10 +51,11 @@ Do not assign `Lightweight` as the only model for production Swift implementatio
 - A model tier assignment is an execution requirement, not a label for work the main agent already performed.
 - `Primary` roles belong to the active main agent and must not be delegated to a sub-agent that uses or inherits the active `Primary` model.
 - Every sub-agent created through this role workflow must use either a `Lightweight` or `Fast` model that is different from the active `Primary` model.
-- When a role is assigned to `Lightweight` or `Fast`, the main agent must explicitly select a model that is different from the active `Primary` model and dispatch the role through a separate model or sub-agent call before using its result.
+- When a role is assigned to `Lightweight` or `Fast`, the main agent must dispatch the configured custom agent from the routing table before using its result.
 - A sub-agent that inherits the active `Primary` model does not satisfy a `Lightweight` or `Fast` assignment.
 - Do not satisfy a `Lightweight` or `Fast` role by completing the role directly in `Primary` and describing it as delegated work.
-- If the assigned model cannot be called because no distinct lightweight model is available or the dispatch tool cannot select a model, stop before dispatch and report which role cannot run.
+- A generic sub-agent spawn that does not load the configured custom agent TOML does not satisfy the role assignment.
+- If the custom agent cannot be loaded, its pinned model is unavailable, or the dispatch surface cannot select that custom agent, stop before dispatch and report which role cannot run.
 - If the assigned model is available but current tool policy requires explicit user permission before dispatch, missing permission is not fallback. Stop and ask for permission before continuing the required role.
 - `Primary` must integrate and verify delegated output, but must not skip the delegated role when the workflow requires it and the assigned model is available.
 
@@ -120,7 +123,7 @@ Use `Architecture risk: possible` when the task touches module boundaries, impor
 
 ## Role activation
 
-Use this template when assigning a `Lightweight` or `Fast` role to another AI model or sub-agent. `Primary` roles do not use this activation template because the active main agent owns them.
+Use this template when assigning a `Lightweight` or `Fast` role through its configured custom agent. `Primary` roles do not use this activation template because the active main agent owns them.
 
 ```md
 You are the `<Role Name>` for the DevLog iOS repository.
@@ -128,6 +131,7 @@ You are the `<Role Name>` for the DevLog iOS repository.
 Read `AGENTS.md` first. Then read `AGENT_ROLES.md` and follow the `<Role Name>` section.
 
 Assigned model tier: `<Lightweight | Fast>`
+Custom agent: `<configured custom agent name>`
 
 Task packet:
 <paste Task Packet here>

--- a/AGENT_ROLES.md
+++ b/AGENT_ROLES.md
@@ -27,8 +27,8 @@ Use these model tiers when assigning work to another LLM.
 | Tier | Use | Default model |
 | --- | --- | --- |
 | `Primary` | Planning, implementation, architecture decisions, final integration, failed-check triage | Strongest available Codex/GPT coding model |
-| `Spark` | Read-only review, checklist validation, log summarization, documentation draft, first-pass architecture preflight | `gpt-5.3-codex-spark` when available |
-| `Fast` | Low-risk text cleanup, simple file presence checks, short summaries | Fastest low-cost model available |
+| `Lightweight` | Read-only review, checklist validation, log summarization, documentation draft, first-pass architecture preflight | Best available lightweight coding model that is different from the active `Primary` model |
+| `Fast` | Low-risk text cleanup, simple file presence checks, short summaries | Fastest available coding model that is different from the active `Primary` model |
 
 Default role-to-model assignment:
 
@@ -36,29 +36,33 @@ Default role-to-model assignment:
 | --- | --- | --- |
 | Planner | `Primary` | Always for live issues, PR scope, architecture scope, or implementation planning |
 | Implementer | `Primary` | Always for Swift production code, tests, target dependencies, DI, SDK placement, or GitHub writes |
-| Architecture Watcher | `Spark` for preflight, `Primary` for final boundary verdict | Any finding is `Block` or `Needs Owner Decision`, or the change touches module dependency, SDK placement, Widget flow, StorePattern, or DI |
-| Code Reviewer | `Spark` for first pass, `Primary` for final blocking review | Findings involve runtime behavior, concurrency, data loss, architecture, or test strategy |
-| Verification Runner | `Spark` | Verification fails, failure cause is unclear, or a fix is needed |
-| GitHub/CI Analyst | `Spark` | CI root cause requires code or workflow changes, or review comments conflict |
-| Documentation Writer | `Spark` | Text must explain complex architecture, release risk, or PR scope tradeoffs |
+| Architecture Watcher | `Lightweight` for preflight, `Primary` for final boundary verdict | Any finding is `Block` or `Needs Owner Decision`, or the change touches module dependency, SDK placement, Widget flow, StorePattern, or DI |
+| Code Reviewer | `Lightweight` for first pass, `Primary` for final blocking review | Findings involve runtime behavior, concurrency, data loss, architecture, or test strategy |
+| Verification Runner | `Lightweight` | Verification fails, failure cause is unclear, or a fix is needed |
+| GitHub/CI Analyst | `Lightweight` | CI root cause requires code or workflow changes, or review comments conflict |
+| Documentation Writer | `Lightweight` | Text must explain complex architecture, release risk, or PR scope tradeoffs |
 
-Do not assign `Spark` as the only model for production Swift implementation, target dependency changes, DI assembly, repository/service contract changes, Firebase or SDK placement, Widget data-flow changes, StorePattern responsibility changes, commits, pushes, PR creation, or final integration.
+Do not assign `Lightweight` as the only model for production Swift implementation, target dependency changes, DI assembly, repository/service contract changes, Firebase or SDK placement, Widget data-flow changes, StorePattern responsibility changes, commits, pushes, PR creation, or final integration.
 
 ### Model dispatch requirements
 
 - A model tier assignment is an execution requirement, not a label for work the main agent already performed.
-- When a role is assigned to `Spark` or `Fast`, and tooling can select that model, the main agent must dispatch that role through a separate model or sub-agent call before using its result.
-- Do not satisfy a `Spark` or `Fast` role by completing the role directly in `Primary` and describing it as delegated work.
-- If the assigned model cannot be called because the model or model-selecting tool is unavailable, apply the fallback policy and report which role was not dispatched to its default tier.
+- `Primary` roles belong to the active main agent and must not be delegated to a sub-agent that uses or inherits the active `Primary` model.
+- Every sub-agent created through this role workflow must use either a `Lightweight` or `Fast` model that is different from the active `Primary` model.
+- When a role is assigned to `Lightweight` or `Fast`, the main agent must explicitly select a model that is different from the active `Primary` model and dispatch the role through a separate model or sub-agent call before using its result.
+- A sub-agent that inherits the active `Primary` model does not satisfy a `Lightweight` or `Fast` assignment.
+- Do not satisfy a `Lightweight` or `Fast` role by completing the role directly in `Primary` and describing it as delegated work.
+- If the assigned model cannot be called because no distinct lightweight model is available or the dispatch tool cannot select a model, stop before dispatch and report which role cannot run.
 - If the assigned model is available but current tool policy requires explicit user permission before dispatch, missing permission is not fallback. Stop and ask for permission before continuing the required role.
 - `Primary` must integrate and verify delegated output, but must not skip the delegated role when the workflow requires it and the assigned model is available.
 
 ### Fallback policy
 
-- If `gpt-5.3-codex-spark` is unavailable, assign `Spark` roles to the fastest available read-only capable coding model.
-- If no reliable read-only model is available, assign the role to `Primary`.
+- Choose the best available role-capable lightweight coding model without hardcoding a provider or model name.
+- If the preferred lightweight model is unavailable, choose another available role-capable model that is still different from the active `Primary` model.
+- If no eligible non-Primary model is available, do not fall back to `Primary`; stop and report the unavailable role.
 - If `Primary` is unavailable, do not perform implementation, architecture verdict, final integration, git write actions, or GitHub write actions.
-- Do not downgrade `Primary` roles to `Spark` or `Fast` only because a cheaper model is available.
+- Do not downgrade `Primary` roles to `Lightweight` or `Fast` only because a cheaper model is available.
 - For user-facing summaries, a lower tier may draft text, but `Primary` must check it when the text depends on architecture decisions, release risk, CI root cause, or exact diff behavior.
 
 ### Escalation rule
@@ -116,14 +120,14 @@ Use `Architecture risk: possible` when the task touches module boundaries, impor
 
 ## Role activation
 
-Use this template when assigning work to another AI model or sub-agent.
+Use this template when assigning a `Lightweight` or `Fast` role to another AI model or sub-agent. `Primary` roles do not use this activation template because the active main agent owns them.
 
 ```md
 You are the `<Role Name>` for the DevLog iOS repository.
 
 Read `AGENTS.md` first. Then read `AGENT_ROLES.md` and follow the `<Role Name>` section.
 
-Assigned model tier: `<Primary | Spark | Fast>`
+Assigned model tier: `<Lightweight | Fast>`
 
 Task packet:
 <paste Task Packet here>

--- a/AGENT_WORKFLOWS.md
+++ b/AGENT_WORKFLOWS.md
@@ -17,7 +17,7 @@ The main agent must run every workflow with this protocol.
 3. Create the task packet.
 4. Assign only the roles required by the selected workflow.
 5. Assign each role a model tier from `AGENT_ROLES.md`.
-6. Keep `Primary` roles with the active main agent, and dispatch every sub-agent as a `Lightweight` or `Fast` role with an explicitly selected model that is different from the active `Primary` model.
+6. Keep `Primary` roles with the active main agent, and dispatch every `Lightweight` or `Fast` role through the custom agent mapped in `AGENT_ROLES.md`.
 7. Dispatch read-only `Lightweight` or `Fast` roles in parallel only when they do not depend on unfinished edits.
 8. Do not complete a required `Lightweight` or `Fast` role directly in `Primary`, including when the dispatch tool would inherit the active `Primary` model.
 9. Keep `Primary` editing roles sequential unless the files and ownership boundaries are disjoint.
@@ -35,7 +35,7 @@ Stop and ask the user before editing when:
 - The task packet conflicts with `AGENTS.md`.
 - The requested fix requires relaxing a layer boundary.
 - A role needs to run, launch, install, boot, or open the app or Simulator.
-- A required `Lightweight` or `Fast` role cannot be dispatched with an explicitly selected non-Primary model, or current tool policy requires user permission that has not been granted.
+- A required `Lightweight` or `Fast` custom agent cannot be loaded or selected, its pinned model is unavailable, or current tool policy requires user permission that has not been granted.
 - The current issue or PR scope is unclear after live GitHub inspection.
 - Two editing roles would touch the same file.
 - A read-only role reports `Block` or `Needs Owner Decision`.
@@ -239,7 +239,7 @@ Use for PR body, issue text, release note, README wording, review reply draft, o
 ### Execution
 
 - Documentation Writer must inspect the actual diff before writing PR or release text.
-- When the Documentation Writer role is required, the main agent must dispatch the draft to an available `Lightweight` model that is different from the active `Primary` model before writing the final response.
+- When the Documentation Writer role is required, the main agent must dispatch the draft through `documentation_writer` before writing the final response.
 - If dispatch requires explicit user permission and it has not been granted, ask before drafting, returning, or posting the Documentation Writer output.
 - `Primary` must review the Documentation Writer output against the template, issue scope, and diff before returning or posting it.
 - Do not write AI workflow documents under `docs/`.
@@ -350,7 +350,7 @@ Include the selected workflow name in the task packet `Source` or `Goal` field s
 - Current owner: repository workflow documentation
 - Architecture risk: none
 - Required roles: Planner, Implementer, Code Reviewer, Verification Runner
-- Model assignment: Planner=Primary, Implementer=Primary, Code Reviewer=Lightweight, Verification Runner=Lightweight
+- Model assignment: Planner=Primary, Implementer=Primary, Code Reviewer=code_reviewer (Lightweight), Verification Runner=verification_runner (Lightweight)
 - Verification: `git diff --check -- AGENTS.md AGENT_ROLES.md AGENT_WORKFLOWS.md README.md`
 - Stop conditions: README `docs/` asset policy changes, Swift/iOS code changes, request to remove architecture harness immediately
 ```
@@ -368,7 +368,7 @@ Include the selected workflow name in the task packet `Source` or `Goal` field s
 - Current owner: <layer and target identified by Planner>
 - Architecture risk: none / possible / confirmed
 - Required roles: GitHub/CI Analyst, Planner, Implementer, Code Reviewer, Verification Runner
-- Model assignment: GitHub/CI Analyst=Lightweight, Planner=Primary, Implementer=Primary, Code Reviewer=Lightweight -> Primary if blocking, Verification Runner=Lightweight
+- Model assignment: GitHub/CI Analyst=github_ci_analyst (Lightweight), Planner=Primary, Implementer=Primary, Code Reviewer=code_reviewer (Lightweight) -> Primary if blocking, Verification Runner=verification_runner (Lightweight)
 - Verification: changed-file SwiftLint for Swift changes, targeted tests or build-only check when applicable
 - Stop conditions: unresolved thread requires owner decision, fix relaxes architecture boundary, two comments conflict, CI failure source is unrelated to review feedback
 ```

--- a/AGENT_WORKFLOWS.md
+++ b/AGENT_WORKFLOWS.md
@@ -17,12 +17,12 @@ The main agent must run every workflow with this protocol.
 3. Create the task packet.
 4. Assign only the roles required by the selected workflow.
 5. Assign each role a model tier from `AGENT_ROLES.md`.
-6. Dispatch each `Spark` or `Fast` role through a separate model or sub-agent call when tooling can select that assigned model.
-7. Dispatch read-only `Spark` or `Fast` roles in parallel only when they do not depend on unfinished edits.
-8. Do not complete a required `Spark` or `Fast` role directly in `Primary` unless the model or model-selecting tool is unavailable and the fallback policy in `AGENT_ROLES.md` applies.
+6. Keep `Primary` roles with the active main agent, and dispatch every sub-agent as a `Lightweight` or `Fast` role with an explicitly selected model that is different from the active `Primary` model.
+7. Dispatch read-only `Lightweight` or `Fast` roles in parallel only when they do not depend on unfinished edits.
+8. Do not complete a required `Lightweight` or `Fast` role directly in `Primary`, including when the dispatch tool would inherit the active `Primary` model.
 9. Keep `Primary` editing roles sequential unless the files and ownership boundaries are disjoint.
 10. Integrate role outputs.
-11. Escalate any `Spark` or `Fast` blocker to a `Primary` model before editing.
+11. Escalate any `Lightweight` or `Fast` blocker to a `Primary` model before editing.
 12. Run completion gates.
 13. Report changed files, architecture decision, verification result, delegated roles, model tiers used, and unresolved decisions.
 
@@ -35,7 +35,7 @@ Stop and ask the user before editing when:
 - The task packet conflicts with `AGENTS.md`.
 - The requested fix requires relaxing a layer boundary.
 - A role needs to run, launch, install, boot, or open the app or Simulator.
-- A required `Spark` or `Fast` role needs a separate model or sub-agent call, but current tool policy requires user permission that has not been granted.
+- A required `Lightweight` or `Fast` role cannot be dispatched with an explicitly selected non-Primary model, or current tool policy requires user permission that has not been granted.
 - The current issue or PR scope is unclear after live GitHub inspection.
 - Two editing roles would touch the same file.
 - A read-only role reports `Block` or `Needs Owner Decision`.
@@ -239,7 +239,7 @@ Use for PR body, issue text, release note, README wording, review reply draft, o
 ### Execution
 
 - Documentation Writer must inspect the actual diff before writing PR or release text.
-- When the Documentation Writer role is required and `Spark` is available, the main agent must dispatch the draft to `gpt-5.3-codex-spark` or the configured `Spark` fallback before writing the final response.
+- When the Documentation Writer role is required, the main agent must dispatch the draft to an available `Lightweight` model that is different from the active `Primary` model before writing the final response.
 - If dispatch requires explicit user permission and it has not been granted, ask before drafting, returning, or posting the Documentation Writer output.
 - `Primary` must review the Documentation Writer output against the template, issue scope, and diff before returning or posting it.
 - Do not write AI workflow documents under `docs/`.
@@ -350,7 +350,7 @@ Include the selected workflow name in the task packet `Source` or `Goal` field s
 - Current owner: repository workflow documentation
 - Architecture risk: none
 - Required roles: Planner, Implementer, Code Reviewer, Verification Runner
-- Model assignment: Planner=Primary, Implementer=Primary, Code Reviewer=Spark, Verification Runner=Spark
+- Model assignment: Planner=Primary, Implementer=Primary, Code Reviewer=Lightweight, Verification Runner=Lightweight
 - Verification: `git diff --check -- AGENTS.md AGENT_ROLES.md AGENT_WORKFLOWS.md README.md`
 - Stop conditions: README `docs/` asset policy changes, Swift/iOS code changes, request to remove architecture harness immediately
 ```
@@ -368,7 +368,7 @@ Include the selected workflow name in the task packet `Source` or `Goal` field s
 - Current owner: <layer and target identified by Planner>
 - Architecture risk: none / possible / confirmed
 - Required roles: GitHub/CI Analyst, Planner, Implementer, Code Reviewer, Verification Runner
-- Model assignment: GitHub/CI Analyst=Spark, Planner=Primary, Implementer=Primary, Code Reviewer=Spark -> Primary if blocking, Verification Runner=Spark
+- Model assignment: GitHub/CI Analyst=Lightweight, Planner=Primary, Implementer=Primary, Code Reviewer=Lightweight -> Primary if blocking, Verification Runner=Lightweight
 - Verification: changed-file SwiftLint for Swift changes, targeted tests or build-only check when applicable
 - Stop conditions: unresolved thread requires owner decision, fix relaxes architecture boundary, two comments conflict, CI failure source is unrelated to review feedback
 ```

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ flowchart LR
 		Integrator["Final Integration"]
 	end
 
-	subgraph Spark["gpt-5.3-codex-spark"]
+	subgraph Lightweight["gpt-5.3-codex-spark"]
 		ArchitectureWatcher["Architecture Watcher"]
 		CodeReviewer["Code Reviewer"]
 		VerificationRunner["Verification Runner"]
@@ -296,8 +296,8 @@ flowchart LR
 | --- | --- | --- | --- |
 | Planner | Primary | 이슈, 요청, 변경 범위, role routing 정리 | Implementer / Architecture Watcher |
 | Implementer | Primary | task packet 기준 코드 또는 문서 수정 | Code Reviewer |
-| Architecture Watcher | Spark -> Primary | layer, target, dependency, SDK placement, Widget/StorePattern 경계 감시 | Implementer / Final Integration |
-| Code Reviewer | Spark -> Primary | diff 기준 버그, 회귀, 테스트 누락, scope drift 검토 | Verification Runner |
+| Architecture Watcher | Lightweight -> Primary | layer, target, dependency, SDK placement, Widget/StorePattern 경계 감시 | Implementer / Final Integration |
+| Code Reviewer | Lightweight -> Primary | diff 기준 버그, 회귀, 테스트 누락, scope drift 검토 | Verification Runner |
 | Verification Runner | gpt-5.3-codex-spark | SwiftLint, test, build-only, docs check 결과 기록 | Final Integration |
 | GitHub/CI Analyst | gpt-5.3-codex-spark | issue, PR thread, review comment, workflow run, CI log 분석 | Planner |
 | Documentation Writer | gpt-5.3-codex-spark | PR 본문, release note, README, issue/comment 문안 작성 | Final Integration |


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #716

## 🎯 의도

- 역할별 모델 등급과 실제 실행 설정을 분리하고 서브에이전트가 `Primary`와 다른 모델로 실행되도록 역할 선택 및 중단 조건 명확화

## 📝 작업 내용

### 📌 요약

- 기존 `Spark` 모델 등급을 `Lightweight`로 변경
- 역할별 custom agent 및 실행 설정을 `.codex/agents`에 추가
- custom agent 선택 불가 시 `Primary`로 대체하지 않도록 실행 규칙 강화

### 🔍 상세

- `AGENT_ROLES.md`에 역할별 custom agent 연결, 모델 선택 조건, 대체 및 상향 검토 규칙 반영
- `AGENT_WORKFLOWS.md`의 실행 절차와 예시를 역할별 custom agent 호출 방식에 맞게 수정
- `architecture_watcher`, `code_reviewer`, `documentation_writer`, `github_ci_analyst`, `verification_runner`에 실행 모델, 추론 수준, sandbox 권한 및 역할 지침 지정
- `git diff --check origin/develop...HEAD` 통과
- `.codex/agents` TOML 5개 구문 검증 통과
- Swift 및 iOS 프로젝트 파일 변경이 없어 앱 빌드 생략

## 📸 영상 / 이미지 (Optional)
