### PR TITLE
[#755]  새 버전이 나오면 업데이트를 유도할 수 있는 얼럿을 구성한다

### DIFF
--- a/Application/App/Sources/App/DevLogApp.swift
+++ b/Application/App/Sources/App/DevLogApp.swift
@@ -31,6 +31,7 @@ struct DevLogApp: App {
                 networkConnectivityUseCase: container.resolve(ObserveNetworkConnectivityUseCase.self),
                 systemThemeUseCase: container.resolve(ObserveSystemThemeUseCase.self),
                 trackAnalyticsEventUseCase: container.resolve(TrackAnalyticsEventUseCase.self),
+                checkAppUpdateUseCase: container.resolve(CheckAppUpdateUseCase.self),
                 widgetURLTab: { MainTab(widgetURL: $0) },
                 windowEvent: windowEvent,
                 pushNotificationTodoIdPublisher: PushNotificationRoute.shared.observe(),

--- a/Application/App/Sources/Resource/Info.plist
+++ b/Application/App/Sources/Resource/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>APP_STORE_URL</key>
+	<string>$(APP_STORE_URL)</string>
 	<key>TESTFLIGHT_URL</key>
 	<string>$(TESTFLIGHT_URL)</string>
 	<key>CFBundleDevelopmentRegion</key>

--- a/Application/App/Sources/Resource/Localizable.xcstrings
+++ b/Application/App/Sources/Resource/Localizable.xcstrings
@@ -1493,6 +1493,57 @@
         }
       }
     },
+    "root_app_update_action" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Update"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "업데이트"
+          }
+        }
+      }
+    },
+    "root_app_update_message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Update to the latest version to continue using DevLog."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DevLog를 계속 사용하려면 최신 버전으로 업데이트해주세요."
+          }
+        }
+      }
+    },
+    "root_app_update_title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Update Required"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "업데이트 필요"
+          }
+        }
+      }
+    },
     "root_network_disconnected_message" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Application/Data/Sources/DataAssembler.swift
+++ b/Application/Data/Sources/DataAssembler.swift
@@ -72,6 +72,12 @@ public final class DataAssembler: Assembler {
             )
         }
 
