### PR TITLE
[#762] 업데이트 얼럿 문구 및 문자열 카탈로그 상태 정리

### DIFF
--- a/Application/App/Sources/Resource/Localizable.xcstrings
+++ b/Application/App/Sources/Resource/Localizable.xcstrings
@@ -1479,14 +1479,14 @@
       "localizations" : {
         "en" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Update to the latest version to continue using DevLog."
           }
         },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "DevLog를 계속 사용하려면 최신 버전으로 업데이트해주세요."
+            "value" : "DevLog를 계속 사용하려면 최신 버전으로 업데이트 해주세요."
           }
         }
       }

--- a/Application/App/Sources/Resource/Localizable.xcstrings
+++ b/Application/App/Sources/Resource/Localizable.xcstrings
@@ -1,42 +1,6 @@
 {
   "sourceLanguage" : "ko",
   "strings" : {
-    "" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : ""
-          }
-        }
-      },
-      "shouldTranslate" : false
-    },
-    "#%lld" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "#%lld"
-          }
-        }
-      },
-      "shouldTranslate" : false
-    },
-    "%lld" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld"
-          }
-        }
-      },
-      "shouldTranslate" : false
-    },
     "account_alert_already_linked_message" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -565,7 +529,7 @@
       }
     },
     "https://" : {
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -2531,7 +2495,7 @@
       }
     },
     "TODO" : {
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -2577,7 +2541,7 @@
     },
     "todo_category_doc" : {
       "comment" : "Todo category: Documentation",
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -2595,7 +2559,7 @@
     },
     "todo_category_etc" : {
       "comment" : "Todo category: Etc",
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -2613,7 +2577,7 @@
     },
     "todo_category_feature" : {
       "comment" : "Todo category: Feature",
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -2631,7 +2595,7 @@
     },
     "todo_category_improvement" : {
       "comment" : "Todo category: Improvement",
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -2649,7 +2613,7 @@
     },
     "todo_category_issue" : {
       "comment" : "Todo category: Issue",
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -2667,7 +2631,7 @@
     },
     "todo_category_research" : {
       "comment" : "Todo category: Research",
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -2685,7 +2649,7 @@
     },
     "todo_category_review" : {
       "comment" : "Todo category: Review",
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -2703,7 +2667,7 @@
     },
     "todo_category_test" : {
       "comment" : "Todo category: Test",
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -3536,7 +3500,7 @@
       }
     },
     "Todos" : {
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -3547,7 +3511,7 @@
       }
     },
     "Web Page" : {
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -3558,7 +3522,7 @@
       }
     },
     "Web Pages" : {
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {


### PR DESCRIPTION
## 🔗 연관된 이슈

- closed #762

## 🎯 의도

- 업데이트 얼럿 한국어 문구의 띄어쓰기 수정
- 사용 중인 문자열 키의 `stale` 상태 재발 방지

## 📝 작업 내용

### 📌 요약

- `root_app_update_message` 한국어 문구 수정
- 사용 중인 `stale` 키 13개의 `manual` 전환
- 번역 대상이 아닌 빈 문자열 및 형식 키 3개의 제거

### 🔍 상세

- 한국어 문구 변경
  - `DevLog를 계속 사용하려면 최신 버전으로 업데이트해주세요.`
  - `DevLog를 계속 사용하려면 최신 버전으로 업데이트 해주세요.`
- 한국어 원문 변경에 따른 영어 번역 상태의 `needs_review` 전환
- `https://`, `TODO`, Todo 카테고리, `Todos`, `Web Page`, `Web Pages` 키의 `manual` 전환
- `""`, `#%lld`, `%lld` 키 제거

## 📸 영상 / 이미지 (Optional)