### PR TITLE
[#735] Watcher 버전을 0.3.1으로 업데이트한다

### DIFF
--- a/.github/workflows/merge-risk-watch.yml
+++ b/.github/workflows/merge-risk-watch.yml
@@ -11,25 +11,11 @@ permissions:
 jobs:
   watch:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
-    uses: opficdev/Watcher/.github/workflows/merge-risk-watch.yml@0.2.1
+    uses: opficdev/Watcher/.github/workflows/merge-risk-watch.yml@0.3.0
     with:
       repository: ${{ github.repository }}
       base_branch: develop
       default_branch: main
-      critical_file_patterns: |
-        .github/workflows/**
-        .github/actions/**
-        .mise.toml
-        .package.resolved
-        Gemfile.lock
-        Tuist.swift
-        Workspace.swift
-        Tuist/ProjectDescriptionHelpers/**
-        Application/**/Project.swift
-        Application/Shared/**
-        Widget/**/Project.swift
-        fastlane/**
-        **/*.xcstrings
     secrets:
       watcher_github_token: ${{ secrets.WATCHER_GITHUB_TOKEN }}
       openai_api_key: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/merge-risk-watch.yml
+++ b/.github/workflows/merge-risk-watch.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   watch:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
-    uses: opficdev/Watcher/.github/workflows/merge-risk-watch.yml@0.3.0
+    uses: opficdev/Watcher/.github/workflows/merge-risk-watch.yml@0.3.1
     with:
       repository: ${{ github.repository }}
       base_branch: develop


### PR DESCRIPTION
## 🔗 연관된 이슈

- closed #735

## 🎯 의도

Watcher 기능 변경 반영과 Discord webhook HTTP 429 응답 재시도 처리를 위한 재사용 워크플로 버전 상향

## 📝 작업 내용

### 📌 요약

- Watcher 참조 버전 `0.2.1`에서 `0.3.1`로 상향
- 제거된 `critical_file_patterns` 입력 정리

### 🔍 상세

- `0.3.0` 수동 실행에서 Discord webhook HTTP 429로 인한 실패 확인
- HTTP 429 재시도 처리가 포함된 `0.3.1`로 최종 상향
- 기존 `schedule`, `workflow_dispatch`, `base_branch: develop`, `default_branch: main`, `contents: read` 설정 유지
- 기존 `WATCHER_GITHUB_TOKEN`, `OPENAI_API_KEY`, `DISCORD_WEBHOOK_URL` 설정 유지
- [[Merge Risk Watch 수동 실행](https://github.com/opficdev/DevLog_iOS/actions/runs/29683222500)](https://github.com/opficdev/DevLog_iOS/actions/runs/29683222500)에서 `fca125b92` 기준 전체 작업 및 `Run Watcher` 성공 확인

## 📸 영상 / 이미지 (Optional)

없음