### PR TITLE
[#375] Todo를 LongPressGesture 시 호버로 해당 뷰를 뜨게 한다

### DIFF
--- a/Application/Presentation/HomeTab/Sources/Home/Home/HomeView.swift
+++ b/Application/Presentation/HomeTab/Sources/Home/Home/HomeView.swift
@@ -300,20 +300,23 @@ public struct HomeView: View {
 
     @ViewBuilder
     private func recentTodoRow(_ item: RecentTodoItem) -> some View {
-        if isCompactLayout {
-            NavigationLink(value: HomeRoute.todo(TodoIdItem(id: item.id))) {
-                RecentTodoRow(todo: item)
+        Group {
+            if isCompactLayout {
+                NavigationLink(value: HomeRoute.todo(TodoIdItem(id: item.id))) {
+                    RecentTodoRow(todo: item)
+                }
+            } else {
+                Button {
+                    coordinator.router.replace(with: .todo(TodoIdItem(id: item.id)))
+                } label: {
+                    RecentTodoRow(todo: item)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .contentShape(.rect)
+                }
+                .buttonStyle(.plain)
             }
-        } else {
-            Button {
-                coordinator.router.replace(with: .todo(TodoIdItem(id: item.id)))
-            } label: {
-                RecentTodoRow(todo: item)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .contentShape(.rect)
-            }
-            .buttonStyle(.plain)
         }
+        .todoDetailPreview(todoId: item.id)
     }
 
     @ViewBuilder

--- a/Application/Presentation/HomeTab/Sources/Home/Search/SearchView.swift
+++ b/Application/Presentation/HomeTab/Sources/Home/Search/SearchView.swift
@@ -205,6 +205,7 @@ struct SearchView: View {
                 Divider()
             }
         }
+        .todoDetailPreview(todoId: item.id)
     }
 
     private func webResultRow(_ item: WebPageItem) -> some View {

--- a/Application/Presentation/PresentationShared/Sources/Todo/Detail/TodoDetailPreviewModifier.swift
+++ b/Application/Presentation/PresentationShared/Sources/Todo/Detail/TodoDetailPreviewModifier.swift
@@ -114,6 +114,38 @@ extension TodoDetailPreviewInteractionCoordinator: UIContextMenuInteractionDeleg
         )
     }
 
+    // 미리보기가 표시될 때 원본 행에 기본 배경색이 적용되는 현상 방지
+    func contextMenuInteraction(
+        _ interaction: UIContextMenuInteraction,
+        configuration: UIContextMenuConfiguration,
+        highlightPreviewForItemWithIdentifier identifier: any NSCopying
+    ) -> UITargetedPreview? {
+        targetedPreview()
+    }
+
+    // 미리보기가 닫힐 때 원본 행에 기본 배경색이 적용되는 현상 방지
+    func contextMenuInteraction(
+        _ interaction: UIContextMenuInteraction,
+        configuration: UIContextMenuConfiguration,
+        dismissalPreviewForItemWithIdentifier identifier: any NSCopying
+    ) -> UITargetedPreview? {
+        targetedPreview()
+    }
+
+    // iOS 18 이하에서 투명한 원본 뷰의 기본 전환 배경이 흰색으로 표시되는 현상 방지
+    private func targetedPreview() -> UITargetedPreview? {
+        guard let view else { return nil }
+
+        let parameters = UIPreviewParameters()
+        parameters.backgroundColor = .clear
+        parameters.shadowPath = UIBezierPath()
+
+        return UITargetedPreview(
+            view: view,
+            parameters: parameters
+        )
+    }
+
     private func preferredContentSize(for view: UIView?) -> CGSize {
         let bounds = view?.window?.bounds ?? view?.bounds ?? .zero
         let width = min(420, max(280, bounds.width - 32))

--- a/Application/Presentation/PresentationShared/Sources/Todo/Detail/TodoDetailPreviewModifier.swift
+++ b/Application/Presentation/PresentationShared/Sources/Todo/Detail/TodoDetailPreviewModifier.swift
@@ -1,0 +1,123 @@
+//
+//  TodoDetailPreviewModifier.swift
+//  PresentationShared
+//
+//  Created by opfic on 8/11/26.
+//
+
+import SwiftUI
+import ComposableArchitecture
+import Core
+import Domain
+
+public extension View {
+    func todoDetailPreview(todoId: String) -> some View {
+        modifier(TodoDetailPreviewModifier(todoId: todoId))
+    }
+}
+
+private struct TodoDetailPreviewModifier: ViewModifier {
+    @Environment(\.diContainer) private var container
+    let todoId: String
+
+    func body(content: Content) -> some View {
+        content.overlay {
+            TodoDetailPreviewInteractionView(
+                todoId: todoId,
+                makePreview: makePreviewViewController
+            )
+        }
+    }
+
+    private func makePreviewViewController() -> UIViewController {
+        let store = Store(
+            initialState: TodoDetailFeature.State(
+                todoId: todoId,
+                showEditButton: false
+            )
+        ) {
+            TodoDetailFeature()
+        } withDependencies: {
+            $0.fetchTodoByIdUseCase = container.resolve(FetchTodoByIdUseCase.self)
+            $0.fetchReferenceItemsUseCase = container.resolve(FetchReferenceItemsUseCase.self)
+        }
+        return UIHostingController(rootView: TodoDetailPreviewView(store: store))
+    }
+}
+
+private struct TodoDetailPreviewInteractionView: UIViewRepresentable {
+    let todoId: String
+    let makePreview: () -> UIViewController
+
+    func makeCoordinator() -> TodoDetailPreviewInteractionCoordinator {
+        TodoDetailPreviewInteractionCoordinator()
+    }
+
+    func makeUIView(context: Context) -> UIView {
+        let view = UIView()
+        view.backgroundColor = .clear
+        view.isAccessibilityElement = false
+        context.coordinator.update(todoId: todoId, makePreview: makePreview)
+        context.coordinator.install(on: view)
+        return view
+    }
+
+    func updateUIView(_ view: UIView, context: Context) {
+        context.coordinator.update(todoId: todoId, makePreview: makePreview)
+    }
+}
+
+private final class TodoDetailPreviewInteractionCoordinator: NSObject {
+    private weak var view: UIView?
+    private var contextMenuInteraction: UIContextMenuInteraction?
+    private var todoId = ""
+    private var makePreview: (() -> UIViewController)?
+
+    func update(
+        todoId: String,
+        makePreview: @escaping () -> UIViewController
+    ) {
+        self.todoId = todoId
+        self.makePreview = makePreview
+    }
+
+    func install(on view: UIView) {
+        guard self.view !== view else { return }
+
+        if let contextMenuInteraction {
+            self.view?.removeInteraction(contextMenuInteraction)
+        }
+
+        let contextMenuInteraction = UIContextMenuInteraction(delegate: self)
+        view.addInteraction(contextMenuInteraction)
+        self.view = view
+        self.contextMenuInteraction = contextMenuInteraction
+    }
+}
+
+extension TodoDetailPreviewInteractionCoordinator: UIContextMenuInteractionDelegate {
+    func contextMenuInteraction(
+        _ interaction: UIContextMenuInteraction,
+        configurationForMenuAtLocation location: CGPoint
+    ) -> UIContextMenuConfiguration? {
+        guard let makePreview else { return nil }
+
+        let preferredContentSize = preferredContentSize(for: interaction.view)
+        return UIContextMenuConfiguration(
+            identifier: todoId as NSString,
+            previewProvider: {
+                let viewController = makePreview()
+                viewController.preferredContentSize = preferredContentSize
+                return viewController
+            },
+            actionProvider: nil
+        )
+    }
+
+    private func preferredContentSize(for view: UIView?) -> CGSize {
+        let bounds = view?.window?.bounds ?? view?.bounds ?? .zero
+        let width = min(420, max(280, bounds.width - 32))
+        let height = min(640, max(320, bounds.height * 0.7))
+        return CGSize(width: width, height: height)
+    }
+}

--- a/Application/Presentation/PresentationShared/Sources/Todo/Detail/TodoDetailPreviewView.swift
+++ b/Application/Presentation/PresentationShared/Sources/Todo/Detail/TodoDetailPreviewView.swift
@@ -1,0 +1,40 @@
+//
+//  TodoDetailPreviewView.swift
+//  PresentationShared
+//
+//  Created by opfic on 8/11/26.
+//
+
+import SwiftUI
+import ComposableArchitecture
+
+struct TodoDetailPreviewView: View {
+    @State var store: StoreOf<TodoDetailFeature>
+
+    var body: some View {
+        ZStack {
+            Color(.systemGroupedBackground).ignoresSafeArea()
+            if let todo = store.todo {
+                TodoDetailContentView(
+                    title: todo.title,
+                    content: todo.content,
+                    referenceItems: store.referenceItems,
+                    number: todo.number,
+                    onOpenTodoID: nil
+                )
+            } else if store.alert != nil {
+                ContentUnavailableView {
+                    Label(
+                        String(localized: "common_error_title"),
+                        systemImage: "exclamationmark.triangle"
+                    )
+                } description: {
+                    Text(String(localized: "common_error_message"))
+                }
+            } else {
+                LoadingView()
+            }
+        }
+        .onAppear { store.send(.onAppear) }
+    }
+}

--- a/Application/Presentation/PresentationShared/Sources/Todo/List/TodoListView.swift
+++ b/Application/Presentation/PresentationShared/Sources/Todo/List/TodoListView.swift
@@ -112,6 +112,7 @@ public struct TodoListView: View {
                             } label: {
                                 TodoItemRow(todo)
                             }
+                            .todoDetailPreview(todoId: todo.id)
                             .listRowInsets(EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16))
                             .alignmentGuide(.listRowSeparatorLeading) { _ in return 0 }
                             .overlay(alignment: .top) {
@@ -279,6 +280,7 @@ public struct TodoListView: View {
                                 Divider()
                             }
                         }
+                        .todoDetailPreview(todoId: todo.id)
                     }
                     .padding(.horizontal, 16)
 

