### PR TITLE
feat: 태그 복사 메뉴 추가

### DIFF
--- a/Application/App/Sources/Resource/Localizable.xcstrings
+++ b/Application/App/Sources/Resource/Localizable.xcstrings
@@ -290,6 +290,23 @@
         }
       }
     },
+    "common_copy" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copy"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "복사"
+          }
+        }
+      }
+    },
     "common_delete" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Application/Presentation/PresentationShared/Sources/Common/Component/TagCopyMenuView.swift
+++ b/Application/Presentation/PresentationShared/Sources/Common/Component/TagCopyMenuView.swift
@@ -1,0 +1,120 @@
+//
+//  TagCopyMenuView.swift
+//  PresentationShared
+//
+//  Created by opfic on 8/9/26.
+//
+
+import SwiftUI
+import UIKit
+
+struct TagCopyMenuView: UIViewRepresentable {
+    let tagText: String
+
+    func makeCoordinator() -> TagCopyMenuCoordinator {
+        TagCopyMenuCoordinator()
+    }
+
+    func makeUIView(context: Context) -> UIView {
+        let view = UIView()
+        view.backgroundColor = .clear
+        view.isAccessibilityElement = false
+        context.coordinator.install(on: view)
+        context.coordinator.tagText = tagText
+        return view
+    }
+
+    func updateUIView(_ view: UIView, context: Context) {
+        context.coordinator.tagText = tagText
+    }
+}
+
+final class TagCopyMenuCoordinator: NSObject {
+    var tagText = ""
+    private weak var view: UIView?
+    private var editMenuInteraction: UIEditMenuInteraction?
+
+    func install(on view: UIView) {
+        self.view = view
+
+        let editMenuInteraction = UIEditMenuInteraction(delegate: self)
+        view.addInteraction(editMenuInteraction)
+        self.editMenuInteraction = editMenuInteraction
+
+        let longPressGesture = UILongPressGestureRecognizer(
+            target: self,
+            action: #selector(handleLongPressGesture(_:))
+        )
+        longPressGesture.allowedTouchTypes = [
+            NSNumber(value: UITouch.TouchType.direct.rawValue),
+            NSNumber(value: UITouch.TouchType.indirectPointer.rawValue)
+        ]
+        longPressGesture.cancelsTouchesInView = false
+        longPressGesture.delegate = self
+        view.addGestureRecognizer(longPressGesture)
+
+        let secondaryClickGesture = UITapGestureRecognizer(
+            target: self,
+            action: #selector(handleSecondaryClickGesture(_:))
+        )
+        secondaryClickGesture.allowedTouchTypes = [
+            NSNumber(value: UITouch.TouchType.indirectPointer.rawValue)
+        ]
+        secondaryClickGesture.buttonMaskRequired = .secondary
+        secondaryClickGesture.cancelsTouchesInView = false
+        secondaryClickGesture.delegate = self
+        view.addGestureRecognizer(secondaryClickGesture)
+    }
+
+    @objc
+    private func handleLongPressGesture(_ gesture: UILongPressGestureRecognizer) {
+        guard gesture.state == .began, let view else { return }
+
+        presentEditMenu(at: gesture.location(in: view))
+    }
+
+    @objc
+    private func handleSecondaryClickGesture(_ gesture: UITapGestureRecognizer) {
+        guard gesture.state == .ended, let view else { return }
+
+        presentEditMenu(at: gesture.location(in: view))
+    }
+
+    private func presentEditMenu(at sourcePoint: CGPoint) {
+        let configuration = UIEditMenuConfiguration(
+            identifier: nil,
+            sourcePoint: sourcePoint
+        )
+        editMenuInteraction?.presentEditMenu(with: configuration)
+    }
+}
+
+extension TagCopyMenuCoordinator: UIEditMenuInteractionDelegate {
+    func editMenuInteraction(
+        _ interaction: UIEditMenuInteraction,
+        menuFor configuration: UIEditMenuConfiguration,
+        suggestedActions: [UIMenuElement]
+    ) -> UIMenu? {
+        let tagText = tagText
+        let copyAction = UIAction(title: String(localized: "common_copy")) { _ in
+            UIPasteboard.general.string = tagText
+        }
+        return UIMenu(children: [copyAction])
+    }
+
+    func editMenuInteraction(
+        _ interaction: UIEditMenuInteraction,
+        targetRectFor configuration: UIEditMenuConfiguration
+    ) -> CGRect {
+        view?.bounds ?? .zero
+    }
+}
+
+extension TagCopyMenuCoordinator: UIGestureRecognizerDelegate {
+    func gestureRecognizer(
+        _ gestureRecognizer: UIGestureRecognizer,
+        shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
+    ) -> Bool {
+        true
+    }
+}

