### PR TITLE
[#293] 태그를 LongPressGesture로 복붙 가능하도록 구현한다

### DIFF
--- a/Application/App/Sources/Resource/Localizable.xcstrings
+++ b/Application/App/Sources/Resource/Localizable.xcstrings
@@ -290,6 +290,23 @@
         }
       }
     },
+    "common_copy" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copy"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "복사"
+          }
+        }
+      }
+    },
     "common_delete" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Application/Presentation/PresentationShared/Sources/Common/Component/TagCopyMenuView.swift
+++ b/Application/Presentation/PresentationShared/Sources/Common/Component/TagCopyMenuView.swift
@@ -1,0 +1,120 @@
+//
+//  TagCopyMenuView.swift
+//  PresentationShared
+//
+//  Created by opfic on 8/9/26.
+//
+
+import SwiftUI
+import UIKit
+
+struct TagCopyMenuView: UIViewRepresentable {
+    let tagText: String
+
+    func makeCoordinator() -> TagCopyMenuCoordinator {
+        TagCopyMenuCoordinator()
+    }
+
+    func makeUIView(context: Context) -> UIView {
+        let view = UIView()
+        view.backgroundColor = .clear
+        view.isAccessibilityElement = false
+        context.coordinator.install(on: view)
+        context.coordinator.tagText = tagText
+        return view
+    }
+
+    func updateUIView(_ view: UIView, context: Context) {
+        context.coordinator.tagText = tagText
+    }
+}
+
+final class TagCopyMenuCoordinator: NSObject {
+    var tagText = ""
+    private weak var view: UIView?
+    private var editMenuInteraction: UIEditMenuInteraction?
+
+    func install(on view: UIView) {
+        self.view = view
+
+        let editMenuInteraction = UIEditMenuInteraction(delegate: self)
+        view.addInteraction(editMenuInteraction)
+        self.editMenuInteraction = editMenuInteraction
+
+        let longPressGesture = UILongPressGestureRecognizer(
+            target: self,
+            action: #selector(handleLongPressGesture(_:))
+        )
+        longPressGesture.allowedTouchTypes = [
+            NSNumber(value: UITouch.TouchType.direct.rawValue),
+            NSNumber(value: UITouch.TouchType.indirectPointer.rawValue)
+        ]
+        longPressGesture.cancelsTouchesInView = false
+        longPressGesture.delegate = self
+        view.addGestureRecognizer(longPressGesture)
+
+        let secondaryClickGesture = UITapGestureRecognizer(
+            target: self,
+            action: #selector(handleSecondaryClickGesture(_:))
+        )
+        secondaryClickGesture.allowedTouchTypes = [
+            NSNumber(value: UITouch.TouchType.indirectPointer.rawValue)
+        ]
+        secondaryClickGesture.buttonMaskRequired = .secondary
+        secondaryClickGesture.cancelsTouchesInView = false
+        secondaryClickGesture.delegate = self
+        view.addGestureRecognizer(secondaryClickGesture)
+    }
+
+    @objc
+    private func handleLongPressGesture(_ gesture: UILongPressGestureRecognizer) {
+        guard gesture.state == .began, let view else { return }
+
+        presentEditMenu(at: gesture.location(in: view))
+    }
+
+    @objc
+    private func handleSecondaryClickGesture(_ gesture: UITapGestureRecognizer) {
+        guard gesture.state == .ended, let view else { return }
+
+        presentEditMenu(at: gesture.location(in: view))
+    }
+
+    private func presentEditMenu(at sourcePoint: CGPoint) {
+        let configuration = UIEditMenuConfiguration(
+            identifier: nil,
+            sourcePoint: sourcePoint
+        )
+        editMenuInteraction?.presentEditMenu(with: configuration)
+    }
+}
+
+extension TagCopyMenuCoordinator: UIEditMenuInteractionDelegate {
+    func editMenuInteraction(
+        _ interaction: UIEditMenuInteraction,
+        menuFor configuration: UIEditMenuConfiguration,
+        suggestedActions: [UIMenuElement]
+    ) -> UIMenu? {
+        let tagText = tagText
+        let copyAction = UIAction(title: String(localized: "common_copy")) { _ in
+            UIPasteboard.general.string = tagText
+        }
+        return UIMenu(children: [copyAction])
+    }
+
+    func editMenuInteraction(
+        _ interaction: UIEditMenuInteraction,
+        targetRectFor configuration: UIEditMenuConfiguration
+    ) -> CGRect {
+        view?.bounds ?? .zero
+    }
+}
+
+extension TagCopyMenuCoordinator: UIGestureRecognizerDelegate {
+    func gestureRecognizer(
+        _ gestureRecognizer: UIGestureRecognizer,
+        shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
+    ) -> Bool {
+        true
+    }
+}

