### PR TITLE
[#738] 푸시 알림 설정 화면의 문구를 수정한다

### DIFF
--- a/Application/App/Sources/Resource/Localizable.xcstrings
+++ b/Application/App/Sources/Resource/Localizable.xcstrings
@@ -1193,13 +1193,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Enable Push Notifications"
+            "value" : "Push Notifications"
           }
         },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "푸시 알람 활성화"
+            "value" : "푸시 알람"
           }
         }
       }


### PR DESCRIPTION
## 🔗 연관된 이슈
- closed #738

## 🎯 의도
- 푸시 알림 설정 문구에서 불필요한 표현 제거
- 한국어와 영어 문구 간결화

## 📝 작업 내용

### 📌 요약
- `push_settings_enable`의 한국어 및 영어 번역 수정

### 🔍 상세
- `Enable Push Notifications`를 `Push Notifications`로 변경
- `푸시 알람 활성화`를 `푸시 알람`으로 변경
- 문자열 키와 설정 동작은 기존 형태 유지
- `jq empty`, `git diff --check origin/develop...HEAD` 검증 완료

## 📸 영상 / 이미지 (Optional)
- 문구 변경으로 별도 영상 및 이미지 없음