--- a/Application/Presentation/PresentationShared/Sources/Common/Component/Tags.swift
+++ b/Application/Presentation/PresentationShared/Sources/Common/Component/Tags.swift
@@ -12,11 +12,31 @@ public struct Tag: View {
     @State private var height: CGFloat = 0
     private let name: String
     private let isEditing: Bool
+    private let isCopyEnabled: Bool
     private var action: (() -> Void)?
 
-    public init(_ name: String, isEditing: Bool, action: (() -> Void)? = nil) {
+    public init(
+        _ name: String,
+        isEditing: Bool,
+        action: (() -> Void)? = nil
+    ) {
+        self.init(
+            name,
+            isEditing: isEditing,
+            isCopyEnabled: false,
+            action: action
+        )
+    }
+
+    init(
+        _ name: String,
+        isEditing: Bool,
+        isCopyEnabled: Bool,
+        action: (() -> Void)?
+    ) {
         self.name = name
         self.isEditing = isEditing
+        self.isCopyEnabled = isCopyEnabled
         self.action = action
     }
 
@@ -30,6 +50,11 @@ public struct Tag: View {
                 .padding(.vertical, 4)
                 .padding(.leading, 8)
                 .padding(.trailing, isEditing ? 0 : 8)
+                .overlay {
+                    if isCopyEnabled {
+                        TagCopyMenuView(tagText: name)
+                    }
+                }
                 .background {
                     GeometryReader { geo in
                         Color.clear
@@ -120,11 +145,12 @@ public struct TagList: View {
     @ViewBuilder
     private var contentTags: some View {
         ForEach(tags, id: \.self) { tagText in
-            Tag(tagText, isEditing: isEditing) {
+            Tag(
+                tagText,
+                isEditing: isEditing,
+                isCopyEnabled: true
+            ) {
                 action?(tagText)
-            }
-            .overlay {
-                TagCopyMenuView(tagText: tagText)
             }
         }
     }

--- a/Application/Presentation/PresentationShared/Sources/Common/Component/Tags.swift
+++ b/Application/Presentation/PresentationShared/Sources/Common/Component/Tags.swift
@@ -123,6 +123,9 @@ public struct TagList: View {
             Tag(tagText, isEditing: isEditing) {
                 action?(tagText)
             }
+            .overlay {
+                TagCopyMenuView(tagText: tagText)
+            }
         }
     }
 }


### PR DESCRIPTION
## 🔗 연관된 이슈

- closed #293

## 🎯 의도

실제 태그 영역에 한정된 TextField 형태의 복사 메뉴 제공  
List Row 전체가 메뉴 미리보기로 잡히는 `.contextMenu` 대신 `UIEditMenuInteraction` 적용

## 📝 작업 내용

### 📌 요약

- 실제 태그에만 복사 메뉴 오버레이 적용
- `#`을 제외한 태그 문자열만 클립보드에 복사
- Due-date 태그와 오버플로우 `...` 항목은 복사 대상에서 제외
- 기존 태그 삭제 동작 및 `Tag` 공개 API 유지

### 🔍 상세

- `TagCopyMenuView.swift` 추가
	- 터치 및 마우스 좌클릭 길게 누르기 지원
	- 마우스 우클릭 지원
	- 태그 영역을 기준으로 `UIEditMenuInteraction` 표시
	- `UIPasteboard.general.string`에 `tagText` 저장
	- 여러 제스처의 동시 인식 허용
- 복사 메뉴 항목 로컬라이즈 적용
	- 한국어: `복사`
	- 영어: `Copy`
- `TagList.contentTags` 내부의 실제 태그에만 오버레이 적용

## 📸 영상 / 이미지 (Optional)

<img width="118" height="99" alt="image" src="https://github.com/user-attachments/assets/3b9aa632-62f9-482b-aa43-dabca2a814e9" />
