### PR TITLE
[#772] 계정 연동 해제 시 ProgressView 위치가 이동하는 현상을 해결한다

### DIFF
--- a/Application/Presentation/ProfileTab/Sources/Settings/AccountView.swift
+++ b/Application/Presentation/ProfileTab/Sources/Settings/AccountView.swift
@@ -53,7 +53,7 @@ struct AccountView: View {
                             (!isConnected && store.presentationContext == nil)
                         )
                         .opacity(showProgressView ? 0 : 1)
-                        .overlay {
+                        .overlay(alignment: .trailing) {
                             if showProgressView {
                                 ProgressView()
                             }


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #772 

## 🎯 의도
- 계정 연동 시 ProgrssView가 `연동`, `연동 해제` 각 버튼의 중앙에 위치함에 따라 위치가 변하는것을 해결

## 📝 작업 내용

### 📌 요약
- alignment: .trailing 추가해서 우측 정렬화

### 🔍 상세
- alignment: .trailing 추가해서 우측 정렬화

## 📸 영상 / 이미지 (Optional)

<img width="300"  alt="image" src="https://github.com/user-attachments/assets/ddf8f658-93e0-4bf2-90be-3c5cd49a0d9a" />