--- a/Application/Presentation/PresentationShared/Sources/Common/Component/Tags.swift
+++ b/Application/Presentation/PresentationShared/Sources/Common/Component/Tags.swift
@@ -12,11 +12,31 @@ public struct Tag: View {
     @State private var height: CGFloat = 0
     private let name: String
     private let isEditing: Bool
+    private let isCopyEnabled: Bool
     private var action: (() -> Void)?
 
-    public init(_ name: String, isEditing: Bool, action: (() -> Void)? = nil) {
+    public init(
+        _ name: String,
+        isEditing: Bool,
+        action: (() -> Void)? = nil
+    ) {
+        self.init(
+            name,
+            isEditing: isEditing,
+            isCopyEnabled: false,
+            action: action
+        )
+    }
+
+    init(
+        _ name: String,
+        isEditing: Bool,
+        isCopyEnabled: Bool,
+        action: (() -> Void)?
+    ) {
         self.name = name
         self.isEditing = isEditing
+        self.isCopyEnabled = isCopyEnabled
         self.action = action
     }
 
@@ -30,6 +50,11 @@ public struct Tag: View {
                 .padding(.vertical, 4)
                 .padding(.leading, 8)
                 .padding(.trailing, isEditing ? 0 : 8)
+                .overlay {
+                    if isCopyEnabled {
+                        TagCopyMenuView(tagText: name)
+                    }
+                }
                 .background {
                     GeometryReader { geo in
                         Color.clear
@@ -120,11 +145,12 @@ public struct TagList: View {
     @ViewBuilder
     private var contentTags: some View {
         ForEach(tags, id: \.self) { tagText in
-            Tag(tagText, isEditing: isEditing) {
+            Tag(
+                tagText,
+                isEditing: isEditing,
+                isCopyEnabled: true
+            ) {
                 action?(tagText)
-            }
-            .overlay {
-                TagCopyMenuView(tagText: tagText)
             }
         }
     }

--- a/Application/Presentation/PresentationShared/Sources/Common/Component/Tags.swift
+++ b/Application/Presentation/PresentationShared/Sources/Common/Component/Tags.swift
@@ -123,6 +123,9 @@ public struct TagList: View {
             Tag(tagText, isEditing: isEditing) {
                 action?(tagText)
             }
+            .overlay {
+                TagCopyMenuView(tagText: tagText)
+            }
         }
     }
 }


### PR DESCRIPTION
## 🔗 연관된 이슈

- closed 이슈: #293

## 🎯 의도

실제 태그 텍스트 영역에 한정된 시스템 편집 메뉴 제공  
List Row 전체가 메뉴 범위로 잡히는 `.contextMenu` 대신 `UIEditMenuInteraction` 적용  

## 📝 작업 내용

### 📌 요약

- 터치 및 포인터 입력을 지원하는 `TagCopyMenuView` 추가
- `TagList.contentTags`의 실제 태그에만 복사 메뉴 활성화
- 별도의 `#` 접두어를 추가하지 않은 원본 태그 문자열 복사
- 마감일 표시용 `Tag`와 오버플로우 `...`는 복사 대상에서 제외
- 편집 상태의 `xmark` 삭제 버튼 영역을 복사 오버레이에서 제외
- 기존 `Tag` 공개 API 유지

### 🔍 상세

- `UIViewRepresentable`과 `UIEditMenuInteraction` 기반 복사 메뉴 구성
- `UILongPressGestureRecognizer`에서 `direct`, `indirectPointer` 입력 처리
- `UITapGestureRecognizer`와 `.secondary` 버튼 마스크로 보조 클릭 처리
- `UIMenu`에 현지화된 `UIAction` 복사 항목 하나만 구성
- `UIPasteboard.general.string`에 `name` 그대로 저장
- `Text(name)` 영역에만 `TagCopyMenuView` 오버레이 적용
- `isCopyEnabled`를 통해 `TagList.contentTags`의 실제 태그만 복사 허용
- `common_copy` 현지화 추가
	- 한국어: `복사`
	- 영어: `Copy`


## 📸 영상 / 이미지 (Optional)

<img width="118" height="99" alt="image" src="https://github.com/user-attachments/assets/7839405c-3507-4aa9-a028-f5a6c4a08d5b" />
