### PR TITLE
[#785] 배포 Lane이 실패하는 현상을 해결한다

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -83,36 +83,6 @@ rescue SystemCallError => error
   UI.user_error!("Could not read app configuration file at #{expanded_path}: #{error.message}")
 end
 
-def expected_firebase_configuration_from_xcconfig(configuration)
-  expanded_path = File.expand_path(APP_CONFIG_XCCONFIG_PATH)
-  UI.user_error!("Missing app configuration file: #{expanded_path}") if !File.file?(expanded_path)
-
-  escaped_configuration = Regexp.escape(configuration)
-  expected_settings = {
-    firebase_project_id: "EXPECTED_FIREBASE_PROJECT_ID",
-    google_app_id: "EXPECTED_GOOGLE_APP_ID"
-  }
-
-  expected_settings.to_h do |key, setting|
-    assignments = File.foreach(expanded_path).filter_map do |line|
-      assignment = line.match(
-        /^\s*#{setting}\s*\[\s*config\s*=\s*#{escaped_configuration}\s*\]\s*=\s*(.*)$/
-      )
-      next if assignment.nil?
-
-      assignment[1].strip
-    end
-
-    if assignments.empty? || assignments.last.empty?
-      UI.user_error!("Missing #{setting} for #{configuration} in #{expanded_path}")
-    end
-
-    [key, assignments.last]
-  end
-rescue SystemCallError => error
-  UI.user_error!("Could not read app configuration file at #{expanded_path}: #{error.message}")
-end
-
 def expected_google_sign_in_configuration_from_xcconfig(configuration)
   expanded_path = File.expand_path(APP_CONFIG_XCCONFIG_PATH)
   UI.user_error!("Missing app configuration file: #{expanded_path}") if !File.file?(expanded_path)
@@ -268,13 +238,6 @@ platform :ios do
       end
     end
 
-    expected_firebase_project_id = expected_configuration[:firebase_project_id].to_s.strip
-    expected_google_app_id = expected_configuration[:google_app_id].to_s.strip
-
-    if expected_firebase_project_id.empty? != expected_google_app_id.empty?
-      UI.user_error!("Expected Firebase PROJECT_ID and GOOGLE_APP_ID must be provided together")
-    end
-
     Dir.mktmpdir("devlog-ipa") do |tmpdir|
       sh("unzip -q #{Shellwords.escape(ipa_path)} -d #{Shellwords.escape(tmpdir)}")
 
@@ -348,18 +311,6 @@ platform :ios do
         expected: "true"
       )
 
-      actual_firebase_project_id = required_plist_value(
-        path: google_service_info_plist_path,
-        source: "GoogleService-Info.plist",
-        key: "PROJECT_ID"
-      )
-
-      actual_google_app_id = required_plist_value(
-        path: google_service_info_plist_path,
-        source: "GoogleService-Info.plist",
-        key: "GOOGLE_APP_ID"
-      )
-
       verify_plist_value(
         path: google_service_info_plist_path,
         source: "GoogleService-Info.plist",
@@ -383,16 +334,6 @@ platform :ios do
         redact_values: true
       )
 
-      if !expected_firebase_project_id.empty? && actual_firebase_project_id != expected_firebase_project_id
-        UI.user_error!("Unexpected PROJECT_ID in GoogleService-Info.plist")
-      end
-
-      if !expected_google_app_id.empty? && actual_google_app_id != expected_google_app_id
-        UI.user_error!("Unexpected GOOGLE_APP_ID in GoogleService-Info.plist")
-      end
-
-      UI.message("Verified PROJECT_ID in GoogleService-Info.plist")
-      UI.message("Verified GOOGLE_APP_ID in GoogleService-Info.plist")
     end
   end
 
@@ -493,7 +434,6 @@ platform :ios do
       function_api_base_url: expected_function_api_base_url
     )
 
-    firebase_configuration = expected_firebase_configuration_from_xcconfig(configuration)
     google_sign_in_configuration = expected_google_sign_in_configuration_from_xcconfig(configuration)
 
     if ENV["FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT"].to_s.strip.empty?
@@ -587,8 +527,6 @@ platform :ios do
         bundle_id: APP_IDENTIFIER,
         database_id: expected_database_id,
         function_api_base_url: expected_function_api_base_url,
-        firebase_project_id: firebase_configuration[:firebase_project_id],
-        google_app_id: firebase_configuration[:google_app_id],
         client_id: google_sign_in_configuration[:client_id],
         reversed_client_id: google_sign_in_configuration[:reversed_client_id],
         server_client_id: google_sign_in_configuration[:server_client_id]
@@ -656,7 +594,6 @@ platform :ios do
 
   lane :upload_testflight_build do
     api_key = asc_api_key
