### PR TITLE
[#722] Xcode 직접 빌드에서는 Crashlytics를 비활성화하고 배포 빌드에서만 활성화한다

### DIFF
--- a/.github/workflows/appstore.yml
+++ b/.github/workflows/appstore.yml
@@ -109,6 +109,8 @@ jobs:
 
           google_service_info_path="Application/App/Sources/Resource/GoogleService-Info.plist"
           dsym_zip_path="$(find fastlane/appstore_build -maxdepth 1 -name '*.dSYM.zip' -print -quit)"
+          dsym_manifest_path="fastlane/appstore_build/dsym-uuids.txt"
+          dsym_extract_path="$RUNNER_TEMP/appstore-dsym"
           upload_symbols_path="$(find "$HOME/Library/Developer/Xcode/DerivedData" "$HOME/Library/Developer/Xcode/SourcePackages" "$GITHUB_WORKSPACE" -path '*/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/upload-symbols' -type f -print -quit 2>/dev/null || true)"
 
           if [ ! -f "$google_service_info_path" ]; then
@@ -123,6 +125,18 @@ jobs:
 
           if [ -z "$upload_symbols_path" ]; then
             echo "Missing Firebase Crashlytics upload-symbols script" >&2
+            exit 1
+          fi
+
+          mkdir -p "$dsym_extract_path"
+          unzip -q "$dsym_zip_path" -d "$dsym_extract_path"
+
+          while IFS= read -r dsym_path; do
+            dwarfdump --uuid "$dsym_path"
+          done < <(find "$dsym_extract_path" -type d -name '*.dSYM' | sort) | tee "$dsym_manifest_path"
+
+          if [ ! -s "$dsym_manifest_path" ]; then
+            echo "Missing dSYM UUID manifest at $dsym_manifest_path" >&2
             exit 1
           fi
 
@@ -141,7 +155,9 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: appstore-dsym
-          path: fastlane/appstore_build/*.dSYM.zip
+          path: |
+            fastlane/appstore_build/*.dSYM.zip
+            fastlane/appstore_build/dsym-uuids.txt
           if-no-files-found: warn
 
       - name: Skip App Store Upload

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -110,6 +110,8 @@ jobs:
 
           google_service_info_path="Application/App/Sources/Resource/GoogleService-Info.plist"
           dsym_zip_path="$(find fastlane/testflight_build -maxdepth 1 -name '*.dSYM.zip' -print -quit)"
+          dsym_manifest_path="fastlane/testflight_build/dsym-uuids.txt"
+          dsym_extract_path="$RUNNER_TEMP/testflight-dsym"
           upload_symbols_path="$(find "$HOME/Library/Developer/Xcode/DerivedData" "$HOME/Library/Developer/Xcode/SourcePackages" "$GITHUB_WORKSPACE" -path '*/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/upload-symbols' -type f -print -quit 2>/dev/null || true)"
 
           if [ ! -f "$google_service_info_path" ]; then
@@ -124,6 +126,18 @@ jobs:
 
           if [ -z "$upload_symbols_path" ]; then
             echo "Missing Firebase Crashlytics upload-symbols script" >&2
+            exit 1
+          fi
+
+          mkdir -p "$dsym_extract_path"
+          unzip -q "$dsym_zip_path" -d "$dsym_extract_path"
+
+          while IFS= read -r dsym_path; do
+            dwarfdump --uuid "$dsym_path"
+          done < <(find "$dsym_extract_path" -type d -name '*.dSYM' | sort) | tee "$dsym_manifest_path"
+
+          if [ ! -s "$dsym_manifest_path" ]; then
+            echo "Missing dSYM UUID manifest at $dsym_manifest_path" >&2
             exit 1
           fi
 
@@ -142,7 +156,9 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: testflight-dsym
-          path: fastlane/testflight_build/*.dSYM.zip
+          path: |
+            fastlane/testflight_build/*.dSYM.zip
+            fastlane/testflight_build/dsym-uuids.txt
           if-no-files-found: warn
 
       - name: Skip TestFlight Upload

--- a/Application/App/Project.swift
+++ b/Application/App/Project.swift
@@ -46,26 +46,23 @@ let project = Project(
                 base: [
                     "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
                     "CODE_SIGN_STYLE": "Automatic",
+                    "CRASHLYTICS_COLLECTION_ENABLED": "0",
                     "ENABLE_USER_SCRIPT_SANDBOXING": "NO",
+                    "INFOPLIST_PREPROCESS": "YES",
+                    "INFOPLIST_PREPROCESSOR_DEFINITIONS": "$(inherited) CRASHLYTICS_COLLECTION_ENABLED=$(CRASHLYTICS_COLLECTION_ENABLED)",
                     "PRODUCT_MODULE_NAME": "App",
                 ],
                 debug: [
                     "APS_ENVIRONMENT": "development",
-                    "DEBUG_INFORMATION_FORMAT": "dwarf",
                     "FIRESTORE_DATABASE_ID": "staging",
-                    "INFOPLIST_KEY_FirebaseCrashlyticsCollectionEnabled": "NO",
                 ],
                 staging: [
                     "APS_ENVIRONMENT": "production",
-                    "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
                     "FIRESTORE_DATABASE_ID": "staging",
-                    "INFOPLIST_KEY_FirebaseCrashlyticsCollectionEnabled": "YES",
                 ],
                 release: [
                     "APS_ENVIRONMENT": "production",
-                    "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
                     "FIRESTORE_DATABASE_ID": "prod",
-                    "INFOPLIST_KEY_FirebaseCrashlyticsCollectionEnabled": "YES",
                 ]
             )
         ),

--- a/Application/App/Sources/Resource/Info.plist
+++ b/Application/App/Sources/Resource/Info.plist
@@ -38,6 +38,12 @@
 	<false/>
 	<key>FirebaseAutomaticScreenReportingEnabled</key>
 	<false/>
+	<key>FirebaseCrashlyticsCollectionEnabled</key>
+#if CRASHLYTICS_COLLECTION_ENABLED
+	<true/>
+#else
+	<false/>
+#endif
 	<key>FIRESTORE_DATABASE_ID</key>
 	<string>$(FIRESTORE_DATABASE_ID)</string>
 	<key>FUNCTION_API_BASE_URL</key>

--- a/Application/Infra/Sources/Service/FirebaseAppServiceImpl.swift
+++ b/Application/Infra/Sources/Service/FirebaseAppServiceImpl.swift
@@ -6,7 +6,6 @@
 //
 
 import Data
-import FirebaseCrashlytics
 import FirebaseCore
 
 final class FirebaseAppServiceImpl: FirebaseAppService {
@@ -16,15 +15,6 @@ final class FirebaseAppServiceImpl: FirebaseAppService {
         guard !Self.isConfigured else { return }
 
         FirebaseApp.configure()
-        enableCrashlyticsCollectionIfNeeded()
         Self.isConfigured = true
-    }
-}
-
-private extension FirebaseAppServiceImpl {
-    func enableCrashlyticsCollectionIfNeeded() {
-        #if !DEBUG
-        Crashlytics.crashlytics().setCrashlyticsCollectionEnabled(true)
-        #endif
     }
 }

--- a/Application/Presentation/Project.swift
+++ b/Application/Presentation/Project.swift
@@ -10,15 +10,6 @@ let frameworkBuildSettings = Settings.devlog(
     base: [
         "ENABLE_USER_SCRIPT_SANDBOXING": "NO",
         "OTHER_LIBTOOLFLAGS": "$(inherited) -no_warning_for_no_symbols"
-    ],
-    debug: [
-        "DEBUG_INFORMATION_FORMAT": "dwarf"
-    ],
-    staging: [
-        "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym"
-    ],
-    release: [
-        "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym"
     ]
 )
 

--- a/Tuist/ProjectDescriptionHelpers/Project+Settings.swift
+++ b/Tuist/ProjectDescriptionHelpers/Project+Settings.swift
@@ -15,6 +15,7 @@ public extension Settings {
     ) -> Settings {
         var commonBase: SettingsDictionary = [
             "CURRENT_PROJECT_VERSION": "1",
+            "DEBUG_INFORMATION_FORMAT": "dwarf",
             "INFOPLIST_KEY_CFBundleShortVersionString": "$(MARKETING_VERSION)",
             "INFOPLIST_KEY_CFBundleVersion": "$(CURRENT_PROJECT_VERSION)",
             "SWIFT_VERSION": "5.0",

--- a/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
+++ b/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
@@ -30,15 +30,6 @@ public extension Project {
                     versionXcconfigPath: versionXcconfigPath,
                     base: [
                         "ENABLE_USER_SCRIPT_SANDBOXING": "NO",
-                    ],
-                    debug: [
-                        "DEBUG_INFORMATION_FORMAT": "dwarf",
-                    ],
-                    staging: [
-                        "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
-                    ],
-                    release: [
-                        "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
                     ]
                 )
             ),

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -142,6 +142,19 @@ platform :ios do
       end
 
       UI.message("Verified FUNCTION_API_BASE_URL=#{actual_function_api_base_url}")
+
+      actual_crashlytics_collection_enabled = sh(
+        "/usr/libexec/PlistBuddy -c 'Print :FirebaseCrashlyticsCollectionEnabled' #{Shellwords.escape(plist_path)}",
+        log: false
+      ).strip
+
+      if actual_crashlytics_collection_enabled != "true"
+        UI.user_error!(
+          "Unexpected FirebaseCrashlyticsCollectionEnabled: expected true, got #{actual_crashlytics_collection_enabled}"
+        )
+      end
+
+      UI.message("Verified FirebaseCrashlyticsCollectionEnabled=#{actual_crashlytics_collection_enabled}")
     end
   end
 
@@ -240,7 +253,7 @@ platform :ios do
       output_directory: output_directory,
       output_name: "#{APP_PRODUCT_NAME}.ipa",
       include_symbols: true,
-      xcargs: "-skipPackagePluginValidation -skipMacroValidation"
+      xcargs: "CRASHLYTICS_COLLECTION_ENABLED=1 DEBUG_INFORMATION_FORMAT=dwarf-with-dsym -skipPackagePluginValidation -skipMacroValidation"
     )
 
     ipa_output_path = lane_context[SharedValues::IPA_OUTPUT_PATH].to_s


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #722

## 🎯 의도

- Xcode 직접 빌드 UUID가 Crashlytics dSYM 누락 대상으로 등록되는 문제 해결
- TestFlight와 App Store 배포본에서만 Crashlytics 수집 및 dSYM 생성 활성화
- 배포 dSYM UUID 추적 수단 마련

## 📝 작업 내용

### 📌 요약

- Xcode 직접 빌드의 Crashlytics 기본 비활성화
- Fastlane 배포 빌드의 Crashlytics 및 dSYM 활성화
- TestFlight와 App Store dSYM UUID 목록 아티팩트 보존

### 🔍 상세

- 파일 기반 `Info.plist`에 `FirebaseCrashlyticsCollectionEnabled` Boolean 값 추가
- `CRASHLYTICS_COLLECTION_ENABLED` 전처리 값에 따른 수집 여부 분리
- Xcode `Debug`, `Staging`, `Release`의 기본값을 `0`과 `dwarf`로 통일
- `FirebaseAppServiceImpl`의 `setCrashlyticsCollectionEnabled(true)` 호출 제거
- Fastlane `build_for_store`에서 `CRASHLYTICS_COLLECTION_ENABLED=1`과 `dwarf-with-dsym` 주입
- 배포 IPA의 `FirebaseCrashlyticsCollectionEnabled=true` 검증 추가
- TestFlight와 App Store workflow의 `dsym-uuids.txt` 생성 및 아티팩트 보존 추가

### ✅ 검증

- Tuist workspace 생성 성공
- Xcode 기본 `Staging` build 성공
- 로컬 빌드 `FirebaseCrashlyticsCollectionEnabled=false` 확인
- 로컬 빌드 dSYM 0개 확인
- 배포 설정 build 성공
- 배포 빌드 `FirebaseCrashlyticsCollectionEnabled=true` 확인
- 배포 빌드 dSYM 10개 확인
- dSYM UUID manifest 생성 확인
- `Fastfile` 및 workflow YAML 문법 확인

## 📸 영상 / 이미지 (Optional)

- 없음