+        container.register(AppVersionRepository.self) {
+            AppVersionRepositoryImpl(
+                service: container.resolve(AppVersionConfigurationService.self)
+            )
+        }
+
         container.register(AuthDataRepository.self) {
             AuthDataRepositoryImpl(
                 authService: container.resolve(AuthService.self),

--- a/Application/Data/Sources/Protocol/AppVersionConfigurationService.swift
+++ b/Application/Data/Sources/Protocol/AppVersionConfigurationService.swift
@@ -1,0 +1,10 @@
+//
+//  AppVersionConfigurationService.swift
+//  Data
+//
+//  Created by opfic on 7/22/26.
+//
+
+public protocol AppVersionConfigurationService {
+    func fetchRequiredVersion() async throws -> String
+}

--- a/Application/Data/Sources/Repository/AppVersionRepositoryImpl.swift
+++ b/Application/Data/Sources/Repository/AppVersionRepositoryImpl.swift
@@ -1,0 +1,20 @@
+//
+//  AppVersionRepositoryImpl.swift
+//  Data
+//
+//  Created by opfic on 7/22/26.
+//
+
+import Domain
+
+final class AppVersionRepositoryImpl: AppVersionRepository {
+    private let service: AppVersionConfigurationService
+
+    init(service: AppVersionConfigurationService) {
+        self.service = service
+    }
+
+    func fetchRequiredVersion() async throws -> String {
+        try await service.fetchRequiredVersion()
+    }
+}

--- a/Application/Data/Tests/Repository/AppVersionRepositoryImplTests.swift
+++ b/Application/Data/Tests/Repository/AppVersionRepositoryImplTests.swift
@@ -1,0 +1,54 @@
+//
+//  AppVersionRepositoryImplTests.swift
+//  DataTests
+//
+//  Created by opfic on 7/22/26.
+//
+
+import Testing
+@testable import Data
+
+struct AppVersionRepositoryImplTests {
+    @Test("필수 버전 조회는 구성 서비스의 값을 반환한다")
+    func 필수_버전_조회는_구성_서비스의_값을_반환한다() async throws {
+        let service = AppVersionConfigurationServiceSpy(result: .success("1.5"))
+        let repository = AppVersionRepositoryImpl(service: service)
+
+        #expect(try await repository.fetchRequiredVersion() == "1.5")
+        #expect(await service.fetchCallCount() == 1)
+    }
+
+    @Test("필수 버전 조회는 구성 서비스의 오류를 그대로 반환한다")
+    func 필수_버전_조회는_구성_서비스의_오류를_그대로_반환한다() async {
+        let service = AppVersionConfigurationServiceSpy(
+            result: .failure(AppVersionConfigurationServiceTestError.fetchFailed)
+        )
+        let repository = AppVersionRepositoryImpl(service: service)
+
+        await #expect(throws: AppVersionConfigurationServiceTestError.fetchFailed) {
+            try await repository.fetchRequiredVersion()
+        }
+    }
+}
+
+private actor AppVersionConfigurationServiceSpy: AppVersionConfigurationService {
+    private let result: Result<String, Error>
+    private var count = 0
+
+    init(result: Result<String, Error>) {
+        self.result = result
+    }
+
+    func fetchRequiredVersion() async throws -> String {
+        count += 1
+        return try result.get()
+    }
+
+    func fetchCallCount() -> Int {
+        count
+    }
+}
+
+private enum AppVersionConfigurationServiceTestError: Error {
+    case fetchFailed
+}

--- a/Application/Domain/Project.swift
+++ b/Application/Domain/Project.swift
@@ -11,5 +11,5 @@ let project = Project.devlogFramework(
     dependencies: [
         .project(target: "Core", path: "../Core")
     ],
-    hasTests: false
+    hasTests: true
 )

--- a/Application/Domain/Sources/DomainAssembler.swift
+++ b/Application/Domain/Sources/DomainAssembler.swift
@@ -12,6 +12,7 @@ public final class DomainAssembler: Assembler {
 
     public func assemble(_ container: any DIContainer) {
         registerAnalyticsUseCases(container)
+        registerAppUpdateUseCases(container)
         registerAuthUseCases(container)
         registerConnectivityUseCases(container)
         registerAuthProviderUseCases(container)
@@ -25,6 +26,12 @@ public final class DomainAssembler: Assembler {
 }
 
 private extension DomainAssembler {
+    func registerAppUpdateUseCases(_ container: any DIContainer) {
+        container.register(CheckAppUpdateUseCase.self) {
+            CheckAppUpdateUseCaseImpl(container.resolve(AppVersionRepository.self))
+        }
+    }
+
     func registerAnalyticsUseCases(_ container: any DIContainer) {
         container.register(TrackAnalyticsEventUseCase.self) {
             TrackAnalyticsEventUseCaseImpl(container.resolve(AnalyticsRepository.self))

--- a/Application/Domain/Sources/Entity/AppVersion.swift
+++ b/Application/Domain/Sources/Entity/AppVersion.swift
@@ -1,0 +1,40 @@
+//
+//  AppVersion.swift
+//  Domain
+//
+//  Created by opfic on 7/22/26.
+//
+
+public struct AppVersion: Comparable {
+    private let components: [Int]
+
+    public init(marketingVersion: String, buildNumber: String) throws {
+        try self.init("\(marketingVersion).\(buildNumber)")
+    }
+
+    init(_ value: String) throws {
+        let rawComponents = value.split(separator: ".", omittingEmptySubsequences: false)
+        guard !rawComponents.isEmpty,
+              rawComponents.allSatisfy({ !$0.isEmpty && $0.allSatisfy(\.isNumber) }) else {
+            throw DomainLayerError.invalidData(context: "appVersion")
+        }
+
+        let components = rawComponents.compactMap { Int($0) }
+        guard components.count == rawComponents.count else {
+            throw DomainLayerError.invalidData(context: "appVersion")
+        }
+        self.components = components
+    }
+
+    public static func < (lhs: AppVersion, rhs: AppVersion) -> Bool {
+        let count = max(lhs.components.count, rhs.components.count)
+
+        for index in 0..<count {
+            let lhsComponent = index < lhs.components.count ? lhs.components[index] : 0
+            let rhsComponent = index < rhs.components.count ? rhs.components[index] : 0
+            guard lhsComponent != rhsComponent else { continue }
+            return lhsComponent < rhsComponent
+        }
+        return false
+    }
+}

--- a/Application/Domain/Sources/Protocol/AppVersionRepository.swift
+++ b/Application/Domain/Sources/Protocol/AppVersionRepository.swift
@@ -1,0 +1,10 @@
+//
+//  AppVersionRepository.swift
+//  Domain
+//
+//  Created by opfic on 7/22/26.
+//
+
+public protocol AppVersionRepository {
+    func fetchRequiredVersion() async throws -> String
+}

--- a/Application/Domain/Sources/UseCase/AppUpdate/CheckAppUpdateUseCase.swift
+++ b/Application/Domain/Sources/UseCase/AppUpdate/CheckAppUpdateUseCase.swift
@@ -6,5 +6,5 @@
 //
 
 public protocol CheckAppUpdateUseCase {
-    func execute(_ currentVersion: AppVersion) async throws -> Bool
+    func execute() async throws -> Bool
 }

--- a/Application/Domain/Sources/UseCase/AppUpdate/CheckAppUpdateUseCase.swift
+++ b/Application/Domain/Sources/UseCase/AppUpdate/CheckAppUpdateUseCase.swift
@@ -1,0 +1,10 @@
+//
+//  CheckAppUpdateUseCase.swift
+//  Domain
+//
+//  Created by opfic on 7/22/26.
+//
+
+public protocol CheckAppUpdateUseCase {
+    func execute(_ currentVersion: AppVersion) async throws -> Bool
+}

--- a/Application/Domain/Sources/UseCase/AppUpdate/CheckAppUpdateUseCaseImpl.swift
+++ b/Application/Domain/Sources/UseCase/AppUpdate/CheckAppUpdateUseCaseImpl.swift
@@ -5,6 +5,8 @@
 //  Created by opfic on 7/22/26.
 //
 
+import Foundation
+
 public final class CheckAppUpdateUseCaseImpl: CheckAppUpdateUseCase {
     private let repository: AppVersionRepository
 
@@ -12,9 +14,24 @@ public final class CheckAppUpdateUseCaseImpl: CheckAppUpdateUseCase {
         self.repository = repository
     }
 
-    public func execute(_ currentVersion: AppVersion) async throws -> Bool {
+    public func execute() async throws -> Bool {
         let requiredVersionValue = try await repository.fetchRequiredVersion()
         let requiredVersion = try AppVersion(requiredVersionValue)
+        let currentVersion = try currentVersion()
         return currentVersion < requiredVersion
+    }
+
+    private func currentVersion() throws -> AppVersion {
+        guard let marketingVersion = Bundle.main.object(
+            forInfoDictionaryKey: "CFBundleShortVersionString"
+        ) as? String,
+        let buildNumber = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String else {
+            throw DomainLayerError.invalidData(context: "appVersion")
+        }
+
+        return try AppVersion(
+            marketingVersion: marketingVersion,
+            buildNumber: buildNumber
+        )
     }
 }

--- a/Application/Domain/Sources/UseCase/AppUpdate/CheckAppUpdateUseCaseImpl.swift
+++ b/Application/Domain/Sources/UseCase/AppUpdate/CheckAppUpdateUseCaseImpl.swift
@@ -1,0 +1,20 @@
+//
+//  CheckAppUpdateUseCaseImpl.swift
+//  Domain
+//
+//  Created by opfic on 7/22/26.
+//
+
+public final class CheckAppUpdateUseCaseImpl: CheckAppUpdateUseCase {
+    private let repository: AppVersionRepository
+
+    init(_ repository: AppVersionRepository) {
+        self.repository = repository
+    }
+
+    public func execute(_ currentVersion: AppVersion) async throws -> Bool {
+        let requiredVersionValue = try await repository.fetchRequiredVersion()
+        let requiredVersion = try AppVersion(requiredVersionValue)
+        return currentVersion < requiredVersion
+    }
+}

--- a/Application/Domain/Tests/Entity/AppVersionTests.swift
+++ b/Application/Domain/Tests/Entity/AppVersionTests.swift
@@ -1,0 +1,25 @@
+//
+//  AppVersionTests.swift
+//  DomainTests
+//
+//  Created by opfic on 7/22/26.
+//
+
+import Testing
+@testable import Domain
+
+struct AppVersionTests {
+    @Test("마케팅 버전 형식이 잘못되면 invalidData 오류를 반환한다")
+    func 마케팅_버전_형식이_잘못되면_invalidData_오류를_반환한다() {
+        #expect(throws: DomainLayerError.self) {
+            try AppVersion(marketingVersion: "1..5", buildNumber: "127")
+        }
+    }
+
+    @Test("빌드 번호 형식이 잘못되면 invalidData 오류를 반환한다")
+    func 빌드_번호_형식이_잘못되면_invalidData_오류를_반환한다() {
+        #expect(throws: DomainLayerError.self) {
+            try AppVersion(marketingVersion: "1.5", buildNumber: "127a")
+        }
+    }
+}

--- a/Application/Domain/Tests/UseCase/AppUpdate/CheckAppUpdateUseCaseImplTests.swift
+++ b/Application/Domain/Tests/UseCase/AppUpdate/CheckAppUpdateUseCaseImplTests.swift
@@ -5,35 +5,27 @@
 //  Created by opfic on 7/22/26.
 //
 
+import Foundation
 import Testing
 @testable import Domain
 
 struct CheckAppUpdateUseCaseImplTests {
-    @Test(
-        "현재 마케팅 버전과 빌드 번호를 필수 버전과 비교한다",
-        arguments: [
-            ("1.4", "9", "1.5.1", true),
-            ("1.5", "127", "1.5.128", true),
-            ("1.5", "128", "1.5.128", false),
-            ("1.5", "129", "1.5.128", false),
-            ("1.9", "9", "1.10.1", true),
-            ("1.5", "1", "1.5.0", false)
-        ]
-    )
-    func 현재_마케팅_버전과_빌드_번호를_필수_버전과_비교한다(
-        marketingVersion: String,
-        buildNumber: String,
-        requiredVersion: String,
-        expectedResult: Bool
-    ) async throws {
+    @Test("Bundle의 현재 버전보다 필수 버전이 높으면 업데이트가 필요하다")
+    func Bundle의_현재_버전보다_필수_버전이_높으면_업데이트가_필요하다() async throws {
+        let requiredVersion = "\(try currentVersionValue()).1"
         let repository = AppVersionRepositorySpy(result: .success(requiredVersion))
         let useCase = CheckAppUpdateUseCaseImpl(repository)
-        let currentVersion = try AppVersion(
-            marketingVersion: marketingVersion,
-            buildNumber: buildNumber
-        )
 
-        #expect(try await useCase.execute(currentVersion) == expectedResult)
+        #expect(try await useCase.execute())
+        #expect(await repository.fetchCallCount() == 1)
+    }
+
+    @Test("Bundle의 현재 버전과 필수 버전이 같으면 업데이트가 필요하지 않다")
+    func Bundle의_현재_버전과_필수_버전이_같으면_업데이트가_필요하지_않다() async throws {
+        let repository = AppVersionRepositorySpy(result: .success(try currentVersionValue()))
+        let useCase = CheckAppUpdateUseCaseImpl(repository)
+
+        #expect(try await !useCase.execute())
         #expect(await repository.fetchCallCount() == 1)
     }
 
@@ -41,10 +33,8 @@ struct CheckAppUpdateUseCaseImplTests {
     func 필수_버전_형식이_잘못되면_invalidData_오류를_반환한다() async throws {
         let repository = AppVersionRepositorySpy(result: .success("latest"))
         let useCase = CheckAppUpdateUseCaseImpl(repository)
-        let currentVersion = try AppVersion(marketingVersion: "1.5", buildNumber: "127")
-
         await #expect(throws: DomainLayerError.self) {
-            try await useCase.execute(currentVersion)
+            try await useCase.execute()
         }
     }
 
@@ -54,12 +44,20 @@ struct CheckAppUpdateUseCaseImplTests {
             result: .failure(AppVersionRepositoryTestError.fetchFailed)
         )
         let useCase = CheckAppUpdateUseCaseImpl(repository)
-        let currentVersion = try AppVersion(marketingVersion: "1.5", buildNumber: "127")
-
         await #expect(throws: AppVersionRepositoryTestError.fetchFailed) {
-            try await useCase.execute(currentVersion)
+            try await useCase.execute()
         }
     }
+}
+
+private func currentVersionValue() throws -> String {
+    let marketingVersion = try #require(
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
+    )
+    let buildNumber = try #require(
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String
+    )
+    return "\(marketingVersion).\(buildNumber)"
 }
 
 private actor AppVersionRepositorySpy: AppVersionRepository {

--- a/Application/Domain/Tests/UseCase/AppUpdate/CheckAppUpdateUseCaseImplTests.swift
+++ b/Application/Domain/Tests/UseCase/AppUpdate/CheckAppUpdateUseCaseImplTests.swift
@@ -1,0 +1,85 @@
+//
+//  CheckAppUpdateUseCaseImplTests.swift
+//  DomainTests
+//
+//  Created by opfic on 7/22/26.
+//
+
+import Testing
+@testable import Domain
+
+struct CheckAppUpdateUseCaseImplTests {
+    @Test(
+        "현재 마케팅 버전과 빌드 번호를 필수 버전과 비교한다",
+        arguments: [
+            ("1.4", "9", "1.5.1", true),
+            ("1.5", "127", "1.5.128", true),
+            ("1.5", "128", "1.5.128", false),
+            ("1.5", "129", "1.5.128", false),
+            ("1.9", "9", "1.10.1", true),
+            ("1.5", "1", "1.5.0", false)
+        ]
+    )
+    func 현재_마케팅_버전과_빌드_번호를_필수_버전과_비교한다(
+        marketingVersion: String,
+        buildNumber: String,
+        requiredVersion: String,
+        expectedResult: Bool
+    ) async throws {
+        let repository = AppVersionRepositorySpy(result: .success(requiredVersion))
+        let useCase = CheckAppUpdateUseCaseImpl(repository)
+        let currentVersion = try AppVersion(
+            marketingVersion: marketingVersion,
+            buildNumber: buildNumber
+        )
+
+        #expect(try await useCase.execute(currentVersion) == expectedResult)
+        #expect(await repository.fetchCallCount() == 1)
+    }
+
+    @Test("필수 버전 형식이 잘못되면 invalidData 오류를 반환한다")
+    func 필수_버전_형식이_잘못되면_invalidData_오류를_반환한다() async throws {
+        let repository = AppVersionRepositorySpy(result: .success("latest"))
+        let useCase = CheckAppUpdateUseCaseImpl(repository)
+        let currentVersion = try AppVersion(marketingVersion: "1.5", buildNumber: "127")
+
+        await #expect(throws: DomainLayerError.self) {
+            try await useCase.execute(currentVersion)
+        }
+    }
+
+    @Test("필수 버전 조회 오류를 그대로 반환한다")
+    func 필수_버전_조회_오류를_그대로_반환한다() async throws {
+        let repository = AppVersionRepositorySpy(
+            result: .failure(AppVersionRepositoryTestError.fetchFailed)
+        )
+        let useCase = CheckAppUpdateUseCaseImpl(repository)
+        let currentVersion = try AppVersion(marketingVersion: "1.5", buildNumber: "127")
+
+        await #expect(throws: AppVersionRepositoryTestError.fetchFailed) {
+            try await useCase.execute(currentVersion)
+        }
+    }
+}
+
+private actor AppVersionRepositorySpy: AppVersionRepository {
+    private let result: Result<String, Error>
+    private var count = 0
+
+    init(result: Result<String, Error>) {
+        self.result = result
+    }
+
+    func fetchRequiredVersion() async throws -> String {
+        count += 1
+        return try result.get()
+    }
+
+    func fetchCallCount() -> Int {
+        count
+    }
+}
+
+private enum AppVersionRepositoryTestError: Error {
+    case fetchFailed
+}

--- a/Application/Infra/Sources/InfraAssembler.swift
+++ b/Application/Infra/Sources/InfraAssembler.swift
@@ -16,6 +16,10 @@ public final class InfraAssembler: Assembler {
             FirebaseAppServiceImpl()
         }
 
+        container.register(AppVersionConfigurationService.self) {
+            RemoteConfigAppVersionServiceImpl()
+        }
+
         container.register(AnalyticsService.self) {
             FirebaseAnalyticsServiceImpl()
         }

--- a/Application/Infra/Sources/Service/RemoteConfigAppVersionServiceImpl.swift
+++ b/Application/Infra/Sources/Service/RemoteConfigAppVersionServiceImpl.swift
@@ -1,0 +1,45 @@
+//
+//  RemoteConfigAppVersionServiceImpl.swift
+//  Infra
+//
+//  Created by opfic on 7/22/26.
+//
+
+import Data
+import FirebaseRemoteConfig
+import Foundation
+
+enum AppVersionConfigurationError: Error {
+    case missingRequiredVersion
+}
+
+final class RemoteConfigAppVersionServiceImpl: AppVersionConfigurationService {
+    private enum Key {
+        static let requiredVersion = "ios_required_version"
+    }
+
+    private let remoteConfig = RemoteConfig.remoteConfig()
+
+    init() {
+        remoteConfig.setDefaults([
+            Key.requiredVersion: "" as NSString
+        ])
+    }
+
+    func fetchRequiredVersion() async throws -> String {
+        _ = try? await remoteConfig.fetchAndActivate()
+
+        guard let version = normalizedRequiredVersion() else {
+            throw AppVersionConfigurationError.missingRequiredVersion
+        }
+        return version
+    }
+
+    private func normalizedRequiredVersion() -> String? {
+        let version = remoteConfig
+            .configValue(forKey: Key.requiredVersion)
+            .stringValue
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return version.isEmpty ? nil : version
+    }
+}

--- a/Application/Presentation/Entry/Sources/Root/RootFeature.swift
+++ b/Application/Presentation/Entry/Sources/Root/RootFeature.swift
@@ -21,8 +21,10 @@ struct RootFeature {
 
     @ObservableState
     struct State: Equatable {
-        @Presents var alert: AlertState<Never>?
+        @Presents var alert: AlertState<Action.Alert>?
         @Presents var sheet: SheetState?
+        var hasCheckedAppUpdate = false
+        var isAppUpdateRequired = false
         var isNetworkConnected = true
         var signIn: Bool?
         var theme: SystemTheme = .automatic
@@ -39,7 +41,8 @@ struct RootFeature {
     }
 
     enum Action: BindableAction, Equatable {
-        case alert(PresentationAction<Never>)
+        case alert(PresentationAction<Alert>)
+        case appUpdateCheckCompleted(Bool)
         case binding(BindingAction<State>)
         case sheet(PresentationAction<Sheet>)
         case onAppear
@@ -48,6 +51,10 @@ struct RootFeature {
         case networkStatusChanged(Bool)
         case setTheme(SystemTheme)
         case didLogined(Bool)
+
+        enum Alert: Equatable {
+            case tapUpdateButton
+        }
 
         enum Sheet: Equatable {
             case tapCloseButton
@@ -58,14 +65,22 @@ struct RootFeature {
     @Dependency(\.rootNetworkConnectivityUseCase) var networkConnectivityUseCase
     @Dependency(\.rootSystemThemeUseCase) var systemThemeUseCase
     @Dependency(\.trackAnalyticsEventUseCase) var trackAnalyticsEventUseCase
+    @Dependency(\.checkAppUpdateUseCase) var checkAppUpdateUseCase
+    @Dependency(\.openURL) var openURL
     @Dependency(\.setApplicationBadgeCount) var setApplicationBadgeCount
 
     var body: some ReducerOf<Self> {
         BindingReducer()
         Reduce { state, action in
             switch action {
+            case .alert(.presented(.tapUpdateButton)):
+                return openAppStoreEffect()
             case .alert:
                 break
+            case .appUpdateCheckCompleted(let isRequired):
+                guard isRequired else { break }
+                state.isAppUpdateRequired = true
+                state.alert = Self.appUpdateAlertState()
             case .binding:
                 break
             case .sheet(.dismiss), .sheet(.presented(.tapCloseButton)):
@@ -74,6 +89,11 @@ struct RootFeature {
                 break
             case .onAppear:
                 var effect = clearApplicationBadgeCountEffect()
+
+                if !state.hasCheckedAppUpdate {
+                    state.hasCheckedAppUpdate = true
+                    effect = .merge(effect, checkAppUpdateEffect())
+                }
 
                 if !state.isObservingNetworkConnectivity {
                     state.isObservingNetworkConnectivity = true
@@ -99,8 +119,8 @@ struct RootFeature {
             case .networkStatusChanged(let isConnected):
                 let wasConnected = state.isNetworkConnected
                 state.isNetworkConnected = isConnected
-                if wasConnected && !isConnected {
-                    state.alert = Self.alertState()
+                if wasConnected && !isConnected && !state.isAppUpdateRequired {
+                    state.alert = Self.networkDisconnectedAlertState()
                 }
             case .setTheme(let theme):
                 state.theme = theme
@@ -135,6 +155,11 @@ private struct RootSheetFeature: Reducer {
 }
 
 extension DependencyValues {
+    var checkAppUpdateUseCase: CheckAppUpdateUseCase {
+        get { self[CheckAppUpdateUseCaseKey.self] }
+        set { self[CheckAppUpdateUseCaseKey.self] = newValue }
+    }
+
     var observeAuthSessionUseCase: ObserveAuthSessionUseCase {
         get { self[ObserveAuthSessionUseCaseKey.self] }
         set { self[ObserveAuthSessionUseCaseKey.self] = newValue }
@@ -148,6 +173,16 @@ extension DependencyValues {
     var rootSystemThemeUseCase: ObserveSystemThemeUseCase {
         get { self[RootSystemThemeUseCaseKey.self] }
         set { self[RootSystemThemeUseCaseKey.self] = newValue }
+    }
+}
+
+private enum CheckAppUpdateUseCaseKey: DependencyKey {
+    static var liveValue: CheckAppUpdateUseCase {
+        preconditionFailure("CheckAppUpdateUseCase must be provided.")
+    }
+
+    static var testValue: CheckAppUpdateUseCase {
+        liveValue
     }
 }
 
@@ -182,6 +217,20 @@ private enum RootSystemThemeUseCaseKey: DependencyKey {
 }
 
 private extension RootFeature {
+    func checkAppUpdateEffect() -> Effect<Action> {
+        .run { [checkAppUpdateUseCase] send in
+            let isRequired = (try? await checkAppUpdateUseCase.execute()) ?? false
+            await send(.appUpdateCheckCompleted(isRequired))
+        }
+    }
+
+    func openAppStoreEffect() -> Effect<Action> {
+        .run { [openURL] _ in
+            guard let url = URL(string: "https://apps.apple.com/us/app/devlog/id6760288611") else { return }
+            await openURL(url)
+        }
+    }
+
     func clearApplicationBadgeCountEffect() -> Effect<Action> {
         .run { [setApplicationBadgeCount] _ in
             try? await setApplicationBadgeCount(0)
@@ -220,7 +269,19 @@ private extension RootFeature {
         }
     }
 
-    static func alertState() -> AlertState<Never> {
+    static func appUpdateAlertState() -> AlertState<Action.Alert> {
+        AlertState {
+            TextState(String(localized: "root_app_update_title"))
+        } actions: {
+            ButtonState(action: .tapUpdateButton) {
+                TextState(String(localized: "root_app_update_action"))
+            }
+        } message: {
+            TextState(String(localized: "root_app_update_message"))
+        }
+    }
+
+    static func networkDisconnectedAlertState() -> AlertState<Action.Alert> {
         AlertState {
             TextState(String(localized: "root_network_disconnected_title"))
         } actions: {

--- a/Application/Presentation/Entry/Sources/Root/RootFeature.swift
+++ b/Application/Presentation/Entry/Sources/Root/RootFeature.swift
@@ -66,6 +66,7 @@ struct RootFeature {
     @Dependency(\.rootSystemThemeUseCase) var systemThemeUseCase
     @Dependency(\.trackAnalyticsEventUseCase) var trackAnalyticsEventUseCase
     @Dependency(\.checkAppUpdateUseCase) var checkAppUpdateUseCase
+    @Dependency(\.appStoreURL) var appStoreURL
     @Dependency(\.openURL) var openURL
     @Dependency(\.setApplicationBadgeCount) var setApplicationBadgeCount
 
@@ -155,6 +156,11 @@ private struct RootSheetFeature: Reducer {
 }
 
 extension DependencyValues {
+    var appStoreURL: URL? {
+        get { self[AppStoreURLKey.self] }
+        set { self[AppStoreURLKey.self] = newValue }
+    }
+
     var checkAppUpdateUseCase: CheckAppUpdateUseCase {
         get { self[CheckAppUpdateUseCaseKey.self] }
         set { self[CheckAppUpdateUseCaseKey.self] = newValue }
@@ -174,6 +180,21 @@ extension DependencyValues {
         get { self[RootSystemThemeUseCaseKey.self] }
         set { self[RootSystemThemeUseCaseKey.self] = newValue }
     }
+}
+
+private enum AppStoreURLKey: DependencyKey {
+    static let liveValue = configuredAppStoreURL()
+    static let testValue: URL? = nil
+}
+
+private func configuredAppStoreURL() -> URL? {
+    guard let rawValue = Bundle.main.object(forInfoDictionaryKey: "APP_STORE_URL") as? String else {
+        return nil
+    }
+
+    let urlString = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !urlString.isEmpty, !urlString.hasPrefix("$(") else { return nil }
+    return URL(string: urlString)
 }
 
 private enum CheckAppUpdateUseCaseKey: DependencyKey {
@@ -225,9 +246,9 @@ private extension RootFeature {
     }
 
     func openAppStoreEffect() -> Effect<Action> {
-        .run { [openURL] _ in
-            guard let url = URL(string: "https://apps.apple.com/us/app/devlog/id6760288611") else { return }
-            await openURL(url)
+        .run { [appStoreURL, openURL] _ in
+            guard let appStoreURL else { return }
+            await openURL(appStoreURL)
         }
     }
 

--- a/Application/Presentation/Entry/Sources/Root/RootView.swift
+++ b/Application/Presentation/Entry/Sources/Root/RootView.swift
@@ -24,6 +24,7 @@ public struct RootView: View {
         networkConnectivityUseCase: ObserveNetworkConnectivityUseCase,
         systemThemeUseCase: ObserveSystemThemeUseCase,
         trackAnalyticsEventUseCase: TrackAnalyticsEventUseCase,
+        checkAppUpdateUseCase: CheckAppUpdateUseCase,
         widgetURLTab: @escaping (URL) -> MainTab?,
         windowEvent: TodoEditorWindowEvent,
         pushNotificationTodoIdPublisher: AnyPublisher<String, Never>,
@@ -36,6 +37,7 @@ public struct RootView: View {
             $0.rootNetworkConnectivityUseCase = networkConnectivityUseCase
             $0.rootSystemThemeUseCase = systemThemeUseCase
             $0.trackAnalyticsEventUseCase = trackAnalyticsEventUseCase
+            $0.checkAppUpdateUseCase = checkAppUpdateUseCase
         })
         self.widgetURLTab = widgetURLTab
         self.windowEvent = windowEvent

--- a/Application/Presentation/Entry/Tests/Root/RootFeatureTestSupport.swift
+++ b/Application/Presentation/Entry/Tests/Root/RootFeatureTestSupport.swift
@@ -65,6 +65,7 @@ struct RootStoreTestAdapter: RootStateDriving {
         ),
         trackAnalyticsEventUseCase: TrackAnalyticsEventUseCase = RootTrackAnalyticsEventUseCaseSpy(),
         checkAppUpdateUseCase: CheckAppUpdateUseCase = RootCheckAppUpdateUseCaseSpy(),
+        appStoreURL: URL? = URL(string: "https://apps.apple.com/us/app/devlog/id6760288611"),
         openURLSpy: RootOpenURLSpy = RootOpenURLSpy(),
         badgeCountSpy: RootApplicationBadgeCountSpy = RootApplicationBadgeCountSpy()
     ) {
@@ -76,6 +77,7 @@ struct RootStoreTestAdapter: RootStateDriving {
             $0.rootSystemThemeUseCase = systemThemeUseCase
             $0.trackAnalyticsEventUseCase = trackAnalyticsEventUseCase
             $0.checkAppUpdateUseCase = checkAppUpdateUseCase
+            $0.appStoreURL = appStoreURL
             $0.openURL = .init { url in
                 await openURLSpy.open(url)
                 return true
@@ -338,6 +340,10 @@ actor RootOpenURLSpy {
 
     func openCallCount() -> Int {
         urls.count
+    }
+
+    func openedURLs() -> [URL] {
+        urls
     }
 }
 

--- a/Application/Presentation/Entry/Tests/Root/RootFeatureTestSupport.swift
+++ b/Application/Presentation/Entry/Tests/Root/RootFeatureTestSupport.swift
@@ -27,6 +27,7 @@ protocol RootStateDriving {
     func dismissSheet() async
     func selectMainTab(_ tab: MainTab) async
     func openWidgetRoute(_ tab: MainTab) async
+    func tapUpdateButton() async
 }
 
 struct RootStateSnapshot: Equatable {
@@ -63,6 +64,8 @@ struct RootStoreTestAdapter: RootStateDriving {
             currentValue: .automatic
         ),
         trackAnalyticsEventUseCase: TrackAnalyticsEventUseCase = RootTrackAnalyticsEventUseCaseSpy(),
+        checkAppUpdateUseCase: CheckAppUpdateUseCase = RootCheckAppUpdateUseCaseSpy(),
+        openURLSpy: RootOpenURLSpy = RootOpenURLSpy(),
         badgeCountSpy: RootApplicationBadgeCountSpy = RootApplicationBadgeCountSpy()
     ) {
         store = TestStore(initialState: RootFeature.State()) {
@@ -72,6 +75,11 @@ struct RootStoreTestAdapter: RootStateDriving {
             $0.rootNetworkConnectivityUseCase = networkConnectivityUseCase
             $0.rootSystemThemeUseCase = systemThemeUseCase
             $0.trackAnalyticsEventUseCase = trackAnalyticsEventUseCase
+            $0.checkAppUpdateUseCase = checkAppUpdateUseCase
+            $0.openURL = .init { url in
+                await openURLSpy.open(url)
+                return true
+            }
             $0.setApplicationBadgeCount = { count in
                 try await badgeCountSpy.setBadgeCount(count)
             }
@@ -118,6 +126,10 @@ struct RootStoreTestAdapter: RootStateDriving {
 
     func openWidgetRoute(_ tab: MainTab) async {
         await store.send(.openWidgetRoute(tab))
+    }
+
+    func tapUpdateButton() async {
+        await store.send(.alert(.presented(.tapUpdateButton)))
     }
 
     private func drainReceivedActions() async {
@@ -296,6 +308,36 @@ final class RootTrackAnalyticsEventUseCaseSpy: TrackAnalyticsEventUseCase {
 
     func execute(_ event: AnalyticsEvent) {
         events.append(event)
+    }
+}
+
+actor RootCheckAppUpdateUseCaseSpy: CheckAppUpdateUseCase {
+    private let result: Result<Bool, Error>
+    private var count = 0
+
+    init(result: Result<Bool, Error> = .success(false)) {
+        self.result = result
+    }
+
+    func execute() async throws -> Bool {
+        count += 1
+        return try result.get()
+    }
+
+    func executeCallCount() -> Int {
+        count
+    }
+}
+
+actor RootOpenURLSpy {
+    private var urls = [URL]()
+
+    func open(_ url: URL) {
+        urls.append(url)
+    }
+
+    func openCallCount() -> Int {
+        urls.count
     }
 }
 

--- a/Application/Presentation/Entry/Tests/Root/RootFeatureTests.swift
+++ b/Application/Presentation/Entry/Tests/Root/RootFeatureTests.swift
@@ -104,6 +104,50 @@ struct RootFeatureTests {
         #expect(badgeSpy.counts == [0, 0])
     }
 
+    @Test("RootFeature onAppear는 로그인 상태와 무관하게 업데이트를 한 번만 확인한다")
+    func RootFeature_onAppear는_로그인_상태와_무관하게_업데이트를_한_번만_확인한다() async {
+        let checkSpy = RootCheckAppUpdateUseCaseSpy()
+        let adapter = RootStoreTestAdapter(
+            sessionUseCase: ObserveAuthSessionUseCaseSpy(currentValue: false),
+            checkAppUpdateUseCase: checkSpy
+        )
+
+        await adapter.onAppear()
+        await adapter.onAppear()
+
+        #expect(await checkSpy.executeCallCount() == 1)
+    }
+
+    @Test("필수 업데이트 알림은 네트워크 연결 알림보다 우선한다")
+    func 필수_업데이트_알림은_네트워크_연결_알림보다_우선한다() async {
+        let adapter = RootStoreTestAdapter(
+            networkConnectivityUseCase: RootObserveNetworkConnectivityUseCaseSpy(currentValue: false),
+            checkAppUpdateUseCase: RootCheckAppUpdateUseCaseSpy(result: .success(true))
+        )
+
+        await adapter.onAppear()
+
+        #expect(adapter.snapshot.alertTitle == String(localized: "root_app_update_title"))
+        #expect(adapter.snapshot.alertMessage == String(localized: "root_app_update_message"))
+    }
+
+    @Test("업데이트 버튼은 App Store 열기를 요청한다")
+    func 업데이트_버튼은_App_Store_열기를_요청한다() async {
+        let openSpy = RootOpenURLSpy()
+        let adapter = RootStoreTestAdapter(
+            checkAppUpdateUseCase: RootCheckAppUpdateUseCaseSpy(result: .success(true)),
+            openURLSpy: openSpy
+        )
+
+        await adapter.onAppear()
+        await adapter.tapUpdateButton()
+        await waitUntil {
+            await openSpy.openCallCount() == 1
+        }
+
+        #expect(await openSpy.openCallCount() == 1)
+    }
+
     @Test("RootFeature는 TodoDetail sheet 표시와 해제를 store state로 관리한다")
     func RootFeature는_TodoDetail_sheet_표시와_해제를_store_state로_관리한다() async {
         let adapter = RootStoreTestAdapter()

--- a/Application/Presentation/Entry/Tests/Root/RootFeatureTests.swift
+++ b/Application/Presentation/Entry/Tests/Root/RootFeatureTests.swift
@@ -6,6 +6,7 @@
 //
 
 import Core
+import Foundation
 import Testing
 
 @MainActor

--- a/Application/Presentation/Entry/Tests/Root/RootFeatureTests.swift
+++ b/Application/Presentation/Entry/Tests/Root/RootFeatureTests.swift
@@ -132,10 +132,12 @@ struct RootFeatureTests {
     }
 
     @Test("업데이트 버튼은 App Store 열기를 요청한다")
-    func 업데이트_버튼은_App_Store_열기를_요청한다() async {
+    func 업데이트_버튼은_App_Store_열기를_요청한다() async throws {
+        let appStoreURL = try #require(URL(string: "https://apps.apple.com/us/app/devlog/id6760288611"))
         let openSpy = RootOpenURLSpy()
         let adapter = RootStoreTestAdapter(
             checkAppUpdateUseCase: RootCheckAppUpdateUseCaseSpy(result: .success(true)),
+            appStoreURL: appStoreURL,
             openURLSpy: openSpy
         )
 
@@ -146,6 +148,7 @@ struct RootFeatureTests {
         }
 
         #expect(await openSpy.openCallCount() == 1)
+        #expect(await openSpy.openedURLs() == [appStoreURL])
     }
 
     @Test("RootFeature는 TodoDetail sheet 표시와 해제를 store state로 관리한다")

--- a/Application/Presentation/Entry/Tests/Support/EntryTestSupport.swift
+++ b/Application/Presentation/Entry/Tests/Support/EntryTestSupport.swift
@@ -11,12 +11,12 @@ import Domain
 func waitUntil(
     timeout: Duration = .seconds(1),
     pollInterval: Duration = .milliseconds(20),
-    _ condition: @escaping () -> Bool
+    _ condition: @escaping () async -> Bool
 ) async {
     let continuousClock = ContinuousClock()
     let deadline = continuousClock.now + timeout
 
-    while !condition() && continuousClock.now < deadline {
+    while !(await condition()) && continuousClock.now < deadline {
         try? await Task.sleep(for: pollInterval)
     }
 }

--- a/Tuist/ProjectDescriptionHelpers/Project+Packages.swift
+++ b/Tuist/ProjectDescriptionHelpers/Project+Packages.swift
@@ -36,6 +36,7 @@ public enum DevLogPackages {
         .package(product: "FirebaseCrashlytics"),
         .package(product: "FirebaseMessaging"),
         .package(product: "FirebaseFirestore"),
+        .package(product: "FirebaseRemoteConfig"),
         .package(product: "Nexa"),
     ]
 


### PR DESCRIPTION
## 🔗 연관된 이슈

- closed #755

## 🎯 의도

- 앱 최초 실행 시 로그인 여부와 관계없이 필수 업데이트 필요 여부 확인
- 앱 버전보다 Remote Config의 필수 버전이 높은 경우 업데이트 알림 표시
- 업데이트 버튼을 통한 App Store 이동 경로 구성

## 📝 작업 내용

### 📌 요약

- Remote Config의 `ios_required_version` 조회 기능 추가
- `AppVersionConfigurationService` → `AppVersionRepository` → `CheckAppUpdateUseCase` 계층 구성
- 마케팅 버전과 빌드 번호를 포함한 앱 버전 비교 기능 추가
- `RootFeature` 최초 진입 시 한 번만 업데이트를 확인하는 처리 추가
- 필수 업데이트 알림과 App Store 이동 처리 추가
- App Store URL의 `Config.xcconfig` 설정 분리
- 버전 조회·비교·알림 동작 테스트 추가

### 🔍 상세

- `FirebaseRemoteConfig` 제품 의존성과 Infra 구현 등록
- Remote Config의 `ios_required_version` 값을 `마케팅 버전.빌드 번호` 형식으로 사용
  - 예시: 마케팅 버전 `1.5`, 빌드 번호 `127`인 경우 `1.5.127`
- `CFBundleShortVersionString`과 `CFBundleVersion`을 조합한 현재 앱 버전 생성
- 버전 구성 요소를 숫자 단위로 비교하는 `AppVersion` 추가
- Remote Config fetch 실패 시 기존 활성값 사용
- 활성값이 없거나 버전 형식이 잘못된 경우 업데이트 알림을 표시하지 않는 처리
- `RootFeature.onAppear`에서 로그인 상태와 무관하게 업데이트 확인을 한 번만 수행
- 필수 업데이트 알림을 네트워크 연결 알림보다 우선하여 표시
- 업데이트 버튼 선택 시 `APP_STORE_URL`로 이동
- `Info.plist`의 `APP_STORE_URL`을 `$(APP_STORE_URL)`과 연결
- 한국어·영어 업데이트 알림 문구 추가
- `DomainTests` target 활성화 및 Data·Domain·Entry 테스트 추가

운영 설정 필요 항목:

- Firebase Remote Config의 `ios_required_version`
- private `Config.xcconfig`의 `APP_STORE_URL`

## 📸 영상 / 이미지 (Optional)

- 없음