-    firebase_configuration = expected_firebase_configuration_from_xcconfig(TESTFLIGHT_CONFIGURATION)
     google_sign_in_configuration = expected_google_sign_in_configuration_from_xcconfig(TESTFLIGHT_CONFIGURATION)
     # lane_context는 같은 fastlane 실행 내에서만 유지되므로, 별도 CI step에서는 고정 ipa 경로를 사용한다.
     ipa_output_path = lane_context[SharedValues::IPA_OUTPUT_PATH].to_s
@@ -671,8 +608,6 @@ platform :ios do
         bundle_id: APP_IDENTIFIER,
         database_id: TESTFLIGHT_DATABASE_ID,
         function_api_base_url: function_api_base_url_from_xcconfig(TESTFLIGHT_CONFIGURATION),
-        firebase_project_id: firebase_configuration[:firebase_project_id],
-        google_app_id: firebase_configuration[:google_app_id],
         client_id: google_sign_in_configuration[:client_id],
         reversed_client_id: google_sign_in_configuration[:reversed_client_id],
         server_client_id: google_sign_in_configuration[:server_client_id]
@@ -688,7 +623,6 @@ platform :ios do
 
   lane :upload_appstore_build do
     api_key = asc_api_key
-    firebase_configuration = expected_firebase_configuration_from_xcconfig(APPSTORE_CONFIGURATION)
     google_sign_in_configuration = expected_google_sign_in_configuration_from_xcconfig(APPSTORE_CONFIGURATION)
     # lane_context는 같은 fastlane 실행 내에서만 유지되므로, 별도 CI step에서는 고정 ipa 경로를 사용한다.
     ipa_output_path = lane_context[SharedValues::IPA_OUTPUT_PATH].to_s
@@ -703,8 +637,6 @@ platform :ios do
         bundle_id: APP_IDENTIFIER,
         database_id: APPSTORE_DATABASE_ID,
         function_api_base_url: function_api_base_url_from_xcconfig(APPSTORE_CONFIGURATION),
-        firebase_project_id: firebase_configuration[:firebase_project_id],
-        google_app_id: firebase_configuration[:google_app_id],
         client_id: google_sign_in_configuration[:client_id],
         reversed_client_id: google_sign_in_configuration[:reversed_client_id],
         server_client_id: google_sign_in_configuration[:server_client_id]

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -311,6 +311,18 @@ platform :ios do
         expected: "true"
       )
 
+      required_plist_value(
+        path: google_service_info_plist_path,
+        source: "GoogleService-Info.plist",
+        key: "PROJECT_ID"
+      )
+
+      required_plist_value(
+        path: google_service_info_plist_path,
+        source: "GoogleService-Info.plist",
+        key: "GOOGLE_APP_ID"
+      )
+
       verify_plist_value(
         path: google_service_info_plist_path,
         source: "GoogleService-Info.plist",
@@ -334,6 +346,8 @@ platform :ios do
         redact_values: true
       )
 
+      UI.message("Verified PROJECT_ID in GoogleService-Info.plist")
+      UI.message("Verified GOOGLE_APP_ID in GoogleService-Info.plist")
     end
   end
 


### PR DESCRIPTION
## 🔗 연관된 이슈

- closed #785

## 🎯 의도

TestFlight 배포 Lane이 `Config.xcconfig`의 레거시 Firebase 기대 키를 요구하여 실패하던 문제 해결 및 TestFlight/App Store 배포에 필요한 설정만 검증하도록 범위 정리

## 📝 작업 내용

### 📌 요약

- `EXPECTED_FIREBASE_PROJECT_ID`, `EXPECTED_GOOGLE_APP_ID` 기반 레거시 검증 제거
- 배포에 필요한 Firebase 설정과 IPA 필수 키 검증 유지
- TestFlight/App Store 배포 Lane의 검증 기준 통일

### 🔍 상세

- `expected_firebase_configuration_from_xcconfig` 제거
- Firebase 프로젝트 ID와 Google App ID의 기대값 파싱 및 일치 비교 제거
- `GoogleService-Info.plist`의 `PROJECT_ID`, `GOOGLE_APP_ID` 존재 여부 검증 유지
- Functions URL, database ID, bundle ID, OAuth 설정, URL scheme, 앱 환경 및 Crashlytics 검증 유지
- TestFlight/App Store 업로드 단계의 레거시 기대값 전달 코드 제거
- 수정 커밋 기준 [iOS TestFlight 실행 30597550752](https://github.com/opficdev/DevLog_iOS/actions/runs/30597550752) 성공
- App Store 배포 Lane 미실행

## 📸 영상 / 이미지 (Optional)

- 해당 없음