### PR TITLE
[#778] PushNotificationTab에서 refreshable이 수행되면 앱이 강제종료되는 현상을 해결한다

### DIFF
--- a/Application/Presentation/NotificationTab/Sources/PushNotification/View+Refreshable.swift
+++ b/Application/Presentation/NotificationTab/Sources/PushNotification/View+Refreshable.swift
@@ -21,10 +21,10 @@ extension View {
     @ViewBuilder
     func refreshable(
         isEnabled: Bool,
-        action: @escaping @Sendable () async -> Void
+        action: @escaping @MainActor @Sendable () async -> Void
     ) -> some View {
         if isEnabled {
-            refreshable(action: action)
+            refreshable { await action() }
         } else {
             self
         }


### PR DESCRIPTION
## 🔗 연관된 이슈
- closed #778

## 🎯 의도
- `refreshable` 액션의 `MainActor` 격리 누락으로 `Store.send`가 비동기 작업 실행 큐에서 호출되어 앱이 중단되는 문제 해결

## 📝 작업 내용

### 📌 요약
- 기존 `@Sendable` 액션에 `@MainActor` 격리 추가
- SwiftUI `.refreshable` 내부에서 `await action()`을 호출하도록 변경

### 🔍 상세
- `PushNotificationListView`의 `.refresh`와 `.startObserving` 호출이 `MainActor`에서 수행되도록 보장
- TCA 내부 `send` 구현과 푸시 알림 갱신 순서는 변경하지 않음
- 변경 파일 SwiftLint 위반 0건
- `git diff --check` 통과
- Xcode `App` 빌드 성공
- 앱 실행 기반 재현 확인 미수행

## 📸 영상 / 이미지 (Optional)
- 해당 없음