### PR TITLE
[#739] Todo 마감일을 수정 후 저장 전 원본 데이터와 동일해도 체크 버튼이 눌리는 현상을 해결한다

### DIFF
--- a/Application/Presentation/PresentationShared/Sources/Todo/Editor/TodoEditorFeature.swift
+++ b/Application/Presentation/PresentationShared/Sources/Todo/Editor/TodoEditorFeature.swift
@@ -55,7 +55,13 @@ public struct TodoEditorFeature {
         }
         public var hasChanges: Bool {
             guard let originalDraft else { return true }
-            return originalDraft != makeTodoDraft(now: Date())
+            var draft = makeTodoDraft(now: Date())
+            if let originalDueDate = originalDraft.dueDate,
+               let dueDate = draft.dueDate,
+               Calendar.current.isDate(originalDueDate, inSameDayAs: dueDate) {
+                draft.dueDate = originalDueDate
+            }
+            return originalDraft != draft
         }
         public var isReadyToSubmit: Bool {
             isValidToSave && hasChanges

--- a/Application/Presentation/PresentationShared/Tests/Todo/TodoEditorFeatureTests.swift
+++ b/Application/Presentation/PresentationShared/Tests/Todo/TodoEditorFeatureTests.swift
@@ -56,6 +56,27 @@ struct TodoEditorFeatureTests {
         #expect(adapter.isReadyToSubmit)
     }
 
+    @Test("마감일을 원본과 같은 날짜로 되돌리면 변경되지 않은 상태가 된다")
+    func 마감일을_원본과_같은_날짜로_되돌리면_변경되지_않은_상태가_된다() async throws {
+        let calendar = Calendar.current
+        let day = calendar.startOfDay(for: Date(timeIntervalSince1970: 4_102_444_800))
+        let originalDueDate = day.addingTimeInterval(43_200)
+        let restoredDueDate = day.addingTimeInterval(3_600)
+        let changedDueDate = try #require(calendar.date(byAdding: .day, value: 1, to: originalDueDate))
+        let todo = makeTodoEditorTodo(title: "Original", dueDate: originalDueDate)
+        let adapter = TodoEditorStoreTestAdapter(todo: todo)
+
+        await adapter.setDueDate(changedDueDate)
+
+        #expect(adapter.hasChanges)
+        #expect(adapter.isReadyToSubmit)
+
+        await adapter.setDueDate(restoredDueDate)
+
+        #expect(adapter.hasChanges == false)
+        #expect(adapter.isReadyToSubmit == false)
+    }
+
     @Test("onAppear는 Todo 카테고리 설정을 가져와 상태에 반영한다")
     func onAppear는_Todo_카테고리_설정을_가져와_상태에_반영한다() async {
         let fetchSpy = TodoEditorFetchPreferencesUseCaseSpy(preferences: [


### PR DESCRIPTION
## 🔗 연관된 이슈
- closed #739

## 🎯 의도
- 마감일을 다른 날짜로 변경한 뒤 원래 날짜로 되돌렸을 때 시각 차이만으로 저장 버튼이 활성화되는 문제 해결

## 📝 작업 내용

### 📌 요약
- `TodoEditorFeature.State.hasChanges`의 마감일 변경 여부를 날짜 단위로 판정
- 동일 날짜 복귀 동작을 검증하는 회귀 테스트 추가

### 🔍 상세
- 원본과 편집 중인 `dueDate`가 같은 날짜면 비교용 `TodoDraft`의 값을 원본으로 맞춘 뒤 기존 `Equatable` 비교 수행
- 다른 날짜 또는 `nil` 변경은 기존과 같이 변경으로 판정
- `makeTodoDraft` 저장 경로와 `TodoDraft` 동등성 동작 유지
- 변경 파일 SwiftLint 위반 0건 확인
- `PresentationShared` `build-for-testing` 종료 코드 0 확인
- `git diff --check` 통과

## 📸 영상 / 이미지 (Optional)
- 없음