### PR TITLE
[#719] Apple 네이티브 인증을 유지하고 프로필 책임을 서버로 이전한다

### DIFF
--- a/Application/Infra/Sources/Service/FunctionAPIClient.swift
+++ b/Application/Infra/Sources/Service/FunctionAPIClient.swift
@@ -124,6 +124,7 @@ struct FirebaseCustomTokenResponse: Decodable {
 struct AppleCustomTokenRequest: Encodable {
     let challengeId: String
     let authorizationCode: String
+    let displayName: String?
 }
 
 struct AppleAccountLinkRequest: Encodable {

--- a/Application/Infra/Sources/Service/SocialLogin/AppleAuthenticationServiceImpl.swift
+++ b/Application/Infra/Sources/Service/SocialLogin/AppleAuthenticationServiceImpl.swift
@@ -42,38 +42,18 @@ final class AppleAuthenticationServiceImpl: AuthenticationService {
             let response = try await authenticateWithAppleAsync(
                 hashedNonce: challenge.hashedNonce
             )
-                    
+
+            let displayName = Self.makeDisplayName(from: response.fullName)
+
             logger.debug("Requesting custom token from Firebase Function")
             let customToken = try await requestAppleCustomToken(
                 challengeId: challenge.challengeId,
-                authorizationCode: response.authorizationCode
+                authorizationCode: response.authorizationCode,
+                displayName: displayName
             )
-            
+
             logger.debug("Signing in with custom token")
             let result = try await Auth.auth().signIn(withCustomToken: customToken)
-        
-            let changeRequest = result.user.createProfileChangeRequest()
-            var displayName: String?
-
-            if let fullName = response.fullName {
-                let formatter = PersonNameComponentsFormatter()
-                formatter.style = .long
-                let formattedName = formatter.string(from: fullName)
-                if !formattedName.isEmpty {
-                    displayName = formattedName
-                }
-            }
-
-            if displayName == nil {
-                let doc = try await store
-                    .document(FirestorePath.userData(result.user.uid, document: .info))
-                    .getDocument()
-                displayName = doc.data()?["appleName"] as? String
-            }
-
-            changeRequest.displayName = displayName ?? ""
-            changeRequest.photoURL = nil //  Apple ID 프로필 사진 URL은 제공되지 않음
-            try await changeRequest.commitChanges()
 
             logger.info("Successfully signed in with Apple")
             return result.user.makeResponse(providerID: .apple)
@@ -200,6 +180,15 @@ final class AppleAuthenticationServiceImpl: AuthenticationService {
         return request
     }
 
+    static func makeDisplayName(from fullName: PersonNameComponents?) -> String? {
+        guard let fullName else { return nil }
+
+        let formatter = PersonNameComponentsFormatter()
+        formatter.style = .long
+        let displayName = formatter.string(from: fullName)
+        return displayName.isEmpty ? nil : displayName
+    }
+
     @MainActor
     private func completeAppleSignIn(with result: Result<ASAuthorization, Error>) {
         guard let continuation = appleSignInContinuation else { return }
@@ -224,13 +213,15 @@ final class AppleAuthenticationServiceImpl: AuthenticationService {
 
     private func requestAppleCustomToken(
         challengeId: String,
-        authorizationCode: String
+        authorizationCode: String,
+        displayName: String?
     ) async throws -> String {
         let response = try await FunctionAPIClient.shared.send(
             .requestAppleCustomToken,
             payload: AppleCustomTokenRequest(
                 challengeId: challengeId,
-                authorizationCode: authorizationCode
+                authorizationCode: authorizationCode,
+                displayName: displayName
             ),
             requiresAuthentication: false
         )

--- a/Application/Infra/Sources/Service/SocialLogin/AppleAuthenticationServiceImpl.swift
+++ b/Application/Infra/Sources/Service/SocialLogin/AppleAuthenticationServiceImpl.swift
@@ -43,7 +43,7 @@ final class AppleAuthenticationServiceImpl: AuthenticationService {
                 hashedNonce: challenge.hashedNonce
             )
 
-            let displayName = Self.makeDisplayName(from: response.fullName)
+            let displayName = response.fullName?.displayName
 
             logger.debug("Requesting custom token from Firebase Function")
             let customToken = try await requestAppleCustomToken(
@@ -180,15 +180,6 @@ final class AppleAuthenticationServiceImpl: AuthenticationService {
         return request
     }
 
-    static func makeDisplayName(from fullName: PersonNameComponents?) -> String? {
-        guard let fullName else { return nil }
-
-        let formatter = PersonNameComponentsFormatter()
-        formatter.style = .long
-        let displayName = formatter.string(from: fullName)
-        return displayName.isEmpty ? nil : displayName
-    }
-
     @MainActor
     private func completeAppleSignIn(with result: Result<ASAuthorization, Error>) {
         guard let continuation = appleSignInContinuation else { return }
@@ -227,6 +218,15 @@ final class AppleAuthenticationServiceImpl: AuthenticationService {
         )
         
         return response.customToken
+    }
+}
+
+extension PersonNameComponents {
+    var displayName: String? {
+        let formatter = PersonNameComponentsFormatter()
+        formatter.style = .long
+        let name = formatter.string(from: self)
+        return name.isEmpty ? nil : name
     }
 }
 

--- a/Application/Infra/Tests/Service/FunctionAPIEndpointTests.swift
+++ b/Application/Infra/Tests/Service/FunctionAPIEndpointTests.swift
@@ -86,16 +86,12 @@ struct FunctionAPIEndpointTests {
         fullName.givenName = "Apple"
         fullName.familyName = "User"
 
-        #expect(AppleAuthenticationServiceImpl.makeDisplayName(from: fullName) == "Apple User")
+        #expect(fullName.displayName == "Apple User")
     }
 
     @Test("비어 있는 Apple 이름은 display name으로 변환하지 않는다")
     func 비어_있는_Apple_이름은_display_name으로_변환하지_않는다() {
-        #expect(
-            AppleAuthenticationServiceImpl.makeDisplayName(
-                from: PersonNameComponents()
-            ) == nil
-        )
+        #expect(PersonNameComponents().displayName == nil)
     }
 
     @Test("Apple 계정 연결 요청은 credential email을 포함할 수 있다")

--- a/Application/Infra/Tests/Service/FunctionAPIEndpointTests.swift
+++ b/Application/Infra/Tests/Service/FunctionAPIEndpointTests.swift
@@ -52,14 +52,50 @@ struct FunctionAPIEndpointTests {
         #expect(endpoint.path == "/auth/apple/access-token")
     }
 
-    @Test("Apple custom token 요청은 challenge와 authorization code만 인코딩한다")
-    func Apple_custom_token_요청은_challenge와_authorization_code만_인코딩한다() throws {
+    @Test("Apple custom token 요청은 display name을 포함할 수 있다")
+    func Apple_custom_token_요청은_display_name을_포함할_수_있다() throws {
         let request = AppleCustomTokenRequest(
             challengeId: "challenge-id",
-            authorizationCode: "authorization-code"
+            authorizationCode: "authorization-code",
+            displayName: "Apple User"
+        )
+
+        #expect(
+            try encodedKeys(request) == [
+                "challengeId",
+                "authorizationCode",
+                "displayName"
+            ]
+        )
+    }
+
+    @Test("Apple custom token 요청은 없는 display name을 인코딩하지 않는다")
+    func Apple_custom_token_요청은_없는_display_name을_인코딩하지_않는다() throws {
+        let request = AppleCustomTokenRequest(
+            challengeId: "challenge-id",
+            authorizationCode: "authorization-code",
+            displayName: nil
         )
 
         #expect(try encodedKeys(request) == ["challengeId", "authorizationCode"])
+    }
+
+    @Test("Apple 이름은 custom token 요청용 display name으로 변환한다")
+    func Apple_이름은_custom_token_요청용_display_name으로_변환한다() {
+        var fullName = PersonNameComponents()
+        fullName.givenName = "Apple"
+        fullName.familyName = "User"
+
+        #expect(AppleAuthenticationServiceImpl.makeDisplayName(from: fullName) == "Apple User")
+    }
+
+    @Test("비어 있는 Apple 이름은 display name으로 변환하지 않는다")
+    func 비어_있는_Apple_이름은_display_name으로_변환하지_않는다() {
+        #expect(
+            AppleAuthenticationServiceImpl.makeDisplayName(
+                from: PersonNameComponents()
+            ) == nil
+        )
     }
 
     @Test("Apple 계정 연결 요청은 credential email을 포함할 수 있다")

--- a/Application/Infra/Tests/Service/FunctionAPIEndpointTests.swift
+++ b/Application/Infra/Tests/Service/FunctionAPIEndpointTests.swift
@@ -84,9 +84,8 @@ struct FunctionAPIEndpointTests {
     func Apple_이름은_custom_token_요청용_display_name으로_변환한다() {
         var fullName = PersonNameComponents()
         fullName.givenName = "Apple"
-        fullName.familyName = "User"
 
-        #expect(fullName.displayName == "Apple User")
+        #expect(fullName.displayName == "Apple")
     }
 
     @Test("비어 있는 Apple 이름은 display name으로 변환하지 않는다")


### PR DESCRIPTION
## 🔗 연관된 이슈
- closed #719

## 🎯 의도

Apple 인증은 `ASAuthorizationController` 기반 기기 내 인증을 유지하면서, iOS가 담당하던 이름 복구와 Firebase Auth 프로필 변경 책임을 서버로 이전하기 위함

## 📝 작업 내용

### 📌 요약

- `AppleCustomTokenRequest`에 선택적 `displayName` 추가
- Apple `fullName`을 표시 이름으로 변환해 서버에 전달
- iOS의 Firestore `appleName` 조회 제거
- iOS의 Firebase Auth `displayName`과 `photoURL` 변경 제거
- 요청 인코딩과 이름 변환 계약 테스트 추가

### 🔍 상세

- 서버 challenge의 `hashedNonce`를 사용하는 기존 `ASAuthorizationController` 흐름 유지
- `challengeId`, `authorizationCode`, `displayName?`을 `/auth/apple/custom-token`으로 전달
- 서버가 반환한 `customToken`을 `Auth.auth().signIn(withCustomToken:)`에서 즉시 사용
- 서버 오류 발생 시 Firebase 로그인과 `UserService.upsertUser`를 수행하지 않고 기존 공통 Alert 표시
- 로그인·계정 연결 취소 반환값과 `credentialEmail` 전달 계약 유지
- Apple 웹 인증 session·callback·ticket 흐름 미도입
- [DevLog_Firebase #34](https://github.com/opficdev/DevLog_Firebase/issues/34)의 프로필 처리 구현과 배포 선행 필요
- 변경 파일 SwiftLint 통과
- `Infra` 테스트 빌드와 전체 `App` 빌드 통과

## 📸 영상 / 이미지 (Optional)

- 해당 없음