### PR TITLE
[#767] iOS 17에서 스크롤을 해도 NavigationTitle이 large로 고정되는 현상을 해결한다

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,3 +24,4 @@
 - For a delegated role, read `.agents/roles.md` and follow the assigned role section and output format.
 - Use `.agents/workflows.md` when the task matches one of its executable workflows.
 - If repository-local instructions conflict with global memory, follow the repository-local instructions.
+- Write DevLog PR and review text in Korean.

--- a/Application/Presentation/NotificationTab/Sources/PushNotification/PushNotificationListView.swift
+++ b/Application/Presentation/NotificationTab/Sources/PushNotification/PushNotificationListView.swift
@@ -157,81 +157,78 @@ public struct PushNotificationListView: View {
     }
 
     private var headerView: some View {
-        ScrollView(.horizontal) {
-            HStack(spacing: 8) {
-                if 0 < store.appliedFilterCount {
-                    Menu {
-                        Text(
-                            String.localizedStringWithFormat(
-                                String(localized: "push_filters_applied_format"),
-                                Int64(store.appliedFilterCount)
-                            )
-                        )
-                        Button(role: .destructive) {
-                            store.send(.view(.resetFilters))
-                        } label: {
-                            Text(String(localized: "push_clear_all_filters"))
-                        }
-                    } label: {
-                        HStack(spacing: 6) {
-                            Image(systemName: "line.3.horizontal.decrease")
-                            filterBadge
-                        }
-                        .adaptiveButtonStyle()
-                    }
-                }
-
-                Button {
-                    DispatchQueue.main.async {
-                        store.send(.view(.toggleSortOption))
-                    }
-                } label: {
-                    let condition = store.query.sortOrder == .oldest
+        HStack(spacing: 8) {
+            if 0 < store.appliedFilterCount {
+                Menu {
                     Text(
                         String.localizedStringWithFormat(
-                            String(localized: "push_sort_format"),
-                            store.query.sortOrder.title
+                            String(localized: "push_filters_applied_format"),
+                            Int64(store.appliedFilterCount)
                         )
                     )
+                    Button(role: .destructive) {
+                        store.send(.view(.resetFilters))
+                    } label: {
+                        Text(String(localized: "push_clear_all_filters"))
+                    }
+                } label: {
+                    HStack(spacing: 6) {
+                        Image(systemName: "line.3.horizontal.decrease")
+                        filterBadge
+                    }
+                    .adaptiveButtonStyle()
+                }
+            }
+
+            Button {
+                DispatchQueue.main.async {
+                    store.send(.view(.toggleSortOption))
+                }
+            } label: {
+                let condition = store.query.sortOrder == .oldest
+                Text(
+                    String.localizedStringWithFormat(
+                        String(localized: "push_sort_format"),
+                        store.query.sortOrder.title
+                    )
+                )
+                .foregroundStyle(condition ? .white : Color(.label))
+                .adaptiveButtonStyle(color: condition ? .blue : .clear)
+            }
+            .frame(height: headerHeight)
+
+            Menu {
+                Picker(selection: $store.query.timeFilter) {
+                    ForEach(PushNotificationQuery.TimeFilter.availableOptions, id: \.self) { option in
+                        Text(option.title).tag(option)
+                    }
+                } label: {
+                    Text(String(localized: "push_period"))
+                }
+            } label: {
+                let condition = store.query.timeFilter == .none
+                HStack {
+                    Text(String(localized: "push_period"))
+                    Image(systemName: "chevron.down")
+                }
+                .foregroundStyle(condition ? Color(.label) : .white)
+                .adaptiveButtonStyle(color: condition ? .clear : .blue)
+            }
+
+            Button {
+                DispatchQueue.main.async {
+                    store.send(.view(.toggleUnreadOnly))
+                }
+            } label: {
+                let condition = store.query.unreadOnly
+                Text(String(localized: "push_unread"))
                     .foregroundStyle(condition ? .white : Color(.label))
                     .adaptiveButtonStyle(color: condition ? .blue : .clear)
-                }
-                .frame(height: headerHeight)
-
-                Menu {
-                    Picker(selection: $store.query.timeFilter) {
-                        ForEach(PushNotificationQuery.TimeFilter.availableOptions, id: \.self) { option in
-                            Text(option.title).tag(option)
-                        }
-                    } label: {
-                        Text(String(localized: "push_period"))
-                    }
-                } label: {
-                    let condition = store.query.timeFilter == .none
-                    HStack {
-                        Text(String(localized: "push_period"))
-                        Image(systemName: "chevron.down")
-                    }
-                    .foregroundStyle(condition ? Color(.label) : .white)
-                    .adaptiveButtonStyle(color: condition ? .clear : .blue)
-                }
-
-                Button {
-                    DispatchQueue.main.async {
-                        store.send(.view(.toggleUnreadOnly))
-                    }
-                } label: {
-                    let condition = store.query.unreadOnly
-                    Text(String(localized: "push_unread"))
-                        .foregroundStyle(condition ? .white : Color(.label))
-                        .adaptiveButtonStyle(color: condition ? .blue : .clear)
-                }
-                .frame(height: headerHeight)
             }
+            .frame(height: headerHeight)
         }
-        .scrollIndicators(.never)
-        .scrollDisabled(!isScrollTrackingEnabled)
-        .contentMargins(.leading, 16, for: .scrollContent)
+        .padding(.leading, 16)
+        .frame(maxWidth: .infinity, alignment: .leading)
         .frame(height: headerHeight)
         .onAppear {
             headerOffset = 0


### PR DESCRIPTION
## 🔗 연관된 이슈
- closed #767

## 🎯 의도

`PushNotificationListView`의 헤더에 배치된 가로 `ScrollView`가 목록의 스크롤 인식을 방해하여 iOS 17에서 `NavigationTitle`이 large 상태로 고정되는 현상 해결

## 📝 작업 내용

### 📌 요약

- `headerView`의 `ScrollView(.horizontal)` 제거
- 기존 헤더 구성과 사용자 동작 유지

### 🔍 상세

- 헤더의 최상위 컨테이너를 `HStack`으로 변경
- 기존 leading 여백과 헤더 높이 유지

## 📸 영상 / 이미지 (Optional)

- 없음