### PR TITLE
[#753] 기존 설치의 Crashlytics 수집 상태가 Xcode Debug 빌드에 남는 현상을 해결한다

### DIFF
--- a/Application/Infra/Sources/Service/FirebaseAppServiceImpl.swift
+++ b/Application/Infra/Sources/Service/FirebaseAppServiceImpl.swift
@@ -7,14 +7,40 @@
 
 import Data
 import FirebaseCore
+import FirebaseCrashlytics
+import Foundation
 
 final class FirebaseAppServiceImpl: FirebaseAppService {
+    private enum InfoKey {
+        static let crashlyticsCollectionEnabled = "FirebaseCrashlyticsCollectionEnabled"
+    }
+
     private static var isConfigured = false
 
     func configure() {
         guard !Self.isConfigured else { return }
 
         FirebaseApp.configure()
+
+        let crashlytics = Crashlytics.crashlytics()
+        let policy = FirebaseCrashlyticsCollectionPolicy(
+            infoDictionaryValue: Bundle.main.object(
+                forInfoDictionaryKey: InfoKey.crashlyticsCollectionEnabled
+            )
+        )
+        let actions = policy.actions(
+            currentCollectionEnabled: crashlytics.isCrashlyticsCollectionEnabled()
+        )
+
+        for action in actions {
+            switch action {
+            case .deleteUnsentReports:
+                crashlytics.deleteUnsentReports()
+            case let .setCollectionEnabled(isEnabled):
+                crashlytics.setCrashlyticsCollectionEnabled(isEnabled)
+            }
+        }
+
         Self.isConfigured = true
     }
 }

--- a/Application/Infra/Sources/Service/FirebaseAppServiceImpl.swift
+++ b/Application/Infra/Sources/Service/FirebaseAppServiceImpl.swift
@@ -20,14 +20,23 @@ final class FirebaseAppServiceImpl: FirebaseAppService {
     func configure() {
         guard !Self.isConfigured else { return }
 
-        FirebaseApp.configure()
-
-        let crashlytics = Crashlytics.crashlytics()
         let policy = FirebaseCrashlyticsCollectionPolicy(
             infoDictionaryValue: Bundle.main.object(
                 forInfoDictionaryKey: InfoKey.crashlyticsCollectionEnabled
             )
         )
+
+        if policy.shouldRemoveStoredOverride {
+            do {
+                try FirebaseCrashlyticsOverrideMigrator().removeStoredOverride()
+            } catch {
+                preconditionFailure("Failed to migrate Crashlytics collection state: \(error)")
+            }
+        }
+
+        FirebaseApp.configure()
+
+        let crashlytics = Crashlytics.crashlytics()
         let actions = policy.actions(
             currentCollectionEnabled: crashlytics.isCrashlyticsCollectionEnabled()
         )

--- a/Application/Infra/Sources/Service/FirebaseCrashlyticsCollectionPolicy.swift
+++ b/Application/Infra/Sources/Service/FirebaseCrashlyticsCollectionPolicy.swift
@@ -15,6 +15,10 @@ struct FirebaseCrashlyticsCollectionPolicy {
 
     let isCollectionEnabled: Bool
 
+    var shouldRemoveStoredOverride: Bool {
+        !isCollectionEnabled
+    }
+
     init(infoDictionaryValue: Any?) {
         guard let value = infoDictionaryValue as? NSNumber,
               CFGetTypeID(value) == CFBooleanGetTypeID() else {

--- a/Application/Infra/Sources/Service/FirebaseCrashlyticsCollectionPolicy.swift
+++ b/Application/Infra/Sources/Service/FirebaseCrashlyticsCollectionPolicy.swift
@@ -1,0 +1,38 @@
+//
+//  FirebaseCrashlyticsCollectionPolicy.swift
+//  Infra
+//
+//  Created by opfic on 7/22/26.
+//
+
+import Foundation
+
+struct FirebaseCrashlyticsCollectionPolicy {
+    enum Action: Equatable {
+        case deleteUnsentReports
+        case setCollectionEnabled(Bool)
+    }
+
+    let isCollectionEnabled: Bool
+
+    init(infoDictionaryValue: Any?) {
+        guard let value = infoDictionaryValue as? NSNumber,
+              CFGetTypeID(value) == CFBooleanGetTypeID() else {
+            isCollectionEnabled = false
+            return
+        }
+
+        isCollectionEnabled = value.boolValue
+    }
+
+    func actions(currentCollectionEnabled: Bool) -> [Action] {
+        var actions = [Action]()
+
+        if !currentCollectionEnabled {
+            actions.append(.deleteUnsentReports)
+        }
+        actions.append(.setCollectionEnabled(isCollectionEnabled))
+
+        return actions
+    }
+}

--- a/Application/Infra/Sources/Service/FirebaseCrashlyticsStoredCollectionOverrideMigrator.swift
+++ b/Application/Infra/Sources/Service/FirebaseCrashlyticsStoredCollectionOverrideMigrator.swift
@@ -1,0 +1,73 @@
+//
+//  FirebaseCrashlyticsStoredCollectionOverrideMigrator.swift
+//  Infra
+//
+//  Created by opfic on 7/22/26.
+//
+
+import Foundation
+
+struct FirebaseCrashlyticsOverrideMigrator {
+    enum MigrationError: Error {
+        case invalidStoredProperties
+    }
+
+    private enum Storage {
+        static let directoryName = "com.crashlytics"
+        static let fileName = "CLSUserDefaults.plist"
+        static let collectionEnabledKey = "com.crashlytics.data_collection"
+    }
+
+    private let fileManager: FileManager
+    private let applicationSupportDirectoryURL: URL?
+
+    init(
+        fileManager: FileManager = .default,
+        applicationSupportDirectoryURL: URL? = nil
+    ) {
+        self.fileManager = fileManager
+        self.applicationSupportDirectoryURL = applicationSupportDirectoryURL
+    }
+
+    func removeStoredOverride() throws {
+        let directoryURL: URL
+        if let applicationSupportDirectoryURL {
+            directoryURL = applicationSupportDirectoryURL
+        } else {
+            directoryURL = try fileManager.url(
+                for: .applicationSupportDirectory,
+                in: .userDomainMask,
+                appropriateFor: nil,
+                create: false
+            )
+        }
+
+        let fileURL = directoryURL
+            .appendingPathComponent(Storage.directoryName, isDirectory: true)
+            .appendingPathComponent(Storage.fileName, isDirectory: false)
+
+        guard fileManager.fileExists(atPath: fileURL.path) else { return }
+
+        let data = try Data(contentsOf: fileURL)
+        var format = PropertyListSerialization.PropertyListFormat.xml
+        guard var properties = try PropertyListSerialization.propertyList(
+            from: data,
+            options: [],
+            format: &format
+        ) as? [String: Any] else {
+            throw MigrationError.invalidStoredProperties
+        }
+        guard properties.removeValue(forKey: Storage.collectionEnabledKey) != nil else { return }
+
+        let migratedData = try PropertyListSerialization.data(
+            fromPropertyList: properties,
+            format: format,
+            options: 0
+        )
+        try migratedData.write(to: fileURL, options: .atomic)
+        try fileManager.setAttributes(
+            [.protectionKey: FileProtectionType.none],
+            ofItemAtPath: fileURL.path
+        )
+    }
+}

--- a/Application/Infra/Tests/Service/FirebaseCrashlyticsCollectionPolicyTests.swift
+++ b/Application/Infra/Tests/Service/FirebaseCrashlyticsCollectionPolicyTests.swift
@@ -15,6 +15,7 @@ struct FirebaseCrashlyticsCollectionPolicyTests {
         let policy = FirebaseCrashlyticsCollectionPolicy(infoDictionaryValue: true)
 
         #expect(policy.isCollectionEnabled)
+        #expect(!policy.shouldRemoveStoredOverride)
     }
 
     @Test("Info.plist false 값을 수집 비활성 상태로 해석한다")
@@ -22,6 +23,7 @@ struct FirebaseCrashlyticsCollectionPolicyTests {
         let policy = FirebaseCrashlyticsCollectionPolicy(infoDictionaryValue: false)
 
         #expect(!policy.isCollectionEnabled)
+        #expect(policy.shouldRemoveStoredOverride)
     }
 
     @Test("Info.plist 값이 누락되면 수집 비활성 상태로 해석한다")

--- a/Application/Infra/Tests/Service/FirebaseCrashlyticsCollectionPolicyTests.swift
+++ b/Application/Infra/Tests/Service/FirebaseCrashlyticsCollectionPolicyTests.swift
@@ -1,0 +1,80 @@
+//
+//  FirebaseCrashlyticsCollectionPolicyTests.swift
+//  InfraTests
+//
+//  Created by opfic on 7/22/26.
+//
+
+import Foundation
+import Testing
+@testable import Infra
+
+struct FirebaseCrashlyticsCollectionPolicyTests {
+    @Test("Info.plist true 값을 수집 활성 상태로 해석한다")
+    func Info_plist_true_값을_수집_활성_상태로_해석한다() {
+        let policy = FirebaseCrashlyticsCollectionPolicy(infoDictionaryValue: true)
+
+        #expect(policy.isCollectionEnabled)
+    }
+
+    @Test("Info.plist false 값을 수집 비활성 상태로 해석한다")
+    func Info_plist_false_값을_수집_비활성_상태로_해석한다() {
+        let policy = FirebaseCrashlyticsCollectionPolicy(infoDictionaryValue: false)
+
+        #expect(!policy.isCollectionEnabled)
+    }
+
+    @Test("Info.plist 값이 누락되면 수집 비활성 상태로 해석한다")
+    func Info_plist_값이_누락되면_수집_비활성_상태로_해석한다() {
+        let policy = FirebaseCrashlyticsCollectionPolicy(infoDictionaryValue: nil)
+
+        #expect(!policy.isCollectionEnabled)
+    }
+
+    @Test("Info.plist 값의 형식이 잘못되면 수집 비활성 상태로 해석한다")
+    func Info_plist_값의_형식이_잘못되면_수집_비활성_상태로_해석한다() {
+        let policy = FirebaseCrashlyticsCollectionPolicy(infoDictionaryValue: "true")
+
+        #expect(!policy.isCollectionEnabled)
+    }
+
+    @Test("Info.plist 값이 숫자이면 수집 비활성 상태로 해석한다")
+    func Info_plist_값이_숫자이면_수집_비활성_상태로_해석한다() {
+        let policy = FirebaseCrashlyticsCollectionPolicy(
+            infoDictionaryValue: NSNumber(value: 1)
+        )
+
+        #expect(!policy.isCollectionEnabled)
+    }
+
+    @Test("현재 수집 상태가 비활성이면 보고서를 삭제한 뒤 목표 상태를 저장한다", arguments: [false, true])
+    func 현재_수집_상태가_비활성이면_보고서를_삭제한_뒤_목표_상태를_저장한다(
+        isCollectionEnabled: Bool
+    ) {
+        let policy = FirebaseCrashlyticsCollectionPolicy(
+            infoDictionaryValue: isCollectionEnabled
+        )
+
+        #expect(
+            policy.actions(currentCollectionEnabled: false) == [
+                .deleteUnsentReports,
+                .setCollectionEnabled(isCollectionEnabled)
+            ]
+        )
+    }
+
+    @Test("현재 수집 상태가 활성이면 목표 상태만 저장한다", arguments: [false, true])
+    func 현재_수집_상태가_활성이면_목표_상태만_저장한다(
+        isCollectionEnabled: Bool
+    ) {
+        let policy = FirebaseCrashlyticsCollectionPolicy(
+            infoDictionaryValue: isCollectionEnabled
+        )
+
+        #expect(
+            policy.actions(currentCollectionEnabled: true) == [
+                .setCollectionEnabled(isCollectionEnabled)
+            ]
+        )
+    }
+}

--- a/Application/Infra/Tests/Service/FirebaseCrashlyticsStoredCollectionOverrideMigratorTests.swift
+++ b/Application/Infra/Tests/Service/FirebaseCrashlyticsStoredCollectionOverrideMigratorTests.swift
@@ -1,0 +1,137 @@
+//
+//  FirebaseCrashlyticsStoredCollectionOverrideMigratorTests.swift
+//  InfraTests
+//
+//  Created by opfic on 7/22/26.
+//
+
+import Foundation
+import Testing
+@testable import Infra
+
+struct FirebaseCrashlyticsOverrideMigratorTests {
+    private enum Storage {
+        static let directoryName = "com.crashlytics"
+        static let fileName = "CLSUserDefaults.plist"
+        static let collectionEnabledKey = "com.crashlytics.data_collection"
+    }
+
+    @Test("저장 파일이 없으면 아무 작업도 하지 않는다")
+    func 저장_파일이_없으면_아무_작업도_하지_않는다() throws {
+        let directoryURL = try makeTemporaryDirectoryURL()
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+        let migrator = FirebaseCrashlyticsOverrideMigrator(
+            applicationSupportDirectoryURL: directoryURL
+        )
+
+        try migrator.removeStoredOverride()
+    }
+
+    @Test("저장된 수집 상태만 제거하고 다른 속성은 유지한다")
+    func 저장된_수집_상태만_제거하고_다른_속성은_유지한다() throws {
+        let directoryURL = try makeTemporaryDirectoryURL()
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+        let fileURL = try writeStoredProperties(
+            [
+                Storage.collectionEnabledKey: 1,
+                "preserved": "value"
+            ],
+            to: directoryURL
+        )
+        let migrator = FirebaseCrashlyticsOverrideMigrator(
+            applicationSupportDirectoryURL: directoryURL
+        )
+
+        try migrator.removeStoredOverride()
+
+        let properties = try readStoredProperties(from: fileURL)
+        #expect(properties[Storage.collectionEnabledKey] == nil)
+        #expect(properties["preserved"] as? String == "value")
+    }
+
+    @Test("저장된 수집 상태가 없으면 기존 속성을 유지한다")
+    func 저장된_수집_상태가_없으면_기존_속성을_유지한다() throws {
+        let directoryURL = try makeTemporaryDirectoryURL()
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+        let fileURL = try writeStoredProperties(
+            ["preserved": "value"],
+            to: directoryURL
+        )
+        let migrator = FirebaseCrashlyticsOverrideMigrator(
+            applicationSupportDirectoryURL: directoryURL
+        )
+
+        try migrator.removeStoredOverride()
+
+        let properties = try readStoredProperties(from: fileURL)
+        #expect(properties["preserved"] as? String == "value")
+    }
+
+    @Test("저장 파일의 최상위 값이 딕셔너리가 아니면 실패한다")
+    func 저장_파일의_최상위_값이_딕셔너리가_아니면_실패한다() throws {
+        let directoryURL = try makeTemporaryDirectoryURL()
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+        let fileURL = try makeStoredPropertiesURL(in: directoryURL)
+        let data = try PropertyListSerialization.data(
+            fromPropertyList: ["value"],
+            format: .xml,
+            options: 0
+        )
+        try data.write(to: fileURL)
+        let migrator = FirebaseCrashlyticsOverrideMigrator(
+            applicationSupportDirectoryURL: directoryURL
+        )
+
+        #expect(throws: FirebaseCrashlyticsOverrideMigrator.MigrationError.self) {
+            try migrator.removeStoredOverride()
+        }
+    }
+}
+
+private extension FirebaseCrashlyticsOverrideMigratorTests {
+    func makeTemporaryDirectoryURL() throws -> URL {
+        let directoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: directoryURL,
+            withIntermediateDirectories: true
+        )
+        return directoryURL
+    }
+
+    func makeStoredPropertiesURL(in directoryURL: URL) throws -> URL {
+        let crashlyticsDirectoryURL = directoryURL
+            .appendingPathComponent(Storage.directoryName, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: crashlyticsDirectoryURL,
+            withIntermediateDirectories: true
+        )
+        return crashlyticsDirectoryURL
+            .appendingPathComponent(Storage.fileName, isDirectory: false)
+    }
+
+    func writeStoredProperties(
+        _ properties: [String: Any],
+        to directoryURL: URL
+    ) throws -> URL {
+        let fileURL = try makeStoredPropertiesURL(in: directoryURL)
+        let data = try PropertyListSerialization.data(
+            fromPropertyList: properties,
+            format: .xml,
+            options: 0
+        )
+        try data.write(to: fileURL)
+        return fileURL
+    }
+
+    func readStoredProperties(from fileURL: URL) throws -> [String: Any] {
+        let data = try Data(contentsOf: fileURL)
+        return try #require(
+            PropertyListSerialization.propertyList(
+                from: data,
+                options: [],
+                format: nil
+            ) as? [String: Any]
+        )
+    }
+}


### PR DESCRIPTION
## 🔗 연관된 이슈

- closed #753

## 🎯 의도

- 기존 설치에 저장된 Crashlytics 수집 상태가 빌드된 `Info.plist`보다 우선하는 문제 해결
- Xcode 직접 빌드의 첫 실행부터 Crashlytics 수집 비활성화
- Xcode 직접 빌드에서 생성된 미전송 보고서의 추후 배포 빌드 전송 차단
- Fastlane 배포 빌드의 Crashlytics 수집 및 dSYM 처리 유지

## 📝 작업 내용

### 📌 요약

- 빌드된 `FirebaseCrashlyticsCollectionEnabled` 값을 해석하는 `FirebaseCrashlyticsCollectionPolicy` 추가
- 현재 수집 상태와 빌드 정책에 따른 Crashlytics 전환 작업 정의
- `FirebaseApp.configure()` 이전에 기존 Crashlytics 수집 override를 제거하는 `FirebaseCrashlyticsOverrideMigrator` 추가
- 수집 비활성 상태에서 미전송 보고서 삭제 후 현재 빌드 정책 저장
- 정책 입력값, 상태 전환 순서, 내부 저장값 마이그레이션에 대한 단위 테스트 추가

### 🔍 상세

- `Info.plist`의 Boolean 값만 유효한 수집 정책으로 해석
- 값 누락, 잘못된 형식, 숫자 입력을 수집 비활성 상태로 처리
- 수집 비활성 빌드에서 Firebase 11.15.0의 `CLSUserDefaults.plist`에 저장된 `com.crashlytics.data_collection` 제거
- Crashlytics의 다른 내부 속성을 유지하고 수집 override만 제거
- 내부 저장값 제거 완료 후 `FirebaseApp.configure()` 호출
- 마이그레이션 실패 시 Firebase 구성을 진행하지 않는 전송 차단 처리
- 현재 수집 상태가 비활성인 경우 `deleteUnsentReports()` 실행 후 현재 빌드 정책 저장
- 현재 수집 상태가 활성인 경우 현재 빌드 정책으로 저장 상태 갱신

Xcode 직접 빌드 전환 흐름:

```text
저장된 활성 상태 Optional(1)
→ FirebaseApp.configure() 이전 수집 override 제거
→ 저장된 override nil
→ Info.plist=false로 Crashlytics 초기화
→ deleteUnsentReports()
→ setCrashlyticsCollectionEnabled(false)
→ 비활성 상태 Optional(2) 저장
```

Fastlane 배포 빌드 전환 흐름:

```text
저장 false + 배포 빌드 true
→ 비활성 상태로 Crashlytics 초기화
→ deleteUnsentReports()
→ setCrashlyticsCollectionEnabled(true)
→ Debug 미전송 보고서 삭제 후 수집 활성화
```

검증 결과:

- 변경된 Source·Tests 파일 SwiftLint 위반 0건
- `Infra` build-for-testing 성공
- 기존 `TodoServiceImpl.swift` 파일 길이 경고 외 신규 경고 없음
- Xcode Debug 빌드의 `FirebaseCrashlyticsCollectionEnabled=false` 확인
- 기존 활성 상태 `Optional(1)` 재현 확인
- `FirebaseApp.configure()` 이전 마이그레이션 후 저장 상태 `nil` 확인
- 상태 전환 작업 완료 후 비활성 상태 `Optional(2)` 저장 확인
- 다음 Debug 실행에서 `Automatic data collection is disabled.` 확인
- 계획 외 `Project.swift`, `Info.plist`, Fastlane 및 target dependency 변경 없음

내부 구현 의존:

- Firebase iOS SDK 11.15.0의 `Library/Application Support/com.crashlytics/CLSUserDefaults.plist` 저장 구조 의존
- Firebase SDK 버전 변경 시 저장 경로와 `com.crashlytics.data_collection` 키 재검증 필요

남은 관찰 항목:

- 실제 미전송 보고서가 있는 상태에서 삭제 후 `N → 0` 전환 확인
- Fastlane TestFlight/App Store 산출물의 수집 활성화 및 dSYM 유지 확인
- 새로운 Debug UUID가 Firebase 필수 누락 dSYM 목록에 추가되지 않는지 확인

## 📸 영상 / 이미지 (Optional)
