### PR TITLE
[#730] App Store와 TestFlight가 공유하는 build_for_store의 버전 조회 실패를 해결한다

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -13,10 +13,39 @@ TESTFLIGHT_DATABASE_ID = "staging"
 APPSTORE_DATABASE_ID = "prod"
 TESTFLIGHT_FUNCTION_API_BASE_URL = "https://asia-northeast3-devlog-c87b6.cloudfunctions.net/stagingApi/api"
 APPSTORE_FUNCTION_API_BASE_URL = "https://asia-northeast3-devlog-c87b6.cloudfunctions.net/prodApi/api"
+VERSION_XCCONFIG_PATH = "Application/Shared/Version.xcconfig"
 TESTFLIGHT_BUILD_OUTPUT_DIRECTORY = File.expand_path("testflight_build", __dir__)
 TESTFLIGHT_IPA_OUTPUT_PATH = File.join(TESTFLIGHT_BUILD_OUTPUT_DIRECTORY, "#{APP_PRODUCT_NAME}.ipa")
 APPSTORE_BUILD_OUTPUT_DIRECTORY = File.expand_path("appstore_build", __dir__)
 APPSTORE_IPA_OUTPUT_PATH = File.join(APPSTORE_BUILD_OUTPUT_DIRECTORY, "#{APP_PRODUCT_NAME}.ipa")
+
+# xcconfig의 MARKETING_VERSION을 읽고 App Store 버전 형식을 검증한다.
+def marketing_version_from_xcconfig(path)
+  expanded_path = File.expand_path(path)
+  UI.user_error!("Missing version configuration file: #{expanded_path}") if !File.file?(expanded_path)
+
+  version_assignments = File.foreach(expanded_path).filter_map do |line|
+    assignment = line.match(/^\s*MARKETING_VERSION\s*=(.*)$/)
+    next if assignment.nil?
+
+    assignment[1].sub(%r{\s*//.*$}, "").strip
+  end
+
+  UI.user_error!("Missing MARKETING_VERSION in #{expanded_path}") if version_assignments.empty?
+
+  version_number = version_assignments.last
+  UI.user_error!("Empty MARKETING_VERSION in #{expanded_path}") if version_number.empty?
+
+  if !version_number.match?(/\A[1-9]\d*(?:\.\d+){0,2}\z/)
+    UI.user_error!(
+      "Invalid MARKETING_VERSION in #{expanded_path}: #{version_number.inspect}. Expected one to three dot-separated integers beginning with a positive integer."
+    )
+  end
+
+  version_number
+rescue SystemCallError => error
+  UI.user_error!("Could not read version configuration file at #{expanded_path}: #{error.message}")
+end
 
 default_platform(:ios)
 
@@ -182,10 +211,7 @@ platform :ios do
 
     api_key = asc_api_key
 
-    version_number = get_version_number(
-      xcodeproj: XCODE_PROJ,
-      target: TARGET_NAME
-    )
+    version_number = marketing_version_from_xcconfig(VERSION_XCCONFIG_PATH)
 
     latest_build_number = fetch_latest_app_store_connect_build_number(
       api_key: api_key,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -13,7 +13,10 @@ TESTFLIGHT_DATABASE_ID = "staging"
 APPSTORE_DATABASE_ID = "prod"
 TESTFLIGHT_FUNCTION_API_BASE_URL = "https://asia-northeast3-devlog-c87b6.cloudfunctions.net/stagingApi/api"
 APPSTORE_FUNCTION_API_BASE_URL = "https://asia-northeast3-devlog-c87b6.cloudfunctions.net/prodApi/api"
-VERSION_XCCONFIG_PATH = "Application/Shared/Version.xcconfig"
+VERSION_XCCONFIG_PATH = File.expand_path(
+  "../Application/Shared/Version.xcconfig",
+  __dir__
+)
 TESTFLIGHT_BUILD_OUTPUT_DIRECTORY = File.expand_path("testflight_build", __dir__)
 TESTFLIGHT_IPA_OUTPUT_PATH = File.join(TESTFLIGHT_BUILD_OUTPUT_DIRECTORY, "#{APP_PRODUCT_NAME}.ipa")
 APPSTORE_BUILD_OUTPUT_DIRECTORY = File.expand_path("appstore_build", __dir__)


### PR DESCRIPTION
## 🔗 연관된 이슈
- closed #730

## 🎯 의도

- `#722` 반영 뒤 전처리 구문이 포함된 원본 `Info.plist`를 Fastlane의 `get_version_number`가 XML로 파싱하면서 발생한 `CFFormatError` 해소
- App Store와 TestFlight가 공유하는 `build_for_store`의 마케팅 버전 조회 기준을 `Application/Shared/Version.xcconfig`로 통일
- `#722`에서 확정한 Crashlytics 활성화, dSYM 생성·업로드, 생성된 IPA 설정 검증 흐름 유지

## 📝 작업 내용

### 📌 요약

- `get_version_number`를 통한 원본 `Info.plist` 조회 제거
- `Version.xcconfig`의 `MARKETING_VERSION` 직접 조회와 형식 검증 추가
- Fastlane 작업 디렉터리와 무관한 `__dir__` 기준 버전 파일 경로 계산 적용

### 🔍 상세

- `marketing_version_from_xcconfig` 추가
  - 버전 파일 누락 오류 제공
  - `MARKETING_VERSION` 키 누락 오류 제공
  - 빈 값 오류 제공
  - 첫 구성 요소가 양수인 1~3개 정수의 점 구분 형식 검증
  - 오류 원인과 대상 경로를 포함한 Fastlane 오류 제공
- 조회한 `MARKETING_VERSION`을 App Store Connect의 최근 빌드 번호 조회에 사용
- Fastlane 작업 디렉터리에서 `fastlane/Application/Shared/Version.xcconfig`를 조회하던 경로 오류를 `__dir__` 기준 절대 경로로 수정
- `build_app`의 `CRASHLYTICS_COLLECTION_ENABLED=1`, dSYM 생성 설정, `verify_store_info_plist` 호출부 유지
- 검증 결과
  - `fastlane/` 작업 디렉터리에서 `MARKETING_VERSION=1.4` 조회 확인
  - 버전 파일 누락, 키 누락, 빈 값, 형식 오류별 Fastlane 오류 메시지 확인
  - `ruby -c fastlane/Fastfile` 통과
  - `bundle check` 통과
  - `bundle exec fastlane lanes` 통과
  - `git diff --check` 통과
  - 최종 커밋 `0dbc07cf6` 기준 [TestFlight run 29308325910](https://github.com/opficdev/DevLog_iOS/actions/runs/29308325910)의 빌드와 dSYM 업로드 성공 및 TestFlight 업로드 생략
  - 최종 커밋 `0dbc07cf6` 기준 [App Store run 29312793662](https://github.com/opficdev/DevLog_iOS/actions/runs/29312793662)의 빌드, dSYM 업로드, App Store Connect 업로드 성공

## 📸 영상 / 이미지 (Optional)

- 없음