### PR TITLE
[#779] iOS 18 이상에서 PushNotificationTab의 헤더가 스크롤되지 않는 현상을 해결한다

### DIFF
--- a/Application/Presentation/NotificationTab/Sources/PushNotification/PushNotificationListView.swift
+++ b/Application/Presentation/NotificationTab/Sources/PushNotification/PushNotificationListView.swift
@@ -161,6 +161,30 @@ public struct PushNotificationListView: View {
     }
 
     private var headerView: some View {
+        Group {
+            if #available(iOS 18.0, *) {
+                ScrollView(.horizontal) {
+                    headerContent
+                }
+                .scrollIndicators(.never)
+                .contentMargins(.leading, 16, for: .scrollContent)
+            } else {
+                headerContent
+                    .padding(.leading, 16)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .frame(height: headerHeight)
+        .onAppear {
+            headerOffset = 0
+            isScrollTrackingEnabled = false
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                isScrollTrackingEnabled = true
+            }
+        }
+    }
+
+    private var headerContent: some View {
         HStack(spacing: 8) {
             if 0 < store.appliedFilterCount {
                 Menu {
@@ -230,16 +254,6 @@ public struct PushNotificationListView: View {
                     .adaptiveButtonStyle(color: condition ? .blue : .clear)
             }
             .frame(height: headerHeight)
-        }
-        .padding(.leading, 16)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .frame(height: headerHeight)
-        .onAppear {
-            headerOffset = 0
-            isScrollTrackingEnabled = false
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                isScrollTrackingEnabled = true
-            }
         }
     }
 


### PR DESCRIPTION
## 🔗 연관된 이슈
<!-- 이슈 번호를 입력해주세요. (예: #12) -->
<!-- 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요. -->
- closed #779 

## 🎯 의도

- iOS 17에서는 기존 헤더 구조를 유지하고, iOS 18 이상에서만 헤더 가로 스크롤을 제공하기 위한 변경

## 📝 작업 내용

### 📌 요약

- `PushNotificationListView` 헤더의 iOS 버전별 구성 분리
- 공통 헤더 내용을 `headerContent`로 분리해 중복 방지

### 🔍 상세

- iOS 18 이상에서 `ScrollView(.horizontal)` 적용
- 가로 스크롤 표시기 제거 및 왼쪽 `contentMargins` 적용
- iOS 17에서 `ScrollView` 없이 `headerContent`와 기존 왼쪽 여백 유지
- 공통 `frame`, `headerOffset`, `isScrollTrackingEnabled` 처리 유지