--- a/Application/Presentation/TodayTab/Sources/Today/TodayView.swift
+++ b/Application/Presentation/TodayTab/Sources/Today/TodayView.swift
@@ -155,20 +155,23 @@ public struct TodayView: View {
 
     @ViewBuilder
     private func todoRow(_ item: TodayTodoItem) -> some View {
-        if isCompactLayout {
-            NavigationLink(value: TodayRoute.todo(TodoIdItem(id: item.id))) {
-                TodayTodoRow(item: item)
+        Group {
+            if isCompactLayout {
+                NavigationLink(value: TodayRoute.todo(TodoIdItem(id: item.id))) {
+                    TodayTodoRow(item: item)
+                }
+            } else {
+                Button {
+                    coordinator.router.replace(with: .todo(TodoIdItem(id: item.id)))
+                } label: {
+                    TodayTodoRow(item: item)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .contentShape(.rect)
+                }
+                .buttonStyle(.plain)
             }
-        } else {
-            Button {
-                coordinator.router.replace(with: .todo(TodoIdItem(id: item.id)))
-            } label: {
-                TodayTodoRow(item: item)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .contentShape(.rect)
-            }
-            .buttonStyle(.plain)
         }
+        .todoDetailPreview(todoId: item.id)
     }
 
     private var emptyStateContent: EmptyStateContent {


### PR DESCRIPTION
## 🔗 연관된 이슈
- closed #375

## 🎯 의도
Todo 상세 화면으로 이동하지 않고 현재 목록에서 내용을 확인할 수 있는 읽기 전용 미리보기 제공  
기존 짧은 탭 내비게이션과 스와이프 동작을 유지한 긴 누르기 진입점 추가

## 📝 작업 내용

### 📌 요약
- `PresentationShared`에 `UIContextMenuInteraction` 기반 Todo 상세 미리보기 구성요소 추가
- 내비게이션 가능한 다섯 Todo 행 그룹에 공통 미리보기 적용
- 기존 `TodoDetailFeature`의 상세 조회와 참조 해석 흐름 재사용

### 🔍 상세
- `previewProvider`를 통한 `TodoDetailPreviewView` 표시
- `actionProvider`를 `nil`로 설정해 상황별 메뉴 미제공
- 제목, Todo 번호, Markdown 본문 표시
- Todo ID를 사용한 전체 상세 내용 재조회
- Todo 참조 정보 표시 및 참조 열기 동작 미제공
- 조회 중 `LoadingView`, 조회 실패 시 미리보기 내부 오류 화면 표시
- `TodoListView` 일반 목록과 검색 결과에 적용
- Home 통합 검색 결과와 최근 Todo에 적용
- `TodayTodoRow`에 적용
- `PushNotificationListView`와 Todo 본문 안의 참조 링크에는 미적용
- 변경 Swift 파일 SwiftLint 종료 코드 0
- `PresentationShared`, `HomeTab`, `TodayTab`, `App` 빌드 전용 검증 성공
- iPhone·iPad에서 긴 누르기, 짧은 탭 내비게이션, 스와이프, 상세 조회 수동 확인
- 미리보기 내부의 긴 Markdown 본문 세로 스크롤 미지원
- Apple Silicon Mac에서 실행한 iPad 앱의 긴 누르기 미리보기 미지원

## 📸 영상 / 이미지 (Optional)
<table>
<tr>
<td align="center">
<img width=50% alt="image" src="https://github.com/user-attachments/assets/6deb1b9b-8964-4845-89bc-b64f7d551c62" />
<td align="center">
<img width=50%" alt="image" src="https://github.com/user-attachments/assets/ca1f6db8-a521-4f9f-9065-927b18bd2be5" />
</tr>
<tr>
<td align="center">iPhone
<td align="center">iPad
</tr>
</table>